### PR TITLE
Fix: Failure to find matching pull requests

### DIFF
--- a/src/dependamerge/github_graphql.py
+++ b/src/dependamerge/github_graphql.py
@@ -65,7 +65,7 @@ query($org: String!, $reposCursor: String) {
           nodes {
             number
             title
-            bodyText
+            body
             url
             isDraft
             author { login }
@@ -141,7 +141,7 @@ query($owner: String!, $name: String!, $prsCursor: String, $prsPageSize: Int!, $
       nodes {
         number
         title
-        bodyText
+        body
         url
         isDraft
         author { login }

--- a/src/dependamerge/github_service.py
+++ b/src/dependamerge/github_service.py
@@ -427,7 +427,7 @@ class GitHubService:
         return PullRequestInfo(
             number=int(pr.get("number", 0)),
             title=pr.get("title") or "",
-            body=(pr.get("bodyText") or None),
+            body=(pr.get("body") or None),
             author=((pr.get("author") or {}).get("login") or "unknown"),
             head_sha=pr.get("headRefOid") or "",
             base_branch=pr.get("baseRefName") or "",
@@ -527,7 +527,7 @@ class GitHubService:
                 if self._progress:
                     self._progress.analyze_pr(target_pr.number, repo_full_name)
 
-                comparison: ComparisonResult = comparator.compare_pull_requests(source_pr, target_pr)
+                comparison: ComparisonResult = comparator.compare_pull_requests(source_pr, target_pr, only_automation)
                 if comparison.is_similar:
                     matching_prs_in_repo.append((target_pr, comparison))
                     if self._progress:

--- a/src/dependamerge/pr_comparator.py
+++ b/src/dependamerge/pr_comparator.py
@@ -16,21 +16,25 @@ class PRComparator:
         self.similarity_threshold = similarity_threshold
 
     def compare_pull_requests(
-        self, source_pr: PullRequestInfo, target_pr: PullRequestInfo
+        self, source_pr: PullRequestInfo, target_pr: PullRequestInfo, only_automation: bool = True
     ) -> ComparisonResult:
         """Compare two pull requests and determine similarity."""
         reasons = []
         scores = []
 
-        # Check if both are from automation tools
-        if not self._is_automation_pr(source_pr) or not self._is_automation_pr(
-            target_pr
-        ):
-            return ComparisonResult(
-                is_similar=False,
-                confidence_score=0.0,
-                reasons=["One or both PRs are not from automation tools"],
-            )
+        # Check automation requirements based on mode
+        if only_automation:
+            # Both PRs must be from automation tools
+            if not self._is_automation_pr(source_pr) or not self._is_automation_pr(target_pr):
+                return ComparisonResult(
+                    is_similar=False,
+                    confidence_score=0.0,
+                    reasons=["One or both PRs are not from automation tools"],
+                )
+        else:
+            # For non-automation mode, we expect the service already filtered by same author
+            # so we don't need additional automation checks here
+            pass
 
         # Compare titles
         title_score = self._compare_titles(source_pr.title, target_pr.title)


### PR DESCRIPTION
The issue was introduced in the recent "Major performance updates" commit (a252305) when the codebase was refactored to use both REST API and GraphQL API for fetching PR data:

1. **Source PRs** (the PR you provide to dependamerge) were fetched using the **REST API**, which returns the PR body in **markdown format** (`body` field)
2. **Target PRs** (similar PRs found in the organization) were fetched using the **GraphQL API**, which was requesting the PR body in **plain text format** (`bodyText` field)