### PR TITLE
CI: Update Python workflows

### DIFF
--- a/.github/workflows/build-test-release.yaml
+++ b/.github/workflows/build-test-release.yaml
@@ -49,7 +49,7 @@ jobs:
     runs-on: 'ubuntu-latest'
     permissions:
       contents: write  # Needed to draft a release
-    timeout-minutes: 1
+    timeout-minutes: 5
     outputs:
       tag: "${{ steps.tag-validate.outputs.tag_name }}"
     steps:

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -15,7 +15,7 @@ on:
         default: false
         required: false
   pull_request:
-    types: [opened, reopened, edited, synchronize]
+    types: [opened, reopened, synchronize]
     branches:
       - main
       - master
@@ -61,8 +61,92 @@ jobs:
           artifact_upload: 'true'
           artifact_formats: 'json'
 
+  clear-cache:
+    name: 'Clear Python Caches'
+    # Only runs on manual dispatch with clear_cache enabled
+    if: >-
+      github.event_name == 'workflow_dispatch'
+      && github.event.inputs.clear_cache == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write  # Required for gh cache delete
+    timeout-minutes: 5
+    env:
+      GH_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+    steps:
+      # yamllint disable-line rule:line-length
+      - uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d  # v2.16.1
+        with:
+          egress-policy: 'audit'
+
+      - name: 'Clear Python dependency caches'
+        env:
+          REPO: "${{ github.repository }}"
+        run: |
+          # Clear Python dependency caches (scoped to Python key prefixes)
+          # Matches cache keys created by:
+          #   python-*        lfreleng-actions (actions/cache)
+          #   setup-python-*  actions/setup-python built-in caching
+          #   setup-uv-*      astral-sh/setup-uv
+          echo "Clearing Python dependency caches 🗑️"
+          deleted=0
+          failed=0
+          for prefix in python- setup-python- setup-uv-; do
+            while true; do
+              if ! keys=$(gh cache list --repo "$REPO" \
+                --key "$prefix" --limit 100 \
+                --json key --jq '.[].key' 2>&1); then
+                echo "::warning::Failed to list caches" \
+                  "for prefix '$prefix': $keys"
+                echo "Warning: failed to list caches for" \
+                  "prefix \`$prefix\`: $keys" \
+                  >> "$GITHUB_STEP_SUMMARY"
+                failed=1
+                break
+              fi
+              [ -n "$keys" ] || break
+
+              batch_deleted=0
+              while IFS= read -r key; do
+                [ -n "$key" ] || continue
+                if delete_out=$(gh cache delete "$key" \
+                  --repo "$REPO" 2>&1); then
+                  echo "Deleted cache: $key"
+                  deleted=$((deleted + 1))
+                  batch_deleted=$((batch_deleted + 1))
+                else
+                  echo "::warning::Failed to delete" \
+                    "cache '$key': $delete_out"
+                  echo "Warning: failed to delete cache" \
+                    "\`$key\`: $delete_out" \
+                    >> "$GITHUB_STEP_SUMMARY"
+                  failed=1
+                fi
+              done <<< "$keys"
+
+              # Stop if nothing was deleted to avoid looping
+              # forever on the same result set
+              [ "$batch_deleted" -gt 0 ] || break
+            done
+          done
+          if [ "$deleted" -gt 0 ]; then
+            echo "Cleared $deleted Python cache(s) ✅" \
+              >> "$GITHUB_STEP_SUMMARY"
+          elif [ "$failed" -eq 0 ]; then
+            echo "No Python caches found to clear 💬" \
+              >> "$GITHUB_STEP_SUMMARY"
+          fi
+          if [ "$failed" -ne 0 ]; then
+            echo "Cache clearing completed with errors ❌" \
+              >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          fi
+
   python-build:
     name: 'Python Build'
+    needs: 'clear-cache'
+    # Run regardless of clear-cache outcome (success, failure, or skipped);
+    if: ${{ always() && !cancelled() }}
     runs-on: 'ubuntu-latest'
     outputs:
       matrix_json: "${{ steps.python-build.outputs.matrix_json }}"
@@ -70,10 +154,7 @@ jobs:
       artefact_path: "${{ steps.python-build.outputs.artefact_path }}"
     permissions:
       contents: read
-      actions: write  # Required for cache deletion when clear_cache is true
     timeout-minutes: 12
-    env:
-      GH_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
     steps:
       # Harden the runner used by this workflow
       # yamllint disable-line rule:line-length
@@ -88,13 +169,12 @@ jobs:
         id: python-build
         # yamllint disable-line rule:line-length
         uses: lfreleng-actions/python-build-action@70572c4544ab913643a2ddcb05e8dbdab809a936  # v1.0.5
-        with:
-          clear_cache: ${{ github.event.inputs.clear_cache || 'false' }}
 
   python-tests:
     name: 'Python Tests'
     runs-on: 'ubuntu-latest'
     needs: 'python-build'
+    if: ${{ !cancelled() && needs.python-build.result == 'success' }}
     # Matrix job
     strategy:
       fail-fast: false
@@ -122,6 +202,7 @@ jobs:
     name: 'Python Audit'
     runs-on: 'ubuntu-latest'
     needs: 'python-build'
+    if: ${{ !cancelled() && needs.python-build.result == 'success' }}
     # Matrix job
     strategy:
       fail-fast: false
@@ -150,10 +231,17 @@ jobs:
     name: 'Generate SBOM'
     runs-on: ubuntu-latest
     needs: 'python-build'
+    if: ${{ !cancelled() && needs.python-build.result == 'success' }}
     timeout-minutes: 10
     permissions:
       contents: read
     steps:
+      # Harden the runner used by this workflow
+      # yamllint disable-line rule:line-length
+      - uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d  # v2.16.1
+        with:
+          egress-policy: 'audit'
+
       # yamllint disable-line rule:line-length
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 


### PR DESCRIPTION
## Summary

### build-test.yaml
- Move cache-clear into a dedicated workflow job to reduce privileges granted to `python-build-action` (`contents: read` instead of `actions: write`)
- Add missing `harden-runner` step to SBOM job
- Remove `pull_request` `edited` trigger type, since the workflow does not need to run on metadata-only changes
- Scope cache deletion to Python-related key prefixes only (`python-`, `setup-python-`, `setup-uv-`), verified against actual repo caches via the GitHub API and upstream action source code:
  - `python-*` — `lfreleng-actions/python-build-action` (`actions/cache`)
  - `setup-python-*` — `actions/setup-python` built-in pip/poetry/pipenv caching
  - `setup-uv-*` — `astral-sh/setup-uv`

- Use `if: ${{ !cancelled() }}` on `python-build` so it is never blocked by `clear-cache`, regardless of whether it succeeds, fails, or is skipped — only an explicit workflow cancellation prevents downstream jobs

### build-test-release.yaml
- Increase `tag-validate` timeout from 1 minute to 5 minutes