### PR TITLE
Fix: Move --version flag handling to main CLI entry point

### DIFF
--- a/src/dependamerge/cli.py
+++ b/src/dependamerge/cli.py
@@ -46,6 +46,26 @@ class CustomTyper(typer.Typer):
 app = CustomTyper(
     help="Find blocked PRs in GitHub organizations and automatically merge pull requests"
 )
+
+
+@app.callback()
+def main(
+    version: bool = typer.Option(
+        False,
+        "--version",
+        callback=version_callback,
+        is_eager=True,
+        help="Show version and exit",
+    ),
+):
+    """
+    Dependamerge command line interface.
+    """
+    # The actual handling is done via the version_callback.
+    # This callback exists only to expose --version at the top level.
+    pass
+
+
 console = Console(markup=False)
 
 
@@ -186,13 +206,6 @@ def merge(
         False,
         "--dismiss-copilot",
         help="Automatically dismiss unresolved GitHub Copilot review comments",
-    ),
-    version: bool = typer.Option(
-        False,
-        "--version",
-        callback=version_callback,
-        is_eager=True,
-        help="Show version and exit",
     ),
 ):
     """

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -14,6 +14,12 @@ class TestCLI:
     def setup_method(self):
         self.runner = CliRunner()
 
+    def test_top_level_version(self):
+        result = self.runner.invoke(app, ["--version"])
+        assert result.exit_code == 0
+        # Should contain the version banner
+        assert "dependamerge version" in result.stdout
+
     @patch("dependamerge.cli.GitHubClient")
     @patch("dependamerge.cli.PRComparator")
     @patch("dependamerge.github_service.GitHubService")


### PR DESCRIPTION
Also adds a test for the --version flag as per the above.