### PR TITLE
Feat: Update console output to reduce visual clutter

### DIFF
--- a/.github/workflows/build-test-release.yaml
+++ b/.github/workflows/build-test-release.yaml
@@ -37,6 +37,16 @@ jobs:
         with:
           versioning: 'semver'
 
+      - name: 'Reject Development Tags'
+        if: steps.tag-validate.outputs.dev_version == 'true'
+        shell: bash
+        run: |
+          # Reject Development Tags
+          echo "Development tag pushed; aborting release workflow 🛑"
+          echo "Development tag pushed; aborting release workflow 🛑" \
+            >> "$GITHUB_STEP_SUMMARY"
+          exit 1
+
   python-build:
     name: 'Python Build'
     needs: 'tag-validate'
@@ -64,8 +74,6 @@ jobs:
 
       - name: 'Build Python project'
         id: 'python-build'
-        # yamllint disable-line rule:line-length
-        # uses: modeseven-lfreleng-actions/python-build-action@update-action # Testing
         # yamllint disable-line rule:line-length
         uses: lfreleng-actions/python-build-action@1a8f154018f7527622152fcc36dd5974d3199db8 # v0.1.18
         with:

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -51,9 +51,7 @@ jobs:
       - name: 'Build Python project'
         id: python-build
         # yamllint disable-line rule:line-length
-        uses: modeseven-lfreleng-actions/python-build-action@update-action # Testing
-        # yamllint disable-line rule:line-length
-        # uses: lfreleng-actions/python-build-action@a9d0ef8a2324ac76e798ad6dc306f08b83b5b213 # v0.1.11
+        uses: lfreleng-actions/python-build-action@1a8f154018f7527622152fcc36dd5974d3199db8 # v0.1.18
 
   python-tests:
     name: 'Python Tests'

--- a/src/dependamerge/cli.py
+++ b/src/dependamerge/cli.py
@@ -392,9 +392,14 @@ def _merge_single_pr(
 
     # Attempt merge with retry logic for different failure conditions
     for attempt in range(MAX_RETRIES + 1):
-        console.print(
-            f"Merging PR {pr_info.number} in {pr_info.repository_full_name} (attempt {attempt + 1})"
-        )
+        if attempt == 0:
+            console.print(
+                f"Merging PR {pr_info.number} in {pr_info.repository_full_name}"
+            )
+        else:
+            console.print(
+                f"Merging PR {pr_info.number} in {pr_info.repository_full_name} (retry {attempt})"
+            )
 
         merge_result = github_client.merge_pull_request(
             repo_owner, repo_name, pr_info.number, merge_method
@@ -450,9 +455,14 @@ def _merge_single_pr(
                 # Other types of merge failures - no point in retrying
                 break
 
-    console.print(
-        f"Failed to merge PR {pr_info.number} after {MAX_RETRIES + 1} attempts ❌"
-    )
+    if MAX_RETRIES > 0:
+        console.print(
+            f"Failed to merge PR {pr_info.number} after {MAX_RETRIES} retries ❌"
+        )
+    else:
+        console.print(
+            f"Failed to merge PR {pr_info.number} ❌"
+        )
     return False
 
 


### PR DESCRIPTION
Messages like this will no longer be displayed:
`Merging PR 8 in lfreleng-actions/go-httpbin-action (attempt 1)`

Instead, a retry count will only be shown when an operation fails. This will tidy up the output and remove visual clutter.