### PR TITLE
Feat: Repository-scoped bulk merge, permission checks, and reliability fixes

### DIFF
--- a/src/dependamerge/cli.py
+++ b/src/dependamerge/cli.py
@@ -62,7 +62,13 @@ from .pr_comparator import PRComparator
 from .progress_tracker import MergeProgressTracker, ProgressTracker
 from .resolve_conflicts import FixOptions, FixOrchestrator, PRSelection
 from .system_utils import get_default_workers
-from .url_parser import ParsedUrl, UrlParseError, parse_change_url
+from .url_parser import (
+    ParsedRepoUrl,
+    ParsedUrl,
+    UrlParseError,
+    parse_change_url,
+    parse_repo_url,
+)
 
 # Constants
 MAX_RETRIES = 2
@@ -321,6 +327,7 @@ class _MergeContext:
     netrc_file: Path | None
     netrc_optional: bool
     github2gerrit_mode: str
+    include_human_prs: bool = False
 
     # Derived / mutable state
     github_client: GitHubClient | None = None
@@ -863,6 +870,290 @@ def _display_merge_results(
         )
 
 
+def _handle_repo_merge(
+    parsed_repo: ParsedRepoUrl,
+    ctx: _MergeContext,
+) -> None:
+    """Handle merge operation for a repository-scoped URL.
+
+    Instead of scanning an entire org for similar PRs, this fetches all
+    open PRs in a single repository and merges the automation ones (or
+    all of them when --include-human-prs is given).
+
+    Args:
+        parsed_repo: Parsed repository URL with owner and repo.
+        ctx: Shared merge context populated with CLI parameters.
+    """
+    from .github_service import GitHubService
+
+    # --- Initialise GitHub client & token ---
+    ctx.github_client = GitHubClient(ctx.token)
+    assert ctx.github_client.token is not None
+    ctx.token = ctx.github_client.token
+    ctx.owner = parsed_repo.owner
+    ctx.repo_name = parsed_repo.repo
+
+    console.print(
+        f"🔍 Repository mode: fetching open PRs in "
+        f"{parsed_repo.project}..."
+    )
+
+    # --- Token permission check (reuse existing helper) ---
+    _check_merge_permissions(ctx)
+
+    # --- Progress tracker ---
+    if ctx.show_progress:
+        ctx.progress_tracker = MergeProgressTracker(ctx.owner)
+        ctx.progress_tracker.start()
+
+    # --- Fetch open PRs for the repository ---
+    only_automation = not ctx.include_human_prs
+
+    async def _fetch_prs() -> list[PullRequestInfo]:
+        svc = GitHubService(
+            token=ctx.token,
+            progress_tracker=ctx.progress_tracker,
+        )
+        try:
+            return await svc.fetch_repo_open_prs(
+                ctx.owner,
+                ctx.repo_name,
+                only_automation=only_automation,
+            )
+        finally:
+            await svc.close()
+
+    try:
+        repo_prs = asyncio.run(_fetch_prs())
+    except Exception:
+        if ctx.progress_tracker:
+            ctx.progress_tracker.stop()
+        raise
+
+    if ctx.progress_tracker:
+        ctx.progress_tracker.stop()
+
+    if not repo_prs:
+        label = "automation " if only_automation else ""
+        console.print(
+            f"❌ No open {label}PRs found in "
+            f"{parsed_repo.project}"
+        )
+        return
+
+    # --- Classify PRs as automation vs human ---
+    automation_prs: list[PullRequestInfo] = []
+    human_prs: list[PullRequestInfo] = []
+    for pr in repo_prs:
+        if ctx.github_client.is_automation_author(pr.author):
+            automation_prs.append(pr)
+        else:
+            human_prs.append(pr)
+
+    console.print(
+        f"\n📊 Found {len(repo_prs)} open PR(s) in "
+        f"{parsed_repo.project}"
+    )
+    if automation_prs:
+        console.print(
+            f"   🤖 Automation PRs: {len(automation_prs)}"
+        )
+    if human_prs:
+        console.print(
+            f"   👤 Human PRs: {len(human_prs)}"
+        )
+
+    # List PRs that will be processed
+    for pr in repo_prs:
+        is_auto = ctx.github_client.is_automation_author(pr.author)
+        icon = "🤖" if is_auto else "👤"
+        console.print(
+            f"  {icon} #{pr.number} {pr.title} "
+            f"(by {pr.author})"
+        )
+
+    # --- Human PR confirmation gate ---
+    # Only prompt when human PRs are actually in scope, not merely
+    # because --include-human-prs was supplied.
+    needs_human_confirm = bool(human_prs) and not ctx.no_confirm
+    if needs_human_confirm:
+        console.print(
+            "\n⚠️  Human-authored PRs are included in this "
+            "merge operation."
+        )
+        console.print(
+            "   Review the list above carefully before "
+            "proceeding."
+        )
+        try:
+            if "pytest" in sys.modules or os.getenv("TESTING"):
+                console.print(
+                    "⚠️  Test mode detected "
+                    "- skipping interactive prompt"
+                )
+                return
+            user_input = input(
+                "Type 'yes' to include human PRs, "
+                "or press Enter to skip them: "
+            ).strip().lower()
+            if user_input != "yes":
+                console.print(
+                    "ℹ️  Excluding human PRs from merge."
+                )
+                # Remove human PRs from the working set
+                repo_prs = automation_prs
+                human_prs = []
+                if not repo_prs:
+                    console.print(
+                        "❌ No automation PRs remain to merge."
+                    )
+                    return
+        except (KeyboardInterrupt, EOFError):
+            console.print("\n❌ Merge cancelled by user.")
+            return
+
+    # --- Build the merge list (ComparisonResult is None for repo mode) ---
+    all_prs_to_merge: list[
+        tuple[PullRequestInfo, ComparisonResult | None]
+    ] = [(pr, None) for pr in repo_prs]
+
+    # --- Preview / merge using existing infrastructure ---
+    if ctx.show_progress:
+        ctx.progress_tracker = MergeProgressTracker(ctx.owner)
+
+    merge_results = _run_parallel_merge(
+        ctx, all_prs_to_merge, preview=not ctx.no_confirm
+    )
+
+    if not merge_results:
+        console.print("❌ No PRs were processed")
+        return
+
+    merged_count = sum(
+        1 for r in merge_results
+        if r.status.value == "merged"
+    )
+
+    if not ctx.no_confirm:
+        # In preview mode, show what would happen, then prompt
+        # for confirmation via an override-style SHA.
+        _handle_repo_preview_confirmation(
+            ctx,
+            merge_results,
+            all_prs_to_merge,
+            merged_count,
+            len(merge_results),
+        )
+        return
+
+    _display_merge_results(merge_results, ctx.no_confirm)
+
+
+def _handle_repo_preview_confirmation(
+    ctx: _MergeContext,
+    merge_results: list[MergeResult],
+    all_prs_to_merge: list[
+        tuple[PullRequestInfo, ComparisonResult | None]
+    ],
+    merged_count: int,
+    total_to_merge: int,
+) -> None:
+    """Handle preview-then-confirm for repository-scoped merges.
+
+    Similar to _handle_preview_confirmation but does not require a
+    source PR for SHA generation — it uses the repository name instead.
+    """
+    console.print(f"\nMergeable {merged_count}/{total_to_merge} PRs")
+
+    if merged_count == 0:
+        console.print("\n💡 No PRs are mergeable at this time.")
+        return
+
+    # Generate a confirmation token from the repo context
+    combined = (
+        f"repo-merge:{ctx.owner}/{ctx.repo_name}:"
+        f"{merged_count}"
+    )
+    confirm_hash = hashlib.sha256(
+        combined.encode("utf-8")
+    ).hexdigest()[:16]
+
+    console.print()
+    console.print(
+        f"To proceed with merging enter: {confirm_hash}"
+    )
+
+    try:
+        if "pytest" in sys.modules or os.getenv("TESTING"):
+            console.print(
+                "⚠️  Test mode detected "
+                "- skipping interactive prompt"
+            )
+            return
+
+        user_input = input(
+            "Enter the string above to continue "
+            "(or press Enter to cancel): "
+        ).strip()
+
+        if user_input == confirm_hash:
+            _execute_repo_confirmed_merge(
+                ctx, merge_results, all_prs_to_merge
+            )
+        elif user_input == "":
+            console.print("❌ Merge cancelled by user.")
+        else:
+            console.print("❌ Invalid input. Merge cancelled.")
+    except KeyboardInterrupt:
+        console.print("\n❌ Merge cancelled by user.")
+    except EOFError:
+        console.print("\n❌ Merge cancelled.")
+
+
+def _execute_repo_confirmed_merge(
+    ctx: _MergeContext,
+    preview_results: list[MergeResult],
+    all_prs_to_merge: list[
+        tuple[PullRequestInfo, ComparisonResult | None]
+    ],
+) -> None:
+    """Run the real merge after user confirmation (repo mode)."""
+    mergeable_prs = [
+        all_prs_to_merge[i]
+        for i, result in enumerate(preview_results)
+        if result.status.value == "merged"
+    ]
+    merged_count = len(mergeable_prs)
+    console.print(
+        f"\n🔨 Merging {merged_count} mergeable pull requests..."
+    )
+
+    real_results = _run_parallel_merge(
+        ctx, mergeable_prs, preview=False
+    )
+
+    final_merged = sum(
+        1 for r in real_results if r.status.value == "merged"
+    )
+    final_failed = sum(
+        1 for r in real_results if r.status.value == "failed"
+    )
+    final_skipped = sum(
+        1 for r in real_results if r.status.value == "skipped"
+    )
+    final_blocked = sum(
+        1 for r in real_results if r.status.value == "blocked"
+    )
+    console.print(
+        f"\n🚀 Final Results: {final_merged} merged, "
+        f"{final_failed} failed"
+    )
+    if final_skipped > 0:
+        console.print(f"⏭️  Skipped {final_skipped} PRs")
+    if final_blocked > 0:
+        console.print(f"🛑 Blocked {final_blocked} PRs")
+
+
 def _handle_gerrit_merge(
     parsed_url: ParsedUrl,
     no_confirm: bool,
@@ -1072,7 +1363,10 @@ def _handle_gerrit_merge(
 
 @app.command()
 def merge(
-    pr_url: str = typer.Argument(..., help="GitHub PR URL or Gerrit change URL"),
+    pr_url: str = typer.Argument(
+        ...,
+        help="GitHub PR URL, repository URL, or Gerrit change URL",
+    ),
     no_confirm: bool = typer.Option(
         False,
         "--no-confirm",
@@ -1154,16 +1448,21 @@ def merge(
         "--ignore-github2gerrit",
         help="Ignore GitHub2Gerrit comments and merge PRs in GitHub as normal",
     ),
+    include_human_prs: bool = typer.Option(
+        False,
+        "--include-human-prs",
+        help="Include human-authored PRs when merging a repository (prompts for confirmation when human PRs are found)",
+    ),
 ):
     """
     Bulk approve/merge pull requests or Gerrit changes.
 
-    Supports both GitHub PRs and Gerrit Code Review changes.
+    Supports GitHub PRs, GitHub repository URLs, and Gerrit Code Review changes.
 
     By default, runs in interactive mode showing what changes will apply,
     then prompts to proceed with merge. Use --no-confirm to merge immediately.
 
-    For GitHub PRs, this command will:
+    For GitHub PRs (single PR URL), this command will:
 
     1. Analyze the provided PR
 
@@ -1172,6 +1471,19 @@ def merge(
     3. Approve and merge matching PRs
 
     4. Automatically fix out-of-date branches (use --no-fix to disable)
+
+    For GitHub repository URLs, this command will:
+
+    1. Fetch all open PRs in the specified repository
+
+    2. Filter to automation PRs only (unless --include-human-prs is given)
+
+    3. Approve and merge matching PRs in bulk
+
+    Repository URL formats accepted:
+      https://github.com/owner/repo
+      https://github.com/owner/repo/
+      https://github.com/owner/repo/pulls
 
     For Gerrit changes, this command will:
 
@@ -1214,14 +1526,22 @@ def merge(
         verbose,
     )
 
-    # --- Parse URL and route to Gerrit if applicable ---
+    # --- Parse URL and route to the appropriate handler ---
+    # Try as a specific PR/change URL first
+    parsed_url: ParsedUrl | None = None
+    parsed_repo: ParsedRepoUrl | None = None
     try:
         parsed_url = parse_change_url(pr_url)
-    except UrlParseError as e:
-        console.print(f"❌ Invalid URL: {e}")
-        raise typer.Exit(1) from None
+    except UrlParseError:
+        # Not a PR URL — try as a repository URL
+        try:
+            parsed_repo = parse_repo_url(pr_url)
+        except UrlParseError as repo_err:
+            console.print(f"❌ Invalid URL: {repo_err}")
+            raise typer.Exit(1) from None
 
-    if parsed_url.is_gerrit:
+    # --- Route: Gerrit change ---
+    if parsed_url is not None and parsed_url.is_gerrit:
         _handle_gerrit_merge(
             parsed_url=parsed_url,
             no_confirm=no_confirm,
@@ -1234,7 +1554,73 @@ def merge(
         )
         return
 
-    # --- GitHub merge flow ---
+    # --- Route: GitHub repository (bulk per-repo merge) ---
+    if parsed_repo is not None:
+        repo_ctx = _MergeContext(
+            pr_url=parsed_repo.original_url,
+            no_confirm=no_confirm,
+            similarity_threshold=similarity_threshold,
+            merge_method=merge_method,
+            token=token,
+            override=override,
+            no_fix=no_fix,
+            show_progress=show_progress,
+            debug_matching=debug_matching,
+            dismiss_copilot=dismiss_copilot,
+            force=force,
+            verbose=verbose,
+            no_netrc=no_netrc,
+            netrc_file=netrc_file,
+            netrc_optional=netrc_optional,
+            github2gerrit_mode=github2gerrit_mode,
+            include_human_prs=include_human_prs,
+        )
+        try:
+            _handle_repo_merge(parsed_repo, repo_ctx)
+        except DependamergeError as exc:
+            if repo_ctx.progress_tracker:
+                repo_ctx.progress_tracker.stop()
+            exc.display_and_exit()
+        except (KeyboardInterrupt, SystemExit):
+            if repo_ctx.progress_tracker:
+                repo_ctx.progress_tracker.stop()
+            raise
+        except typer.Exit:
+            if repo_ctx.progress_tracker:
+                repo_ctx.progress_tracker.stop()
+            raise
+        except (
+            GitError,
+            RateLimitError,
+            SecondaryRateLimitError,
+            GraphQLError,
+        ) as exc:
+            if repo_ctx.progress_tracker:
+                repo_ctx.progress_tracker.stop()
+            if isinstance(exc, GitError):
+                converted_error = convert_git_error(exc)
+            else:
+                converted_error = convert_github_api_error(exc)
+            converted_error.display_and_exit()
+        except Exception as e:
+            if repo_ctx.progress_tracker:
+                repo_ctx.progress_tracker.stop()
+            if is_github_api_permission_error(e):
+                exit_for_github_api_error(exception=e)
+            elif is_network_error(e):
+                converted_error = convert_network_error(e)
+                converted_error.display_and_exit()
+            else:
+                exit_with_error(
+                    ExitCode.GENERAL_ERROR,
+                    message="❌ Error during repository merge operation",
+                    details=str(e),
+                    exception=e,
+                )
+        return
+
+    # --- Route: GitHub single PR merge flow ---
+    assert parsed_url is not None
     ctx = _MergeContext(
         pr_url=parsed_url.original_url,
         no_confirm=no_confirm,
@@ -1252,6 +1638,7 @@ def merge(
         netrc_file=netrc_file,
         netrc_optional=netrc_optional,
         github2gerrit_mode=github2gerrit_mode,
+        include_human_prs=include_human_prs,
     )
 
     try:

--- a/src/dependamerge/cli.py
+++ b/src/dependamerge/cli.py
@@ -943,7 +943,11 @@ def _handle_repo_merge(
 
     # --- Progress tracker ---
     if ctx.show_progress:
-        ctx.progress_tracker = MergeProgressTracker(ctx.owner)
+        ctx.progress_tracker = MergeProgressTracker(
+            ctx.owner,
+            operation_label="Fetching open PRs",
+            operation_icon="🔍",
+        )
         ctx.progress_tracker.update_total_repositories(1)
         ctx.progress_tracker.start()
 
@@ -1064,7 +1068,11 @@ def _handle_repo_merge(
 
     # --- Preview / merge using existing infrastructure ---
     if ctx.show_progress:
-        ctx.progress_tracker = MergeProgressTracker(ctx.owner)
+        ctx.progress_tracker = MergeProgressTracker(
+            ctx.owner,
+            operation_label="Merging PRs",
+            operation_icon="🔀",
+        )
         ctx.progress_tracker.update_total_repositories(1)
         ctx.progress_tracker.start()
 
@@ -1177,7 +1185,11 @@ def _execute_repo_confirmed_merge(
     )
 
     if ctx.show_progress:
-        ctx.progress_tracker = MergeProgressTracker(ctx.owner)
+        ctx.progress_tracker = MergeProgressTracker(
+            ctx.owner,
+            operation_label="Merging PRs",
+            operation_icon="🔀",
+        )
         ctx.progress_tracker.update_total_repositories(1)
         ctx.progress_tracker.start()
 

--- a/src/dependamerge/cli.py
+++ b/src/dependamerge/cli.py
@@ -9,6 +9,7 @@ import sys
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
+from urllib.parse import urlparse
 
 import requests
 import typer
@@ -507,11 +508,27 @@ def _check_merge_permissions(ctx: _MergeContext) -> None:
 
     try:
         perm_results = asyncio.run(_check())
+        # Separate blocking failures from advisory warnings.
+        # branch_protection (Administration: Read) is advisory — the
+        # merge flow tolerates missing visibility and the token can
+        # still approve/merge successfully without it.
+        _ADVISORY_OPS = {"branch_protection"}
         missing_perms = [
             op
             for op, result in perm_results.items()
-            if not result["has_permission"]
+            if not result["has_permission"] and op not in _ADVISORY_OPS
         ]
+        advisory_perms = [
+            op
+            for op, result in perm_results.items()
+            if not result["has_permission"] and op in _ADVISORY_OPS
+        ]
+        if advisory_perms:
+            for op in advisory_perms:
+                result = perm_results[op]
+                console.print(
+                    f"⚠️  {op}: {result['error']} (non-blocking)"
+                )
         if missing_perms:
             console.print("\n❌ Token Permission Check Failed:\n")
             for op in missing_perms:
@@ -897,6 +914,17 @@ def _handle_repo_merge(
         ctx: Shared merge context populated with CLI parameters.
     """
     from .github_service import GitHubService
+    from .url_parser import _host_matches
+
+    # --- Guard: repo-merge only supports github.com for now ---
+    if not _host_matches(parsed_repo.host, "github.com"):
+        console.print(
+            "❌ Repository-scoped merge is currently only supported "
+            f"for github.com (got host: {parsed_repo.host}).\n"
+            "   GitHub Enterprise support requires API base URL "
+            "configuration — use a direct PR URL instead."
+        )
+        raise typer.Exit(code=1)
 
     # --- Initialise GitHub client & token ---
     ctx.github_client = GitHubClient(ctx.token)
@@ -916,6 +944,7 @@ def _handle_repo_merge(
     # --- Progress tracker ---
     if ctx.show_progress:
         ctx.progress_tracker = MergeProgressTracker(ctx.owner)
+        ctx.progress_tracker.update_total_repositories(1)
         ctx.progress_tracker.start()
 
     # --- Fetch open PRs for the repository ---
@@ -959,7 +988,7 @@ def _handle_repo_merge(
     # GraphQL returns authors without the "[bot]" suffix (e.g.
     # "dependabot" not "dependabot[bot]"), so the exact-match
     # GitHubClient.is_automation_author() would misclassify them.
-    def _is_auto(author: str) -> bool:
+    def _is_auto(author: str | None) -> bool:
         author_lower = (author or "").lower()
         return any(tool in author_lower for tool in AUTOMATION_TOOLS)
 
@@ -1006,15 +1035,11 @@ def _handle_repo_merge(
             "proceeding."
         )
         try:
-            if "pytest" in sys.modules or os.getenv("TESTING"):
-                console.print(
-                    "⚠️  Test mode detected "
-                    "- skipping interactive prompt"
-                )
-                return
-            user_input = input(
+            user_input = typer.prompt(
                 "Type 'yes' to include human PRs, "
-                "or press Enter to skip them: "
+                "or press Enter to skip them",
+                default="",
+                show_default=False,
             ).strip().lower()
             if user_input != "yes":
                 console.print(
@@ -1028,7 +1053,7 @@ def _handle_repo_merge(
                         "❌ No automation PRs remain to merge."
                     )
                     return
-        except (KeyboardInterrupt, EOFError):
+        except (KeyboardInterrupt, EOFError, typer.Abort):
             console.print("\n❌ Merge cancelled by user.")
             return
 
@@ -1040,14 +1065,20 @@ def _handle_repo_merge(
     # --- Preview / merge using existing infrastructure ---
     if ctx.show_progress:
         ctx.progress_tracker = MergeProgressTracker(ctx.owner)
+        ctx.progress_tracker.update_total_repositories(1)
+        ctx.progress_tracker.start()
 
-    # Serialise merges for repo-scoped operations: all PRs target
-    # the same repository, so parallel approve+merge would race
-    # against GitHub's branch-protection propagation and cause
-    # spurious "branch protection" failures.
-    merge_results = _run_parallel_merge(
-        ctx, all_prs_to_merge, preview=not ctx.no_confirm, concurrency=1
-    )
+    try:
+        # Serialise merges for repo-scoped operations: all PRs target
+        # the same repository, so parallel approve+merge would race
+        # against GitHub's branch-protection propagation and cause
+        # spurious "branch protection" failures.
+        merge_results = _run_parallel_merge(
+            ctx, all_prs_to_merge, preview=not ctx.no_confirm, concurrency=1
+        )
+    finally:
+        if ctx.show_progress and ctx.progress_tracker:
+            ctx.progress_tracker.stop()
 
     if not merge_results:
         console.print("❌ No PRs were processed")
@@ -1108,16 +1139,11 @@ def _handle_repo_preview_confirmation(
     )
 
     try:
-        if "pytest" in sys.modules or os.getenv("TESTING"):
-            console.print(
-                "⚠️  Test mode detected "
-                "- skipping interactive prompt"
-            )
-            return
-
-        user_input = input(
+        user_input = typer.prompt(
             "Enter the string above to continue "
-            "(or press Enter to cancel): "
+            "(or press Enter to cancel)",
+            default="",
+            show_default=False,
         ).strip()
 
         if user_input == confirm_hash:
@@ -1128,10 +1154,8 @@ def _handle_repo_preview_confirmation(
             console.print("❌ Merge cancelled by user.")
         else:
             console.print("❌ Invalid input. Merge cancelled.")
-    except KeyboardInterrupt:
+    except (KeyboardInterrupt, EOFError, typer.Abort):
         console.print("\n❌ Merge cancelled by user.")
-    except EOFError:
-        console.print("\n❌ Merge cancelled.")
 
 
 def _execute_repo_confirmed_merge(
@@ -1152,9 +1176,18 @@ def _execute_repo_confirmed_merge(
         f"\n🔨 Merging {merged_count} mergeable pull requests..."
     )
 
-    real_results = _run_parallel_merge(
-        ctx, mergeable_prs, preview=False, concurrency=1
-    )
+    if ctx.show_progress:
+        ctx.progress_tracker = MergeProgressTracker(ctx.owner)
+        ctx.progress_tracker.update_total_repositories(1)
+        ctx.progress_tracker.start()
+
+    try:
+        real_results = _run_parallel_merge(
+            ctx, mergeable_prs, preview=False, concurrency=1
+        )
+    finally:
+        if ctx.show_progress and ctx.progress_tracker:
+            ctx.progress_tracker.stop()
 
     final_merged = sum(
         1 for r in real_results if r.status.value == "merged"
@@ -1554,14 +1587,36 @@ def merge(
     # Try as a specific PR/change URL first
     parsed_url: ParsedUrl | None = None
     parsed_repo: ParsedRepoUrl | None = None
+    change_err: UrlParseError | None = None
     try:
         parsed_url = parse_change_url(pr_url)
-    except UrlParseError:
+    except UrlParseError as e:
+        change_err = e
         # Not a PR URL — try as a repository URL
         try:
             parsed_repo = parse_repo_url(pr_url)
         except UrlParseError as repo_err:
-            console.print(f"❌ Invalid URL: {repo_err}")
+            # Show the most relevant error: if the URL targets a
+            # non-github.com host the original parse_change_url error
+            # gives host-appropriate guidance (e.g. Gerrit tips),
+            # whereas parse_repo_url only talks about github.com.
+            from .url_parser import _host_matches
+
+            try:
+                # Prepend scheme if missing so urlparse can extract the
+                # hostname.  Without a scheme, schemeless URLs like
+                # "gerrit.example.org/..." are parsed as a path with no
+                # hostname, causing the wrong error to be shown.
+                _norm = pr_url
+                if not _norm.startswith(("http://", "https://")):
+                    _norm = "https://" + _norm
+                host = urlparse(_norm).hostname or ""
+            except Exception:
+                host = ""
+            if host and not _host_matches(host.lower(), "github.com"):
+                console.print(f"❌ Invalid URL: {change_err}")
+            else:
+                console.print(f"❌ Invalid URL: {repo_err}")
             raise typer.Exit(1) from None
 
     # --- Route: Gerrit change ---

--- a/src/dependamerge/cli.py
+++ b/src/dependamerge/cli.py
@@ -942,10 +942,19 @@ def _handle_repo_merge(
         return
 
     # --- Classify PRs as automation vs human ---
+    # Use AUTOMATION_TOOLS substring matching (consistent with
+    # GitHubService.fetch_repo_open_prs and _is_automation_author).
+    # GraphQL returns authors without the "[bot]" suffix (e.g.
+    # "dependabot" not "dependabot[bot]"), so the exact-match
+    # GitHubClient.is_automation_author() would misclassify them.
+    def _is_auto(author: str) -> bool:
+        author_lower = (author or "").lower()
+        return any(tool in author_lower for tool in AUTOMATION_TOOLS)
+
     automation_prs: list[PullRequestInfo] = []
     human_prs: list[PullRequestInfo] = []
     for pr in repo_prs:
-        if ctx.github_client.is_automation_author(pr.author):
+        if _is_auto(pr.author):
             automation_prs.append(pr)
         else:
             human_prs.append(pr)
@@ -965,8 +974,7 @@ def _handle_repo_merge(
 
     # List PRs that will be processed
     for pr in repo_prs:
-        is_auto = ctx.github_client.is_automation_author(pr.author)
-        icon = "🤖" if is_auto else "👤"
+        icon = "🤖" if _is_auto(pr.author) else "👤"
         console.print(
             f"  {icon} #{pr.number} {pr.title} "
             f"(by {pr.author})"

--- a/src/dependamerge/cli.py
+++ b/src/dependamerge/cli.py
@@ -498,7 +498,7 @@ def _check_merge_permissions(ctx: _MergeContext) -> None:
 
     async def _check() -> dict[str, dict[str, Any]]:
         async with GitHubAsync(token=ctx.token) as client:
-            operations = ["approve", "merge"]
+            operations = ["approve", "merge", "branch_protection"]
             if not ctx.no_fix:
                 operations.append("update_branch")
             return await client.check_token_permissions(

--- a/src/dependamerge/cli.py
+++ b/src/dependamerge/cli.py
@@ -695,15 +695,27 @@ def _run_parallel_merge(
         tuple[PullRequestInfo, ComparisonResult | None]
     ],
     preview: bool,
+    concurrency: int = 10,
 ) -> list[MergeResult]:
-    """Execute a parallel merge (preview or real) and return results."""
+    """Execute a parallel merge (preview or real) and return results.
+
+    Args:
+        ctx: Shared merge context.
+        prs_to_merge: PRs to process.
+        preview: If True, run in preview mode without side effects.
+        concurrency: Maximum number of concurrent merge workers.
+            For org-wide merges (PRs spread across repos) the default
+            of 10 is fine.  For repo-scoped merges (all PRs in the
+            same repo) use 1 to serialise operations and give GitHub
+            time to propagate approvals between merges.
+    """
 
     async def _do_merge():
         async with AsyncMergeManager(
             token=ctx.token,  # pyright: ignore[reportArgumentType]
             merge_method=ctx.merge_method,
             max_retries=MAX_RETRIES,
-            concurrency=10,
+            concurrency=concurrency,
             fix_out_of_date=not ctx.no_fix,
             progress_tracker=ctx.progress_tracker,
             preview_mode=preview,
@@ -1029,8 +1041,12 @@ def _handle_repo_merge(
     if ctx.show_progress:
         ctx.progress_tracker = MergeProgressTracker(ctx.owner)
 
+    # Serialise merges for repo-scoped operations: all PRs target
+    # the same repository, so parallel approve+merge would race
+    # against GitHub's branch-protection propagation and cause
+    # spurious "branch protection" failures.
     merge_results = _run_parallel_merge(
-        ctx, all_prs_to_merge, preview=not ctx.no_confirm
+        ctx, all_prs_to_merge, preview=not ctx.no_confirm, concurrency=1
     )
 
     if not merge_results:
@@ -1137,7 +1153,7 @@ def _execute_repo_confirmed_merge(
     )
 
     real_results = _run_parallel_merge(
-        ctx, mergeable_prs, preview=False
+        ctx, mergeable_prs, preview=False, concurrency=1
     )
 
     final_merged = sum(

--- a/src/dependamerge/cli.py
+++ b/src/dependamerge/cli.py
@@ -1073,7 +1073,7 @@ def _handle_repo_merge(
             operation_label="Merging PRs",
             operation_icon="🔀",
         )
-        ctx.progress_tracker.update_total_repositories(1)
+        ctx.progress_tracker.set_total_prs(len(all_prs_to_merge))
         ctx.progress_tracker.start()
 
     try:
@@ -1190,7 +1190,7 @@ def _execute_repo_confirmed_merge(
             operation_label="Merging PRs",
             operation_icon="🔀",
         )
-        ctx.progress_tracker.update_total_repositories(1)
+        ctx.progress_tracker.set_total_prs(len(mergeable_prs))
         ctx.progress_tracker.start()
 
     try:

--- a/src/dependamerge/gerrit/models.py
+++ b/src/dependamerge/gerrit/models.py
@@ -272,13 +272,16 @@ class GerritChangeInfo(BaseModel):
                 submit_requirements_met = False
                 break
 
-        # Construct URL
+        # Construct URL via the centralised builder to ensure base_path
+        # is handled consistently (see GerritUrlBuilder).
         url = ""
         if host:
-            if base_path:
-                url = f"https://{host}/{base_path}/c/{project}/+/{number}"
-            else:
-                url = f"https://{host}/c/{project}/+/{number}"
+            from dependamerge.gerrit.urls import GerritUrlBuilder
+
+            builder = GerritUrlBuilder(
+                host=host, base_path=base_path, auto_discover=False
+            )
+            url = builder.change_url(project, number)
 
         # Timestamps
         created = data.get("created", "")

--- a/src/dependamerge/github2gerrit_detector.py
+++ b/src/dependamerge/github2gerrit_detector.py
@@ -233,7 +233,9 @@ def build_gerrit_change_url_from_mapping(
     Build a Gerrit web change URL from mapping metadata.
 
     This constructs a URL suitable for posting as a comment on the GitHub PR
-    after the Gerrit change has been submitted.
+    after the Gerrit change has been submitted.  URL construction is delegated
+    to :class:`~dependamerge.gerrit.urls.GerritUrlBuilder` to ensure the
+    base path is handled consistently.
 
     Args:
         mapping: The parsed mapping containing Change-IDs and topic.
@@ -244,15 +246,17 @@ def build_gerrit_change_url_from_mapping(
         A Gerrit change URL string.  If the exact change number is not
         available in the mapping, returns a search URL using the Change-ID.
     """
-    base = f"https://{gerrit_host}"
-    if gerrit_base_path:
-        base = f"{base}/{gerrit_base_path}"
+    from dependamerge.gerrit.urls import GerritUrlBuilder
+
+    builder = GerritUrlBuilder(
+        host=gerrit_host, base_path=gerrit_base_path, auto_discover=False
+    )
 
     # Use the primary Change-ID for the search URL
     change_id = mapping.primary_change_id
     if change_id:
-        return f"{base}/q/{change_id}"
-    return base
+        return builder.web_url(f"q/{change_id}")
+    return builder.web_url()
 
 
 def build_gerrit_submission_comment(

--- a/src/dependamerge/github_async.py
+++ b/src/dependamerge/github_async.py
@@ -239,6 +239,9 @@ class GitHubAsync:
         self._adaptive_delay = 0.0
         self._last_adaptive_update: float | None = None
 
+        # Cache for the authenticated user's login (never changes during a session)
+        self._authenticated_user_login: str | None = None
+
         mounts = None
         if proxies:
             mounts = {}
@@ -1258,19 +1261,23 @@ class GitHubAsync:
             try:
                 # For organization repos, check if user has bypass permissions
                 # This requires checking the user's role/permissions
-                user_data = await self.get("/user")
-                if isinstance(user_data, dict):
-                    username = user_data.get("login")
-                    if username:
-                        # Check collaborator permissions
-                        collab_data = await self.get(
-                            f"/repos/{owner}/{repo}/collaborators/{username}/permission"
-                        )
-                        if isinstance(collab_data, dict):
-                            permission_level = collab_data.get("permission")
-                            # admin permission can bypass
-                            if permission_level == "admin":
-                                return True, "User has admin collaborator permissions"
+                # Use cached login to avoid repeated /user calls
+                if self._authenticated_user_login is None:
+                    user_data = await self.get("/user")
+                    if isinstance(user_data, dict):
+                        self._authenticated_user_login = user_data.get("login")
+
+                username = self._authenticated_user_login
+                if username:
+                    # Check collaborator permissions
+                    collab_data = await self.get(
+                        f"/repos/{owner}/{repo}/collaborators/{username}/permission"
+                    )
+                    if isinstance(collab_data, dict):
+                        permission_level = collab_data.get("permission")
+                        # admin permission can bypass
+                        if permission_level == "admin":
+                            return True, "User has admin collaborator permissions"
             except Exception as e:
                 # If we can't check detailed permissions, continue with basic check
                 self.log.debug(

--- a/src/dependamerge/github_async.py
+++ b/src/dependamerge/github_async.py
@@ -1394,13 +1394,13 @@ class GitHubAsync:
                         )
                         if isinstance(collab_data, dict):
                             perm_level = collab_data.get("permission", "none")
-                            # write or admin is required for approve/merge/close/update
-                            if perm_level in ("write", "admin"):
+                            # write, maintain, or admin is required for approve/merge/close/update
+                            if perm_level in ("write", "maintain", "admin"):
                                 result["has_permission"] = True
                             else:
                                 result["error"] = (
                                     f"Token has '{perm_level}' access to "
-                                    f"{owner}/{repo} — write or admin is required"
+                                    f"{owner}/{repo} — write, maintain, or admin is required"
                                 )
                                 perms = OPERATION_PERMISSIONS.get(operation, {})
                                 result["guidance"] = {
@@ -1419,12 +1419,32 @@ class GitHubAsync:
                     # 404 "Branch not protected"; without it GitHub
                     # returns 403 "Resource not accessible".
                     #
-                    # Note: Administration: Read also gates access to the
-                    # actions/permissions endpoint, so this check
-                    # implicitly covers Workflows/Actions access too.
+                    # The repo metadata fetch is separated from the
+                    # branch-protection probe so that a 404 from
+                    # GET /repos/{owner}/{repo} (repo doesn't exist or
+                    # token can't see it) is NOT silently treated as
+                    # success.
+                    default_branch = "main"
+                    try:
+                        repo_data = await self.get(
+                            f"/repos/{owner}/{repo}"
+                        )
+                        if isinstance(repo_data, dict):
+                            default_branch = repo_data.get(
+                                "default_branch", "main"
+                            )
+                    except Exception:
+                        # Repo metadata fetch failed — token may lack
+                        # access.  Let the error propagate to the outer
+                        # handler which will surface it as a permission
+                        # error.  Do NOT fall through to treat this as
+                        # success.
+                        raise
+
                     try:
                         await self.get(
-                            f"/repos/{owner}/{repo}/branches/main/protection"
+                            f"/repos/{owner}/{repo}/branches/"
+                            f"{default_branch}/protection"
                         )
                         result["has_permission"] = True
                     except Exception as e:

--- a/src/dependamerge/github_async.py
+++ b/src/dependamerge/github_async.py
@@ -1364,58 +1364,76 @@ class GitHubAsync:
 
             try:
                 # Perform a lightweight check for each operation
-                if operation == "approve" and owner and repo:
-                    # Check if we can access PR reviews endpoint
-                    # Use a non-existent PR number to test permission without side effects
-                    try:
-                        await self.get(f"/repos/{owner}/{repo}/pulls/999999/reviews")
-                    except Exception as e:
-                        if "404" not in str(e):  # 404 is fine, means we have permission
-                            raise
-                    result["has_permission"] = True
+                if operation in ("approve", "merge", "close", "update_branch") and owner and repo:
+                    # Use the collaborator permission endpoint to verify
+                    # the token has write access to this specific repo.
+                    #
+                    # The previous approach (GET /repos/{owner}/{repo} and
+                    # inspecting permissions.push) is unreliable for
+                    # fine-grained PATs: GitHub returns the *user's*
+                    # org-level permissions regardless of token scope,
+                    # producing false positives when the token is scoped
+                    # to a different org.
+                    #
+                    # The collaborator endpoint correctly returns 403
+                    # ("Resource not accessible by personal access token")
+                    # when the token doesn't cover the target repo.
 
-                elif operation == "merge" and owner and repo:
-                    # Check repository permissions
-                    repo_data = await self.get(f"/repos/{owner}/{repo}")
-                    if isinstance(repo_data, dict):
-                        permissions = repo_data.get("permissions", {})
-                        if permissions.get("push") or permissions.get("admin"):
-                            result["has_permission"] = True
-                        else:
-                            result["error"] = "Token lacks push/write permissions"
-                            perms = OPERATION_PERMISSIONS.get("merge", {})
-                            result["guidance"] = {
-                                "classic": perms.get("classic"),
-                                "fine_grained": perms.get("fine_grained"),
-                            }
+                    # Resolve authenticated username (cached after first call)
+                    if self._authenticated_user_login is None:
+                        user_data = await self.get("/user")
+                        if isinstance(user_data, dict):
+                            self._authenticated_user_login = user_data.get("login")
 
-                elif operation == "close" and owner and repo:
-                    # Similar to approve - check PR access
-                    try:
-                        await self.get(
-                            f"/repos/{owner}/{repo}/pulls?state=closed&per_page=1"
+                    username = self._authenticated_user_login
+                    if not username:
+                        result["error"] = "Could not determine authenticated user"
+                    else:
+                        collab_data = await self.get(
+                            f"/repos/{owner}/{repo}/collaborators/{username}/permission"
                         )
-                    except Exception as e:
-                        if "404" not in str(e):
-                            raise
-                    result["has_permission"] = True
-
-                elif operation == "update_branch" and owner and repo:
-                    # Check repository write permissions
-                    repo_data = await self.get(f"/repos/{owner}/{repo}")
-                    if isinstance(repo_data, dict):
-                        permissions = repo_data.get("permissions", {})
-                        if permissions.get("push") or permissions.get("admin"):
-                            result["has_permission"] = True
+                        if isinstance(collab_data, dict):
+                            perm_level = collab_data.get("permission", "none")
+                            # write or admin is required for approve/merge/close/update
+                            if perm_level in ("write", "admin"):
+                                result["has_permission"] = True
+                            else:
+                                result["error"] = (
+                                    f"Token has '{perm_level}' access to "
+                                    f"{owner}/{repo} — write or admin is required"
+                                )
+                                perms = OPERATION_PERMISSIONS.get(operation, {})
+                                result["guidance"] = {
+                                    "classic": perms.get("classic"),
+                                    "fine_grained": perms.get("fine_grained"),
+                                }
                         else:
                             result["error"] = (
-                                "Token lacks push/write permissions for branch updates"
+                                "Could not determine collaborator permissions"
                             )
-                            perms = OPERATION_PERMISSIONS.get("update_branch", {})
-                            result["guidance"] = {
-                                "classic": perms.get("classic"),
-                                "fine_grained": perms.get("fine_grained"),
-                            }
+
+                elif operation == "branch_protection" and owner and repo:
+                    # Verify Administration: Read permission by probing
+                    # the branch protection endpoint.  A token with this
+                    # permission receives either 200 (rules exist) or
+                    # 404 "Branch not protected"; without it GitHub
+                    # returns 403 "Resource not accessible".
+                    #
+                    # Note: Administration: Read also gates access to the
+                    # actions/permissions endpoint, so this check
+                    # implicitly covers Workflows/Actions access too.
+                    try:
+                        await self.get(
+                            f"/repos/{owner}/{repo}/branches/main/protection"
+                        )
+                        result["has_permission"] = True
+                    except Exception as e:
+                        if "404" in str(e):
+                            # 404 = branch exists but has no protection
+                            # rules — the token still has the permission.
+                            result["has_permission"] = True
+                        else:
+                            raise
 
                 elif operation == "list_repos":
                     # Check organization access

--- a/src/dependamerge/github_service.py
+++ b/src/dependamerge/github_service.py
@@ -760,7 +760,7 @@ class GitHubService:
             results.append(pr_info)
 
         if self._progress:
-            self._progress.complete_repository(len(results))
+            self._progress.complete_repository(0)
 
         return results
 

--- a/src/dependamerge/github_service.py
+++ b/src/dependamerge/github_service.py
@@ -696,6 +696,74 @@ class GitHubService:
 
         return results
 
+    async def fetch_repo_open_prs(
+        self,
+        owner: str,
+        repo: str,
+        *,
+        only_automation: bool = True,
+    ) -> list[PullRequestInfo]:
+        """
+        Fetch all open PRs for a specific repository.
+
+        This is used for repository-scoped bulk operations where we don't
+        need to scan across an organization. It reuses the same GraphQL
+        pagination infrastructure used by find_similar_prs.
+
+        Args:
+            owner: Repository owner (user or organization).
+            repo: Repository name.
+            only_automation: If True, only return PRs from automation tools.
+                           If False, return all open PRs.
+
+        Returns:
+            List of PullRequestInfo for matching open PRs.
+        """
+        repo_full_name = f"{owner}/{repo}"
+
+        if self._progress:
+            self._progress.start_repository(repo_full_name)
+            self._progress.update_operation(
+                f"Fetching open PRs from {repo_full_name}"
+            )
+
+        first_nodes, page_info = await self._fetch_repo_prs_first_page(
+            owner, repo
+        )
+        pr_nodes = list(first_nodes)
+        has_next = bool(page_info.get("hasNextPage"))
+        end_cursor = page_info.get("endCursor") or None
+
+        # Fetch additional pages if present
+        if has_next:
+            async for pr_node in self._iter_repo_open_prs_pages(
+                owner, repo, end_cursor
+            ):
+                pr_nodes.append(pr_node)
+
+        results: list[PullRequestInfo] = []
+        for pr_node in pr_nodes:
+            pr_info = self.to_pull_request_info(repo_full_name, pr_node)
+
+            if self._progress:
+                self._progress.analyze_pr(pr_info.number, repo_full_name)
+
+            # Filter by automation author if requested
+            if only_automation:
+                is_auto = any(
+                    bot in (pr_info.author or "").lower()
+                    for bot in AUTOMATION_TOOLS
+                )
+                if not is_auto:
+                    continue
+
+            results.append(pr_info)
+
+        if self._progress:
+            self._progress.complete_repository(len(results))
+
+        return results
+
     async def get_branch_protection_settings(
         self, owner: str, repo: str, branch: str = "main"
     ) -> dict[str, Any] | None:

--- a/src/dependamerge/merge_manager.py
+++ b/src/dependamerge/merge_manager.py
@@ -248,7 +248,18 @@ class AsyncMergeManager:
     ) -> MergeResult:
         """Merge a single PR with concurrency control."""
         async with self._merge_semaphore:
-            return await self._merge_single_pr(pr_info)
+            result = await self._merge_single_pr(pr_info)
+            # merge_success() and merge_failure() already increment
+            # completed_prs for MERGED/FAILED outcomes.  Catch the
+            # remaining terminal states here so PR-level progress
+            # reaches 100% even when some PRs are blocked or skipped.
+            if (
+                self.progress_tracker
+                and result.status
+                in (MergeStatus.BLOCKED, MergeStatus.SKIPPED)
+            ):
+                self.progress_tracker.pr_completed()
+            return result
 
     async def _detect_github2gerrit(
         self,

--- a/src/dependamerge/merge_manager.py
+++ b/src/dependamerge/merge_manager.py
@@ -1541,10 +1541,11 @@ class AsyncMergeManager:
             )
             return False
 
-        # 4. Poll for the status to appear (up to ~30 seconds)
-        # Keep this short to avoid stalling merge workers — if pre-commit.ci
-        # hasn't responded yet, the next run will pick it up.
-        max_polls = 6  # 6 × 5s = 30s
+        # 4. Poll for the status to appear (up to ~5 minutes)
+        # pre-commit.ci can take up to five minutes to run and report back,
+        # so we need a generous timeout to avoid prematurely marking PRs as
+        # unmergeable when the check simply hasn't finished yet.
+        max_polls = 60  # 60 × 5s = 300s
         for attempt in range(max_polls):
             await asyncio.sleep(5.0)
             try:

--- a/src/dependamerge/merge_manager.py
+++ b/src/dependamerge/merge_manager.py
@@ -119,6 +119,8 @@ class AsyncMergeManager:
         # Cache for organization-level settings to avoid repeated API calls
         # Key: org name, Value: org settings dict (or None on failure)
         self._org_settings_cache: dict[str, dict[str, Any] | None] = {}
+        self._org_settings_locks: dict[str, asyncio.Lock] = {}
+        self._org_settings_locks_lock = asyncio.Lock()
 
         # Track last merge exception per PR for better error reporting
         self._last_merge_exception: dict[str, Exception] = {}
@@ -2483,32 +2485,47 @@ class AsyncMergeManager:
         Returns:
             Organization settings dict, or None if the lookup failed
         """
+        # Fast path: no lock needed if already cached
         if owner in self._org_settings_cache:
             return self._org_settings_cache[owner]
 
-        if not self._github_client:
-            return None
+        # Acquire a per-owner lock so concurrent lookups for the same
+        # org are serialised, but lookups for *different* orgs proceed
+        # in parallel without blocking each other.
+        async with self._org_settings_locks_lock:
+            if owner not in self._org_settings_locks:
+                self._org_settings_locks[owner] = asyncio.Lock()
+            owner_lock = self._org_settings_locks[owner]
 
-        try:
-            org_data = await self._github_client.get(f"/orgs/{owner}")
-            if isinstance(org_data, dict):
-                self._org_settings_cache[owner] = org_data
-                # Log org-level details once, not per-PR
-                web_commit_signoff = org_data.get(
-                    "web_commit_signoff_required", False
-                )
-                if web_commit_signoff:
-                    self.log.debug(
-                        f"Organization {owner} requires commit signoff"
+        async with owner_lock:
+            # Re-check after acquiring the per-owner lock (another
+            # task may have populated the cache while we waited).
+            if owner in self._org_settings_cache:
+                return self._org_settings_cache[owner]
+
+            if not self._github_client:
+                return None
+
+            try:
+                org_data = await self._github_client.get(f"/orgs/{owner}")
+                if isinstance(org_data, dict):
+                    self._org_settings_cache[owner] = org_data
+                    # Log org-level details once, not per-PR
+                    web_commit_signoff = org_data.get(
+                        "web_commit_signoff_required", False
                     )
-                return org_data
-            else:
+                    if web_commit_signoff:
+                        self.log.debug(
+                            f"Organization {owner} requires commit signoff"
+                        )
+                    return org_data
+                else:
+                    self._org_settings_cache[owner] = None
+                    return None
+            except Exception as e:
+                self.log.debug(f"Could not check organization settings for {owner}: {e}")
                 self._org_settings_cache[owner] = None
                 return None
-        except Exception as e:
-            self.log.debug(f"Could not check organization settings for {owner}: {e}")
-            self._org_settings_cache[owner] = None
-            return None
 
     async def _test_merge_capability(
         self, owner: str, repo: str, pr_number: int, merge_method: str

--- a/src/dependamerge/merge_manager.py
+++ b/src/dependamerge/merge_manager.py
@@ -118,7 +118,7 @@ class AsyncMergeManager:
 
         # Cache for organization-level settings to avoid repeated API calls
         # Key: org name, Value: org settings dict (or None on failure)
-        self._org_settings_cache: dict[str, dict | None] = {}
+        self._org_settings_cache: dict[str, dict[str, Any] | None] = {}
 
         # Track last merge exception per PR for better error reporting
         self._last_merge_exception: dict[str, Exception] = {}
@@ -2468,7 +2468,7 @@ class AsyncMergeManager:
         # For other failure types, don't retry
         return False
 
-    async def _get_org_settings(self, owner: str) -> dict | None:
+    async def _get_org_settings(self, owner: str) -> dict[str, Any] | None:
         """
         Get organization-level settings, with caching.
 

--- a/src/dependamerge/merge_manager.py
+++ b/src/dependamerge/merge_manager.py
@@ -116,6 +116,10 @@ class AsyncMergeManager:
         # Track merge methods per repository
         self._pr_merge_methods: dict[str, str] = {}
 
+        # Cache for organization-level settings to avoid repeated API calls
+        # Key: org name, Value: org settings dict (or None on failure)
+        self._org_settings_cache: dict[str, dict | None] = {}
+
         # Track last merge exception per PR for better error reporting
         self._last_merge_exception: dict[str, Exception] = {}
 
@@ -2464,6 +2468,47 @@ class AsyncMergeManager:
         # For other failure types, don't retry
         return False
 
+    async def _get_org_settings(self, owner: str) -> dict | None:
+        """
+        Get organization-level settings, with caching.
+
+        Organization settings (e.g. web_commit_signoff_required) don't change
+        between PRs in the same org, so we cache the result for the lifetime
+        of the merge session.
+
+        Args:
+            owner: Organization/owner name
+
+        Returns:
+            Organization settings dict, or None if the lookup failed
+        """
+        if owner in self._org_settings_cache:
+            return self._org_settings_cache[owner]
+
+        if not self._github_client:
+            return None
+
+        try:
+            org_data = await self._github_client.get(f"/orgs/{owner}")
+            if isinstance(org_data, dict):
+                self._org_settings_cache[owner] = org_data
+                # Log org-level details once, not per-PR
+                web_commit_signoff = org_data.get(
+                    "web_commit_signoff_required", False
+                )
+                if web_commit_signoff:
+                    self.log.debug(
+                        f"Organization {owner} requires commit signoff"
+                    )
+                return org_data
+            else:
+                self._org_settings_cache[owner] = None
+                return None
+        except Exception as e:
+            self.log.debug(f"Could not check organization settings for {owner}: {e}")
+            self._org_settings_cache[owner] = None
+            return None
+
     async def _test_merge_capability(
         self, owner: str, repo: str, pr_number: int, merge_method: str
     ) -> tuple[bool, str]:
@@ -2486,21 +2531,8 @@ class AsyncMergeManager:
             return False, "GitHub client not initialized"
 
         try:
-            # Check organization-level restrictions that may not be visible in branch protection
-            try:
-                org_data = await self._github_client.get(f"/orgs/{owner}")
-                if isinstance(org_data, dict):
-                    # Some organizations have additional restrictions
-                    web_commit_signoff = org_data.get(
-                        "web_commit_signoff_required", False
-                    )
-                    if web_commit_signoff:
-                        self.log.debug(f"Organization {owner} requires commit signoff")
-            except Exception as org_check_error:
-                # Organization check failed, continue with other checks
-                self.log.debug(
-                    f"Could not check organization settings: {org_check_error}"
-                )
+            # Check organization-level restrictions (cached per org)
+            await self._get_org_settings(owner)
 
             # Note: Removed DCO signoff check as web_commit_signoff_required only affects
             # web-based commits, not PR merges. DCO enforcement for PRs is handled by

--- a/src/dependamerge/progress_tracker.py
+++ b/src/dependamerge/progress_tracker.py
@@ -346,13 +346,34 @@ class ProgressTracker:
 class MergeProgressTracker(ProgressTracker):
     """Extended progress tracker with merge-specific metrics."""
 
-    def __init__(self, organization: str, is_close_operation: bool = False):
+    def __init__(
+        self,
+        organization: str,
+        is_close_operation: bool = False,
+        operation_label: str | None = None,
+        operation_icon: str | None = None,
+    ):
+        """Initialize merge progress tracker.
+
+        Args:
+            organization: Name of the GitHub organization or owner.
+            is_close_operation: Whether this tracks a close operation.
+            operation_label: Custom heading label for the progress
+                display.  When ``None``, defaults to
+                ``"Searching for similar PRs"`` (merge) or
+                ``"Closing PRs"`` (close).
+            operation_icon: Custom emoji icon for the heading.  When
+                ``None``, defaults to ``"🔀"`` / ``"🔍"`` (merge) or
+                ``"🚪"`` (close) depending on context.
+        """
         super().__init__(organization, show_pr_stats=True)
         self.similar_prs_found = 0
         self.prs_merged = 0
         self.prs_failed = 0
         self.prs_closed = 0
         self.is_close_operation = is_close_operation
+        self._custom_label = operation_label
+        self._custom_icon = operation_icon
 
     def found_similar_pr(self, count: int = 1) -> None:
         """Update count of similar PRs found."""
@@ -381,16 +402,21 @@ class MergeProgressTracker(ProgressTracker):
 
         text = Text()
 
+        # Resolve label and icon — use custom values when provided,
+        # otherwise fall back to the default close/merge text.
+        default_label = (
+            "Closing PRs"
+            if self.is_close_operation
+            else "Searching for similar PRs"
+        )
+        label = self._custom_label or default_label
+
         # Main progress line for merge/close operations
         if self.total_repositories > 0:
             progress_pct = (self.completed_repositories / self.total_repositories) * 100
-            operation_icon = "🚪" if self.is_close_operation else "🔀"
-            operation_text = (
-                "Searching for similar PRs"
-                if not self.is_close_operation
-                else "Closing PRs"
-            )
-            text.append(f"{operation_icon} {operation_text} in ", style="bold blue")
+            default_icon = "🚪" if self.is_close_operation else "🔀"
+            icon = self._custom_icon or default_icon
+            text.append(f"{icon} {label} in ", style="bold blue")
             text.append(f"{self.organization} ", style="bold cyan")
             text.append(
                 f"({self.completed_repositories}/{self.total_repositories} repos, ",
@@ -399,13 +425,9 @@ class MergeProgressTracker(ProgressTracker):
             text.append(f"{progress_pct:.0f}%", style="bold green")
             text.append(")", style="dim")
         else:
-            operation_icon = "🚪" if self.is_close_operation else "🔍"
-            operation_text = (
-                "Closing PRs"
-                if self.is_close_operation
-                else "Searching for similar PRs"
-            )
-            text.append(f"{operation_icon} {operation_text} in ", style="bold blue")
+            default_icon = "🚪" if self.is_close_operation else "🔍"
+            icon = self._custom_icon or default_icon
+            text.append(f"{icon} {label} in ", style="bold blue")
             text.append(f"{self.organization} ", style="bold cyan")
 
         # Current operation
@@ -495,6 +517,8 @@ class DummyProgressTracker(ProgressTracker):
         self.prs_failed = 0
         self.prs_closed = 0
         self.is_close_operation = False
+        self._custom_label: str | None = None
+        self._custom_icon: str | None = None
 
     def start(self) -> None:
         pass

--- a/src/dependamerge/progress_tracker.py
+++ b/src/dependamerge/progress_tracker.py
@@ -374,25 +374,56 @@ class MergeProgressTracker(ProgressTracker):
         self.is_close_operation = is_close_operation
         self._custom_label = operation_label
         self._custom_icon = operation_icon
+        # PR-level progress (used for repo-scoped operations)
+        self.total_prs = 0
+        self.completed_prs = 0
 
     def found_similar_pr(self, count: int = 1) -> None:
         """Update count of similar PRs found."""
         self.similar_prs_found += count
         self._refresh_display()
 
+    def set_total_prs(self, total: int) -> None:
+        """Set the total number of PRs to process.
+
+        When set, the progress display switches from repo-level
+        to PR-level progress (e.g. ``3/9 PRs, 33%``).
+        """
+        self.total_prs = total
+        self._refresh_display()
+
     def merge_success(self) -> None:
         """Record a successful merge."""
         self.prs_merged += 1
+        if self.total_prs > 0:
+            self.completed_prs += 1
         self._refresh_display()
 
     def merge_failure(self) -> None:
         """Record a failed merge."""
         self.prs_failed += 1
+        if self.total_prs > 0:
+            self.completed_prs += 1
         self._refresh_display()
 
     def increment_closed(self) -> None:
         """Record a successful close."""
         self.prs_closed += 1
+        if self.total_prs > 0:
+            self.completed_prs += 1
+        self._refresh_display()
+
+    def pr_completed(self) -> None:
+        """Record a PR as processed without changing status counters.
+
+        Use this for BLOCKED/SKIPPED outcomes that bypass
+        ``merge_success()`` and ``merge_failure()``.  Those
+        methods already increment ``completed_prs``; this one
+        exists solely to keep the progress percentage accurate
+        for terminal states that neither method covers.
+        """
+        if self.total_prs > 0:
+            self.completed_prs += 1
         self._refresh_display()
 
     def _generate_display_text(self) -> Any:
@@ -411,8 +442,22 @@ class MergeProgressTracker(ProgressTracker):
         )
         label = self._custom_label or default_label
 
-        # Main progress line for merge/close operations
-        if self.total_repositories > 0:
+        # Main progress line for merge/close operations.
+        # PR-level progress takes priority over repo-level progress
+        # so repo-scoped merges show "3/9 PRs" instead of "0/1 repos".
+        if self.total_prs > 0:
+            progress_pct = (self.completed_prs / self.total_prs) * 100
+            default_icon = "🚪" if self.is_close_operation else "🔀"
+            icon = self._custom_icon or default_icon
+            text.append(f"{icon} {label} in ", style="bold blue")
+            text.append(f"{self.organization} ", style="bold cyan")
+            text.append(
+                f"({self.completed_prs}/{self.total_prs} PRs, ",
+                style="dim",
+            )
+            text.append(f"{progress_pct:.0f}%", style="bold green")
+            text.append(")", style="dim")
+        elif self.total_repositories > 0:
             progress_pct = (self.completed_repositories / self.total_repositories) * 100
             default_icon = "🚪" if self.is_close_operation else "🔀"
             icon = self._custom_icon or default_icon
@@ -482,6 +527,8 @@ class MergeProgressTracker(ProgressTracker):
                 "prs_merged": self.prs_merged,
                 "prs_failed": self.prs_failed,
                 "prs_closed": self.prs_closed,
+                "total_prs": self.total_prs,
+                "completed_prs": self.completed_prs,
             }
         )
         return base
@@ -519,6 +566,8 @@ class DummyProgressTracker(ProgressTracker):
         self.is_close_operation = False
         self._custom_label: str | None = None
         self._custom_icon: str | None = None
+        self.total_prs = 0
+        self.completed_prs = 0
 
     def start(self) -> None:
         pass
@@ -548,6 +597,12 @@ class DummyProgressTracker(ProgressTracker):
         pass
 
     def clear_rate_limited(self) -> None:
+        pass
+
+    def set_total_prs(self, total: int) -> None:
+        pass
+
+    def pr_completed(self) -> None:
         pass
 
     def found_similar_pr(self, count: int = 1) -> None:

--- a/src/dependamerge/url_parser.py
+++ b/src/dependamerge/url_parser.py
@@ -374,10 +374,22 @@ def parse_repo_url(url: str) -> ParsedRepoUrl:
     host = parsed.hostname.lower()
     path = parsed.path.rstrip("/")
 
-    # Only GitHub repository URLs are supported
-    if not _is_github_url(host, path) and not _host_matches(host, "github.com"):
+    # Only github.com and actual subdomains of github.com (e.g.
+    # foo.github.com) are accepted.  _host_matches() checks for an
+    # exact match or a *.github.com suffix, so hosts like
+    # github.enterprise.com (a subdomain of enterprise.com, NOT
+    # github.com) are correctly rejected.
+    #
+    # GitHub Enterprise Server installations use arbitrary hostnames
+    # (e.g. ghe.corp.example.com) that cannot be reliably distinguished
+    # from non-GitHub hosts without explicit configuration.  GHE support
+    # (both repo-merge and single-PR) requires host-aware API base URL
+    # configuration, which is not yet implemented.
+    if not _host_matches(host, "github.com"):
         raise UrlParseError(
-            f"Repository URL parsing is only supported for GitHub: {url}"
+            f"Repository URL parsing is only supported for "
+            f"github.com hosts (got host: {host}). "
+            f"Use a direct PR URL for non-GitHub hosts."
         )
 
     # Try to extract owner/repo from the path
@@ -395,11 +407,22 @@ def parse_repo_url(url: str) -> ParsedRepoUrl:
             f"https://{host}/owner/repo"
         )
 
-    # Check that this is NOT a PR URL (has /pull/N)
-    if "pull" in parts and len(parts) > parts.index("pull") + 1:
+    # After stripping "pulls", require exactly 2 parts (owner/repo)
+    if len(parts) != 2:
+        # Check if this is a PR URL (owner/repo/pull/…) before giving a generic error.
+        # Match any path starting with /owner/repo/pull/ regardless of whether
+        # the PR segment is numeric — /pull/abc is still clearly a PR-shaped URL
+        # and deserves the more specific guidance.
+        if len(parts) >= 3 and parts[2] == "pull":
+            raise UrlParseError(
+                "This looks like a pull request URL, not a repository URL. "
+                "Pass the full PR URL (…/pull/<number>) directly to merge "
+                "a single PR, or use the repository URL (…/owner/repo) for "
+                "bulk operations."
+            )
         raise UrlParseError(
-            "URL appears to be a PR URL, not a repository URL. "
-            "Use parse_change_url() instead."
+            f"Invalid GitHub repository URL format. Expected: "
+            f"https://{host}/owner/repo"
         )
 
     owner = parts[0]

--- a/src/dependamerge/url_parser.py
+++ b/src/dependamerge/url_parser.py
@@ -71,6 +71,33 @@ class ParsedUrl:
         return self.source == ChangeSource.GERRIT
 
 
+@dataclass(frozen=True)
+class ParsedRepoUrl:
+    """
+    Parsed repository URL (not a specific PR/change).
+
+    Attributes:
+        source: The code review platform (GitHub only for now).
+        host: The hostname of the server.
+        owner: The repository owner/organization.
+        repo: The repository name.
+        project: The full "owner/repo" string.
+        original_url: The original URL that was parsed.
+    """
+
+    source: ChangeSource
+    host: str
+    owner: str
+    repo: str
+    project: str
+    original_url: str
+
+    @property
+    def is_github(self) -> bool:
+        """Check if this URL is from GitHub."""
+        return self.source == ChangeSource.GITHUB
+
+
 def _host_matches(
     hostname: str,
     target: str,
@@ -310,11 +337,91 @@ def detect_source(url: str) -> ChangeSource:
         raise UrlParseError(f"Cannot determine platform for URL: {url}")
 
 
+def parse_repo_url(url: str) -> ParsedRepoUrl:
+    """
+    Parse a GitHub repository URL (not a specific PR).
+
+    Supports formats:
+        https://github.com/owner/repo
+        https://github.com/owner/repo/
+        https://github.com/owner/repo/pulls
+
+    Args:
+        url: The URL to parse.
+
+    Returns:
+        A ParsedRepoUrl instance with the extracted components.
+
+    Raises:
+        UrlParseError: If the URL format is not recognized as a valid repository URL.
+    """
+    url = url.strip()
+    if not url:
+        raise UrlParseError("URL cannot be empty")
+
+    # Ensure URL has a scheme
+    if not url.startswith(("http://", "https://")):
+        url = "https://" + url
+
+    try:
+        parsed = urlparse(url)
+    except Exception as exc:
+        raise UrlParseError(f"Invalid URL format: {exc}") from exc
+
+    if not parsed.hostname:
+        raise UrlParseError("URL must include a hostname")
+
+    host = parsed.hostname.lower()
+    path = parsed.path.rstrip("/")
+
+    # Only GitHub repository URLs are supported
+    if not _is_github_url(host, path) and not _host_matches(host, "github.com"):
+        raise UrlParseError(
+            f"Repository URL parsing is only supported for GitHub: {url}"
+        )
+
+    # Try to extract owner/repo from the path
+    # Expected: /owner/repo or /owner/repo/pulls
+    # Strip the path, remove "pulls" suffix if present
+    parts = [p for p in path.split("/") if p]
+
+    # Remove "pulls" suffix if present
+    if parts and parts[-1] == "pulls":
+        parts = parts[:-1]
+
+    if len(parts) < 2:
+        raise UrlParseError(
+            f"Invalid GitHub repository URL format. Expected: "
+            f"https://{host}/owner/repo"
+        )
+
+    # Check that this is NOT a PR URL (has /pull/N)
+    if "pull" in parts and len(parts) > parts.index("pull") + 1:
+        raise UrlParseError(
+            "URL appears to be a PR URL, not a repository URL. "
+            "Use parse_change_url() instead."
+        )
+
+    owner = parts[0]
+    repo = parts[1]
+
+    return ParsedRepoUrl(
+        source=ChangeSource.GITHUB,
+        host=host,
+        owner=owner,
+        repo=repo,
+        project=f"{owner}/{repo}",
+        original_url=url,
+    )
+
+
 __all__ = [
     "ChangeSource",
+    "ParsedRepoUrl",
     "ParsedUrl",
     "UrlParseError",
     "_host_matches",
     "detect_source",
     "parse_change_url",
+    "parse_repo_url",
 ]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -140,7 +140,6 @@ class TestCLI:
 
         assert result.exit_code == 1
         assert "❌ Invalid URL:" in result.stdout
-        assert "Cannot determine platform" in result.stdout
 
     @patch("dependamerge.cli.GitHubClient")
     def test_merge_command_non_automation_pr(self, mock_client_class):

--- a/tests/test_gerrit_url_hygiene.py
+++ b/tests/test_gerrit_url_hygiene.py
@@ -1,0 +1,346 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2025 The Linux Foundation
+
+"""Architectural tests enforcing Gerrit URL construction via GerritUrlBuilder.
+
+All Gerrit URL construction in production code MUST go through the centralised
+``GerritUrlBuilder`` class (``dependamerge.gerrit.urls``).  Building URLs with
+ad-hoc f-strings bypasses base-path handling and leads to inconsistent URLs
+when a Gerrit instance is deployed behind a reverse-proxy prefix (e.g.
+``/infra``).
+
+These tests scan production source files for patterns that indicate direct
+Gerrit URL construction and fail if any are found outside the builder itself.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Paths
+# ---------------------------------------------------------------------------
+
+_PROJECT_ROOT = Path(__file__).resolve().parent.parent
+_SRC_ROOT = _PROJECT_ROOT / "src" / "dependamerge"
+
+# Files that are *allowed* to construct Gerrit URLs directly.
+# gerrit/urls.py  — the canonical builder implementation
+_ALLOWED_FILES: set[str] = {
+    str(_SRC_ROOT / "gerrit" / "urls.py"),
+}
+
+# Files that only *detect* / *parse* Gerrit URL shapes (pattern matching,
+# not construction) — these legitimately reference /c/ and /+/ in regexes,
+# docstrings, and error messages but never emit a URL.
+_DETECTION_ONLY_FILES: set[str] = {
+    str(_SRC_ROOT / "url_parser.py"),
+}
+
+# ---------------------------------------------------------------------------
+# Patterns that indicate direct Gerrit URL construction
+# ---------------------------------------------------------------------------
+
+# Each entry is (compiled_regex, human-readable description).
+# The regexes are intentionally broad to catch creative variants.
+
+_DIRECT_URL_PATTERNS: list[tuple[re.Pattern[str], str]] = [
+    # f"https://{host}/c/{project}/+/{number}"  — change URL
+    (
+        re.compile(
+            r"""f["']https?://\{[^}]+\}/c/\{[^}]+\}/\+/\{[^}]+\}""",
+        ),
+        "Direct Gerrit change URL construction (use GerritUrlBuilder.change_url())",
+    ),
+    # f"https://{host}/{base_path}/c/{project}/+/{number}"  — change URL with base_path
+    (
+        re.compile(
+            r"""f["']https?://\{[^}]+\}/\{[^}]+\}/c/\{[^}]+\}/\+/\{[^}]+\}""",
+        ),
+        "Direct Gerrit change URL with base_path (use GerritUrlBuilder.change_url())",
+    ),
+    # f"https://{host}/q/{change_id}"  — search/query URL
+    (
+        re.compile(
+            r"""f["']https?://\{[^}]+\}/q/\{[^}]+\}""",
+        ),
+        "Direct Gerrit search URL construction (use GerritUrlBuilder.web_url())",
+    ),
+    # f"https://{host}/changes/"  — REST API changes endpoint
+    (
+        re.compile(
+            r"""f["']https?://\{[^}]+\}/changes/""",
+        ),
+        "Direct Gerrit changes API URL (use GerritUrlBuilder.changes_api_url())",
+    ),
+    # f"https://{host}/a/changes/"  — authenticated REST API changes endpoint
+    (
+        re.compile(
+            r"""f["']https?://\{[^}]+\}/a/changes/""",
+        ),
+        "Direct Gerrit authenticated API URL (use GerritUrlBuilder.api_url())",
+    ),
+    # f"{base}/q/{change_id}"  — search URL built from a base variable
+    (
+        re.compile(
+            r"""f["']\{[^}]+\}/q/\{[^}]+\}""",
+        ),
+        "Direct Gerrit search URL from base variable (use GerritUrlBuilder.web_url())",
+    ),
+]
+
+# Pattern for constructing a Gerrit base URL from host + base_path.
+# This catches: f"https://{host}/{base_path}/"  and similar shapes.
+# Only flagged outside urls.py AND the low-level client bootstrap
+# (gerrit/client.py:build_client is the HTTP transport layer and needs
+# its own base URL before the builder exists).
+_BASE_URL_PATTERN = re.compile(
+    r"""f["']https?://\{[^}]+\}/\{[^}]+(?:\.strip\([^)]*\))?\}/?\s*["']""",
+)
+
+_BASE_URL_ALLOWED_FILES: set[str] = {
+    str(_SRC_ROOT / "gerrit" / "urls.py"),
+    # The REST client bootstraps its own base URL before the builder is
+    # available — this is acceptable at the transport layer.
+    str(_SRC_ROOT / "gerrit" / "client.py"),
+}
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _production_python_files() -> list[Path]:
+    """Return all production .py files under src/dependamerge/."""
+    return sorted(_SRC_ROOT.rglob("*.py"))
+
+
+def _is_comment_line(line: str) -> bool:
+    """Check whether *line* is a ``#`` comment (ignoring leading whitespace)."""
+    return line.lstrip().startswith("#")
+
+
+def _scan_file(
+    path: Path,
+    patterns: list[tuple[re.Pattern[str], str]],
+) -> list[tuple[int, str, str]]:
+    """Scan a single file for pattern violations.
+
+    Skips:
+    - ``#`` comment lines
+    - Triple-quoted docstring / string-literal blocks whose opening
+      delimiter (``\"\"\"``, ``'''``) appears at the start of the line
+      (after whitespace).  The *entire* block is skipped — opening
+      line, interior lines, and closing line — so that example URLs
+      in docstrings do not trigger false positives.
+    - Lines starting with ``f\"\"\"`` / ``f'''`` are **not** skipped
+      because f-strings are executed code whose interpolations may
+      construct URLs.
+
+    **Limitation:** triple-quoted strings that start mid-line (e.g.
+    ``text = \"\"\"...``) are not detected and will be scanned normally.
+    This is acceptable for this project's codebase where docstrings
+    and multi-line string literals consistently start on their own
+    line.  A ``tokenize``/AST approach would be needed for full
+    coverage.
+
+    Returns list of (line_number, line_content, description) tuples.
+    """
+    violations: list[tuple[int, str, str]] = []
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except (OSError, UnicodeDecodeError):
+        return violations
+
+    # Stateful tracking of triple-quoted blocks.
+    # When inside a block, *in_triple_quote* holds the delimiter
+    # (either '"""' or "'''"); otherwise it is None.
+    in_triple_quote: str | None = None
+
+    for line_no, line in enumerate(lines, start=1):
+        stripped = line.lstrip()
+
+        # --- Inside a triple-quoted block: skip until closing delimiter ---
+        if in_triple_quote is not None:
+            if in_triple_quote in stripped:
+                # Closing delimiter found — end the block, skip this line
+                in_triple_quote = None
+            continue
+
+        # --- Comment line ---
+        if _is_comment_line(line):
+            continue
+
+        # --- Opening a new triple-quoted block (non-f-string) ---
+        for delim in ('"""', "'''"):
+            if stripped.startswith(delim):
+                # Count occurrences of the delimiter on this line.
+                # A single-line docstring (e.g. """text""") has ≥ 2;
+                # only enter the "inside block" state for multi-line
+                # strings that open but don't close on the same line.
+                if stripped.count(delim) == 1:
+                    in_triple_quote = delim
+                # Either way, skip the opening / single-line docstring
+                break
+        else:
+            # Not a comment, not a docstring — scan for violations
+            for pattern, description in patterns:
+                if pattern.search(line):
+                    violations.append((line_no, line.strip(), description))
+
+    return violations
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestNoDirectGerritUrlConstruction:
+    """Ensure production code uses GerritUrlBuilder for all Gerrit URLs."""
+
+    def test_no_direct_gerrit_url_construction_in_production_code(self) -> None:
+        """Production files must not construct Gerrit URLs with f-strings.
+
+        All Gerrit URL building should go through GerritUrlBuilder to
+        ensure the detected base_path (``/infra``, etc.) is consistently
+        applied.  Direct f-string construction bypasses this and causes
+        broken URLs when a base path is present.
+        """
+        all_violations: list[str] = []
+
+        for py_file in _production_python_files():
+            file_str = str(py_file)
+
+            if file_str in _ALLOWED_FILES:
+                continue
+            if file_str in _DETECTION_ONLY_FILES:
+                continue
+
+            violations = _scan_file(py_file, _DIRECT_URL_PATTERNS)
+            for line_no, line_content, description in violations:
+                rel = py_file.relative_to(_PROJECT_ROOT)
+                all_violations.append(
+                    f"  {rel}:{line_no}: {description}\n    {line_content}"
+                )
+
+        if all_violations:
+            msg = (
+                "Direct Gerrit URL construction detected in production code.\n"
+                "Use GerritUrlBuilder (from dependamerge.gerrit.urls) instead.\n\n"
+                + "\n".join(all_violations)
+            )
+            pytest.fail(msg)
+
+    def test_no_direct_gerrit_base_url_construction(self) -> None:
+        """Production files must not build Gerrit base URLs manually.
+
+        The pattern ``f"https://{host}/{base_path}/"`` should only appear
+        in ``gerrit/urls.py`` (the builder) and ``gerrit/client.py``
+        (transport-layer bootstrap).  Everywhere else, use
+        ``GerritUrlBuilder._build_base_url()`` or its public methods.
+        """
+        all_violations: list[str] = []
+
+        for py_file in _production_python_files():
+            file_str = str(py_file)
+
+            if file_str in _BASE_URL_ALLOWED_FILES:
+                continue
+            if file_str in _DETECTION_ONLY_FILES:
+                continue
+
+            violations = _scan_file(
+                py_file, [(_BASE_URL_PATTERN, "Direct Gerrit base URL construction")]
+            )
+            for line_no, line_content, description in violations:
+                rel = py_file.relative_to(_PROJECT_ROOT)
+                all_violations.append(
+                    f"  {rel}:{line_no}: {description}\n    {line_content}"
+                )
+
+        if all_violations:
+            msg = (
+                "Direct Gerrit base URL construction detected.\n"
+                "Use GerritUrlBuilder (from dependamerge.gerrit.urls) instead.\n\n"
+                + "\n".join(all_violations)
+            )
+            pytest.fail(msg)
+
+    def test_builder_exposes_required_methods(self) -> None:
+        """GerritUrlBuilder must expose all the URL-building methods that
+        production code might need, so there is no excuse to bypass it."""
+        from dependamerge.gerrit.urls import GerritUrlBuilder
+
+        required_methods = [
+            "api_url",
+            "web_url",
+            "change_url",
+            "changes_api_url",
+            "change_api_url",
+            "review_url",
+            "submit_url",
+        ]
+        for method_name in required_methods:
+            assert hasattr(GerritUrlBuilder, method_name), (
+                f"GerritUrlBuilder is missing '{method_name}' — "
+                f"add it before production code resorts to direct construction"
+            )
+            assert callable(getattr(GerritUrlBuilder, method_name)), (
+                f"GerritUrlBuilder.{method_name} must be callable"
+            )
+
+    def test_builder_respects_base_path(self) -> None:
+        """Verify that the builder correctly includes the base path in all
+        URL types — this is the whole reason we centralise construction."""
+        from dependamerge.gerrit.urls import GerritUrlBuilder
+
+        builder = GerritUrlBuilder(
+            host="gerrit.example.org",
+            base_path="infra",
+            auto_discover=False,
+        )
+
+        # change_url must include base path
+        url = builder.change_url("my-project", 12345)
+        assert "/infra/" in url, f"change_url missing base path: {url}"
+        assert "/c/my-project/+/12345" in url
+
+        # web_url must include base path
+        url = builder.web_url("dashboard")
+        assert "/infra/" in url, f"web_url missing base path: {url}"
+
+        # api_url must include base path
+        url = builder.api_url("/changes/")
+        assert "/infra/" in url, f"api_url missing base path: {url}"
+
+    def test_builder_works_without_base_path(self) -> None:
+        """Verify the builder works correctly when no base path is set."""
+        from dependamerge.gerrit.urls import GerritUrlBuilder
+
+        builder = GerritUrlBuilder(
+            host="gerrit.example.org",
+            base_path=None,
+            auto_discover=False,
+        )
+
+        url = builder.change_url("project", 99999)
+        assert url == "https://gerrit.example.org/c/project/+/99999"
+
+        # No double slashes
+        assert "org//" not in url
+
+    def test_allowed_files_exist(self) -> None:
+        """Ensure the allow-lists reference files that actually exist.
+
+        Prevents stale entries hiding violations after file renames.
+        """
+        for allowed in _ALLOWED_FILES | _BASE_URL_ALLOWED_FILES | _DETECTION_ONLY_FILES:
+            assert Path(allowed).exists(), (
+                f"Allow-listed file does not exist: {allowed}\n"
+                "Update the allow-list in test_gerrit_url_hygiene.py"
+            )

--- a/tests/test_org_and_user_caches.py
+++ b/tests/test_org_and_user_caches.py
@@ -1,0 +1,349 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2025 The Linux Foundation
+
+"""Tests for organization-level settings caching and authenticated user login caching.
+
+These tests verify that:
+
+1. ``AsyncMergeManager._get_org_settings()`` caches the result of ``GET /orgs/{owner}``
+   so that the same organization is only queried once per merge session, regardless
+   of how many PRs belong to that org.
+
+2. ``GitHubAsync.check_user_can_bypass_protection()`` caches the authenticated
+   user's login (``GET /user``) so it is only fetched once per session.
+"""
+
+from __future__ import annotations
+
+import logging
+from unittest.mock import AsyncMock
+
+import pytest
+
+from dependamerge.github_async import GitHubAsync
+from dependamerge.merge_manager import AsyncMergeManager
+from tests.conftest import make_merge_manager
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_manager_with_client() -> tuple[AsyncMergeManager, AsyncMock]:
+    """Convenience wrapper around the shared helper."""
+    return make_merge_manager()
+
+
+# ---------------------------------------------------------------------------
+# _get_org_settings cache tests
+# ---------------------------------------------------------------------------
+
+
+class TestOrgSettingsCache:
+    """Tests for AsyncMergeManager._get_org_settings caching."""
+
+    @pytest.mark.asyncio
+    async def test_first_call_queries_api(self):
+        """The first call for an org should hit the API."""
+        mgr, client = _make_manager_with_client()
+        client.get = AsyncMock(
+            return_value={"web_commit_signoff_required": True, "login": "test-org"}
+        )
+
+        result = await mgr._get_org_settings("test-org")
+
+        assert result is not None
+        assert result["web_commit_signoff_required"] is True
+        client.get.assert_called_once_with("/orgs/test-org")
+
+    @pytest.mark.asyncio
+    async def test_second_call_uses_cache(self):
+        """Subsequent calls for the same org should NOT hit the API again."""
+        mgr, client = _make_manager_with_client()
+        client.get = AsyncMock(
+            return_value={"web_commit_signoff_required": False, "login": "test-org"}
+        )
+
+        first = await mgr._get_org_settings("test-org")
+        second = await mgr._get_org_settings("test-org")
+
+        assert first is second  # same cached object
+        client.get.assert_called_once_with("/orgs/test-org")
+
+    @pytest.mark.asyncio
+    async def test_different_orgs_each_query_once(self):
+        """Different orgs should each be queried exactly once."""
+        mgr, client = _make_manager_with_client()
+
+        call_count: dict[str, int] = {}
+
+        async def mock_get(url: str):
+            call_count[url] = call_count.get(url, 0) + 1
+            return {"login": url.split("/")[-1], "web_commit_signoff_required": False}
+
+        client.get = AsyncMock(side_effect=mock_get)
+
+        await mgr._get_org_settings("org-a")
+        await mgr._get_org_settings("org-b")
+        await mgr._get_org_settings("org-a")  # should be cached
+        await mgr._get_org_settings("org-b")  # should be cached
+
+        assert call_count["/orgs/org-a"] == 1
+        assert call_count["/orgs/org-b"] == 1
+
+    @pytest.mark.asyncio
+    async def test_api_failure_is_cached_as_none(self):
+        """If the org lookup fails, the failure (None) should be cached to avoid retries."""
+        mgr, client = _make_manager_with_client()
+        client.get = AsyncMock(side_effect=Exception("network error"))
+
+        first = await mgr._get_org_settings("flaky-org")
+        second = await mgr._get_org_settings("flaky-org")
+
+        assert first is None
+        assert second is None
+        # Only one API call despite two invocations
+        client.get.assert_called_once_with("/orgs/flaky-org")
+
+    @pytest.mark.asyncio
+    async def test_non_dict_response_cached_as_none(self):
+        """If the API returns a non-dict value, it should be cached as None."""
+        mgr, client = _make_manager_with_client()
+        client.get = AsyncMock(return_value="unexpected string")
+
+        result = await mgr._get_org_settings("weird-org")
+
+        assert result is None
+        assert mgr._org_settings_cache["weird-org"] is None
+
+    @pytest.mark.asyncio
+    async def test_no_client_returns_none(self):
+        """If _github_client is None, should return None without caching."""
+        mgr, _client = _make_manager_with_client()
+        mgr._github_client = None
+
+        result = await mgr._get_org_settings("any-org")
+
+        assert result is None
+        assert "any-org" not in mgr._org_settings_cache
+
+    @pytest.mark.asyncio
+    async def test_signoff_logged_once(self, caplog):
+        """The commit signoff debug message should appear only once per org."""
+        caplog.set_level(logging.DEBUG, logger="dependamerge.merge_manager")
+
+        mgr, client = _make_manager_with_client()
+        client.get = AsyncMock(
+            return_value={"web_commit_signoff_required": True, "login": "sign-org"}
+        )
+
+        await mgr._get_org_settings("sign-org")
+        await mgr._get_org_settings("sign-org")
+        await mgr._get_org_settings("sign-org")
+
+        signoff_messages = [
+            r
+            for r in caplog.records
+            if "requires commit signoff" in r.message and "sign-org" in r.message
+        ]
+        assert len(signoff_messages) == 1
+
+
+# ---------------------------------------------------------------------------
+# _test_merge_capability uses the org cache
+# ---------------------------------------------------------------------------
+
+
+class TestTestMergeCapabilityUsesOrgCache:
+    """Verify that _test_merge_capability routes through the cached helper."""
+
+    @pytest.mark.asyncio
+    async def test_multiple_prs_same_org_single_org_query(self):
+        """Calling _test_merge_capability for multiple PRs in the same org
+        should only produce one GET /orgs/{owner} call."""
+        mgr, client = _make_manager_with_client()
+
+        org_call_count = 0
+
+        async def mock_get(url: str):
+            nonlocal org_call_count
+            if url.startswith("/orgs/"):
+                org_call_count += 1
+                return {"web_commit_signoff_required": True}
+            if "/pulls/" in url:
+                return {
+                    "mergeable": True,
+                    "mergeable_state": "clean",
+                    "head": {"sha": "abc123"},
+                }
+            return {}
+
+        client.get = AsyncMock(side_effect=mock_get)
+
+        # Simulate processing 5 PRs across 3 repos in the same org
+        for pr_num in range(1, 6):
+            await mgr._test_merge_capability(
+                "same-org", f"repo-{pr_num}", pr_num, "merge"
+            )
+
+        assert org_call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_org_failure_does_not_block_merge_check(self):
+        """If the org settings lookup fails, _test_merge_capability should
+        still proceed to check the PR's merge status."""
+        mgr, client = _make_manager_with_client()
+
+        async def mock_get(url: str):
+            if url.startswith("/orgs/"):
+                raise Exception("org lookup failed")
+            if "/pulls/" in url:
+                return {
+                    "mergeable": True,
+                    "mergeable_state": "clean",
+                    "head": {"sha": "def456"},
+                }
+            return {}
+
+        client.get = AsyncMock(side_effect=mock_get)
+
+        can_merge, reason = await mgr._test_merge_capability(
+            "broken-org", "some-repo", 1, "merge"
+        )
+
+        assert can_merge is True
+        assert "passed" in reason.lower()
+
+
+# ---------------------------------------------------------------------------
+# GitHubAsync._authenticated_user_login cache tests
+# ---------------------------------------------------------------------------
+
+
+class TestAuthenticatedUserLoginCache:
+    """Tests for GitHubAsync._authenticated_user_login caching."""
+
+    def _make_github_async(self) -> GitHubAsync:
+        """Create a GitHubAsync instance for testing."""
+        return GitHubAsync(token="fake-token")
+
+    @pytest.mark.asyncio
+    async def test_user_login_fetched_once(self, mocker):
+        """GET /user should only be called once across multiple bypass checks."""
+        gh = self._make_github_async()
+
+        call_log: list[str] = []
+
+        async def mock_get(url: str):
+            call_log.append(url)
+            if url == "/user":
+                return {"login": "test-user"}
+            if url.startswith("/repos/") and url.endswith("/permission"):
+                return {"permission": "write"}
+            if url.startswith("/repos/"):
+                return {"permissions": {"admin": False, "push": True}}
+            return {}
+
+        mocker.patch.object(gh, "get", side_effect=mock_get)
+
+        # Check bypass permissions for 3 different repos
+        await gh.check_user_can_bypass_protection("org", "repo-1")
+        await gh.check_user_can_bypass_protection("org", "repo-2")
+        await gh.check_user_can_bypass_protection("org", "repo-3")
+
+        user_calls = [c for c in call_log if c == "/user"]
+        assert len(user_calls) == 1
+        assert gh._authenticated_user_login == "test-user"
+
+    @pytest.mark.asyncio
+    async def test_cached_login_used_for_collaborator_check(self, mocker):
+        """The cached username should be used in the collaborator permission URL."""
+        gh = self._make_github_async()
+
+        collaborator_urls: list[str] = []
+
+        async def mock_get(url: str):
+            if url == "/user":
+                return {"login": "cached-user"}
+            if "/collaborators/" in url:
+                collaborator_urls.append(url)
+                return {"permission": "write"}
+            if url.startswith("/repos/"):
+                return {"permissions": {"admin": False, "push": True}}
+            return {}
+
+        mocker.patch.object(gh, "get", side_effect=mock_get)
+
+        await gh.check_user_can_bypass_protection("org", "my-repo")
+
+        assert len(collaborator_urls) == 1
+        assert "/collaborators/cached-user/permission" in collaborator_urls[0]
+
+    @pytest.mark.asyncio
+    async def test_user_api_failure_does_not_break_bypass_check(self, mocker):
+        """If GET /user fails, the bypass check should still complete gracefully."""
+        gh = self._make_github_async()
+
+        async def mock_get(url: str):
+            if url == "/user":
+                raise Exception("user endpoint unavailable")
+            if url.startswith("/repos/"):
+                return {"permissions": {"admin": False, "push": True}}
+            return {}
+
+        mocker.patch.object(gh, "get", side_effect=mock_get)
+
+        can_bypass, reason = await gh.check_user_can_bypass_protection("org", "repo")
+
+        # Should fall through to the push-permissions path
+        assert can_bypass is False
+        assert "push" in reason.lower() or "admin" in reason.lower()
+
+    @pytest.mark.asyncio
+    async def test_admin_shortcircuits_before_user_call(self, mocker):
+        """If the repo permissions already show admin, GET /user should never be called."""
+        gh = self._make_github_async()
+
+        call_log: list[str] = []
+
+        async def mock_get(url: str):
+            call_log.append(url)
+            if url.startswith("/repos/"):
+                return {"permissions": {"admin": True, "push": True}}
+            if url == "/user":
+                return {"login": "should-not-reach"}
+            return {}
+
+        mocker.patch.object(gh, "get", side_effect=mock_get)
+
+        can_bypass, reason = await gh.check_user_can_bypass_protection("org", "repo")
+
+        assert can_bypass is True
+        assert "admin" in reason.lower()
+        assert "/user" not in call_log
+
+    @pytest.mark.asyncio
+    async def test_login_cache_survives_collaborator_exception(self, mocker):
+        """If the collaborator check raises, the cached login should persist
+        for subsequent calls."""
+        gh = self._make_github_async()
+
+        call_count = {"user": 0}
+
+        async def mock_get(url: str):
+            if url == "/user":
+                call_count["user"] += 1
+                return {"login": "persistent-user"}
+            if "/collaborators/" in url:
+                raise Exception("collaborator endpoint error")
+            if url.startswith("/repos/"):
+                return {"permissions": {"admin": False, "push": True}}
+            return {}
+
+        mocker.patch.object(gh, "get", side_effect=mock_get)
+
+        await gh.check_user_can_bypass_protection("org", "repo-1")
+        await gh.check_user_can_bypass_protection("org", "repo-2")
+
+        assert call_count["user"] == 1
+        assert gh._authenticated_user_login == "persistent-user"

--- a/tests/test_org_and_user_caches.py
+++ b/tests/test_org_and_user_caches.py
@@ -230,120 +230,120 @@ class TestAuthenticatedUserLoginCache:
     @pytest.mark.asyncio
     async def test_user_login_fetched_once(self, mocker):
         """GET /user should only be called once across multiple bypass checks."""
-        gh = self._make_github_async()
+        async with self._make_github_async() as gh:
+            call_log: list[str] = []
 
-        call_log: list[str] = []
+            async def mock_get(url: str):
+                call_log.append(url)
+                if url == "/user":
+                    return {"login": "test-user"}
+                if url.startswith("/repos/") and url.endswith("/permission"):
+                    return {"permission": "write"}
+                if url.startswith("/repos/"):
+                    return {"permissions": {"admin": False, "push": True}}
+                return {}
 
-        async def mock_get(url: str):
-            call_log.append(url)
-            if url == "/user":
-                return {"login": "test-user"}
-            if url.startswith("/repos/") and url.endswith("/permission"):
-                return {"permission": "write"}
-            if url.startswith("/repos/"):
-                return {"permissions": {"admin": False, "push": True}}
-            return {}
+            mocker.patch.object(gh, "get", side_effect=mock_get)
 
-        mocker.patch.object(gh, "get", side_effect=mock_get)
+            # Check bypass permissions for 3 different repos
+            await gh.check_user_can_bypass_protection("org", "repo-1")
+            await gh.check_user_can_bypass_protection("org", "repo-2")
+            await gh.check_user_can_bypass_protection("org", "repo-3")
 
-        # Check bypass permissions for 3 different repos
-        await gh.check_user_can_bypass_protection("org", "repo-1")
-        await gh.check_user_can_bypass_protection("org", "repo-2")
-        await gh.check_user_can_bypass_protection("org", "repo-3")
-
-        user_calls = [c for c in call_log if c == "/user"]
-        assert len(user_calls) == 1
-        assert gh._authenticated_user_login == "test-user"
+            user_calls = [c for c in call_log if c == "/user"]
+            assert len(user_calls) == 1
+            assert gh._authenticated_user_login == "test-user"
 
     @pytest.mark.asyncio
     async def test_cached_login_used_for_collaborator_check(self, mocker):
         """The cached username should be used in the collaborator permission URL."""
-        gh = self._make_github_async()
+        async with self._make_github_async() as gh:
+            collaborator_urls: list[str] = []
 
-        collaborator_urls: list[str] = []
+            async def mock_get(url: str):
+                if url == "/user":
+                    return {"login": "cached-user"}
+                if "/collaborators/" in url:
+                    collaborator_urls.append(url)
+                    return {"permission": "write"}
+                if url.startswith("/repos/"):
+                    return {"permissions": {"admin": False, "push": True}}
+                return {}
 
-        async def mock_get(url: str):
-            if url == "/user":
-                return {"login": "cached-user"}
-            if "/collaborators/" in url:
-                collaborator_urls.append(url)
-                return {"permission": "write"}
-            if url.startswith("/repos/"):
-                return {"permissions": {"admin": False, "push": True}}
-            return {}
+            mocker.patch.object(gh, "get", side_effect=mock_get)
 
-        mocker.patch.object(gh, "get", side_effect=mock_get)
+            await gh.check_user_can_bypass_protection("org", "my-repo")
 
-        await gh.check_user_can_bypass_protection("org", "my-repo")
-
-        assert len(collaborator_urls) == 1
-        assert "/collaborators/cached-user/permission" in collaborator_urls[0]
+            assert len(collaborator_urls) == 1
+            assert "/collaborators/cached-user/permission" in collaborator_urls[0]
 
     @pytest.mark.asyncio
     async def test_user_api_failure_does_not_break_bypass_check(self, mocker):
         """If GET /user fails, the bypass check should still complete gracefully."""
-        gh = self._make_github_async()
+        async with self._make_github_async() as gh:
 
-        async def mock_get(url: str):
-            if url == "/user":
-                raise Exception("user endpoint unavailable")
-            if url.startswith("/repos/"):
-                return {"permissions": {"admin": False, "push": True}}
-            return {}
+            async def mock_get(url: str):
+                if url == "/user":
+                    raise Exception("user endpoint unavailable")
+                if url.startswith("/repos/"):
+                    return {"permissions": {"admin": False, "push": True}}
+                return {}
 
-        mocker.patch.object(gh, "get", side_effect=mock_get)
+            mocker.patch.object(gh, "get", side_effect=mock_get)
 
-        can_bypass, reason = await gh.check_user_can_bypass_protection("org", "repo")
+            can_bypass, reason = await gh.check_user_can_bypass_protection(
+                "org", "repo"
+            )
 
-        # Should fall through to the push-permissions path
-        assert can_bypass is False
-        assert "push" in reason.lower() or "admin" in reason.lower()
+            # Should fall through to the push-permissions path
+            assert can_bypass is False
+            assert "push" in reason.lower() or "admin" in reason.lower()
 
     @pytest.mark.asyncio
     async def test_admin_shortcircuits_before_user_call(self, mocker):
         """If the repo permissions already show admin, GET /user should never be called."""
-        gh = self._make_github_async()
+        async with self._make_github_async() as gh:
+            call_log: list[str] = []
 
-        call_log: list[str] = []
+            async def mock_get(url: str):
+                call_log.append(url)
+                if url.startswith("/repos/"):
+                    return {"permissions": {"admin": True, "push": True}}
+                if url == "/user":
+                    return {"login": "should-not-reach"}
+                return {}
 
-        async def mock_get(url: str):
-            call_log.append(url)
-            if url.startswith("/repos/"):
-                return {"permissions": {"admin": True, "push": True}}
-            if url == "/user":
-                return {"login": "should-not-reach"}
-            return {}
+            mocker.patch.object(gh, "get", side_effect=mock_get)
 
-        mocker.patch.object(gh, "get", side_effect=mock_get)
+            can_bypass, reason = await gh.check_user_can_bypass_protection(
+                "org", "repo"
+            )
 
-        can_bypass, reason = await gh.check_user_can_bypass_protection("org", "repo")
-
-        assert can_bypass is True
-        assert "admin" in reason.lower()
-        assert "/user" not in call_log
+            assert can_bypass is True
+            assert "admin" in reason.lower()
+            assert "/user" not in call_log
 
     @pytest.mark.asyncio
     async def test_login_cache_survives_collaborator_exception(self, mocker):
         """If the collaborator check raises, the cached login should persist
         for subsequent calls."""
-        gh = self._make_github_async()
+        async with self._make_github_async() as gh:
+            call_count = {"user": 0}
 
-        call_count = {"user": 0}
+            async def mock_get(url: str):
+                if url == "/user":
+                    call_count["user"] += 1
+                    return {"login": "persistent-user"}
+                if "/collaborators/" in url:
+                    raise Exception("collaborator endpoint error")
+                if url.startswith("/repos/"):
+                    return {"permissions": {"admin": False, "push": True}}
+                return {}
 
-        async def mock_get(url: str):
-            if url == "/user":
-                call_count["user"] += 1
-                return {"login": "persistent-user"}
-            if "/collaborators/" in url:
-                raise Exception("collaborator endpoint error")
-            if url.startswith("/repos/"):
-                return {"permissions": {"admin": False, "push": True}}
-            return {}
+            mocker.patch.object(gh, "get", side_effect=mock_get)
 
-        mocker.patch.object(gh, "get", side_effect=mock_get)
+            await gh.check_user_can_bypass_protection("org", "repo-1")
+            await gh.check_user_can_bypass_protection("org", "repo-2")
 
-        await gh.check_user_can_bypass_protection("org", "repo-1")
-        await gh.check_user_can_bypass_protection("org", "repo-2")
-
-        assert call_count["user"] == 1
-        assert gh._authenticated_user_login == "persistent-user"
+            assert call_count["user"] == 1
+            assert gh._authenticated_user_login == "persistent-user"

--- a/tests/test_precommit_ci_trigger.py
+++ b/tests/test_precommit_ci_trigger.py
@@ -359,18 +359,18 @@ class TestPollingBehavior:
 
         pending = {"statuses": [{"context": "pre-commit.ci - pr", "state": "pending"}]}
 
-        # step 2 + step 3 + 6 poll iterations (max_polls = 6)
+        # step 2 + step 3 + 60 poll iterations (max_polls = 60)
         client.get.side_effect = [
             {"statuses": []},
             [],
-        ] + [pending] * 6
+        ] + [pending] * 60
 
         with patch("asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
             result = await mgr._trigger_stale_precommit_ci(pr)
 
         assert result is False
         # Should have slept once per poll
-        assert mock_sleep.call_count == 6
+        assert mock_sleep.call_count == 60
 
     @pytest.mark.asyncio
     async def test_polling_handles_api_errors_gracefully(self):

--- a/tests/test_repo_merge.py
+++ b/tests/test_repo_merge.py
@@ -1,0 +1,565 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2025 The Linux Foundation
+
+"""Tests for repository-scoped bulk merge feature."""
+
+import hashlib
+from unittest.mock import Mock, patch
+
+import pytest
+from typer.testing import CliRunner
+
+from dependamerge.cli import app
+from dependamerge.models import FileChange, PullRequestInfo
+from dependamerge.url_parser import (
+    ChangeSource,
+    ParsedRepoUrl,
+    UrlParseError,
+    parse_repo_url,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_pr(
+    number: int,
+    author: str = "dependabot[bot]",
+    title: str = "Bump foo from 1.0 to 2.0",
+    repo: str = "owner/repo",
+    state: str = "open",
+) -> PullRequestInfo:
+    """Build a minimal PullRequestInfo for testing."""
+    return PullRequestInfo(
+        number=number,
+        title=title,
+        body="Automated dependency update",
+        author=author,
+        head_sha="abc123",
+        base_branch="main",
+        head_branch="dependabot/npm_and_yarn/foo-2.0",
+        state=state,
+        mergeable=True,
+        mergeable_state="clean",
+        behind_by=0,
+        files_changed=[
+            FileChange(
+                filename="package.json",
+                additions=1,
+                deletions=1,
+                changes=2,
+                status="modified",
+            )
+        ],
+        repository_full_name=repo,
+        html_url=f"https://github.com/{repo}/pull/{number}",
+    )
+
+
+# ---------------------------------------------------------------------------
+# URL parser: parse_repo_url
+# ---------------------------------------------------------------------------
+
+
+class TestParseRepoUrl:
+    """Tests for the new parse_repo_url function."""
+
+    def test_repo_url_basic(self):
+        result = parse_repo_url("https://github.com/owner/repo")
+        assert result.source == ChangeSource.GITHUB
+        assert result.owner == "owner"
+        assert result.repo == "repo"
+        assert result.project == "owner/repo"
+        assert result.host == "github.com"
+        assert result.is_github is True
+
+    def test_repo_url_trailing_slash(self):
+        result = parse_repo_url("https://github.com/owner/repo/")
+        assert result.owner == "owner"
+        assert result.repo == "repo"
+        assert result.project == "owner/repo"
+
+    def test_repo_url_pulls_page(self):
+        result = parse_repo_url("https://github.com/modeseven-lfit/lftools-uv/pulls")
+        assert result.owner == "modeseven-lfit"
+        assert result.repo == "lftools-uv"
+        assert result.project == "modeseven-lfit/lftools-uv"
+
+    def test_repo_url_pulls_trailing_slash(self):
+        result = parse_repo_url("https://github.com/owner/repo/pulls/")
+        assert result.owner == "owner"
+        assert result.repo == "repo"
+
+    def test_repo_url_without_scheme(self):
+        result = parse_repo_url("github.com/owner/repo")
+        assert result.owner == "owner"
+        assert result.repo == "repo"
+
+    def test_repo_url_http_scheme(self):
+        result = parse_repo_url("http://github.com/owner/repo")
+        assert result.owner == "owner"
+        assert result.repo == "repo"
+
+    def test_repo_url_preserves_original(self):
+        url = "https://github.com/modeseven-lfit/lftools-uv/"
+        result = parse_repo_url(url)
+        assert result.original_url == url
+
+    def test_repo_url_with_dashes_in_names(self):
+        result = parse_repo_url("https://github.com/my-org/my-repo-name")
+        assert result.owner == "my-org"
+        assert result.repo == "my-repo-name"
+
+    def test_repo_url_empty_raises(self):
+        with pytest.raises(UrlParseError, match="URL cannot be empty"):
+            parse_repo_url("")
+
+    def test_repo_url_whitespace_only_raises(self):
+        with pytest.raises(UrlParseError, match="URL cannot be empty"):
+            parse_repo_url("   ")
+
+    def test_repo_url_non_github_raises(self):
+        with pytest.raises(UrlParseError, match="only supported for GitHub"):
+            parse_repo_url("https://gitlab.com/owner/repo")
+
+    def test_repo_url_too_short_raises(self):
+        with pytest.raises(UrlParseError, match="Invalid GitHub repository URL"):
+            parse_repo_url("https://github.com/owner")
+
+    def test_repo_url_just_host_raises(self):
+        with pytest.raises(UrlParseError, match="Invalid GitHub repository URL"):
+            parse_repo_url("https://github.com/")
+
+    def test_repo_url_is_frozen(self):
+        result = parse_repo_url("https://github.com/owner/repo")
+        with pytest.raises(AttributeError):
+            result.owner = "other"  # type: ignore[misc]
+
+    def test_repo_url_with_leading_whitespace(self):
+        result = parse_repo_url("  https://github.com/owner/repo  ")
+        assert result.owner == "owner"
+        assert result.repo == "repo"
+
+    def test_repo_url_case_insensitive_host(self):
+        result = parse_repo_url("https://GitHub.COM/Owner/Repo")
+        assert result.host == "github.com"
+        # Owner/repo are case-sensitive on GitHub
+        assert result.owner == "Owner"
+        assert result.repo == "Repo"
+
+
+class TestParsedRepoUrlDataclass:
+    """Tests for the ParsedRepoUrl dataclass."""
+
+    def test_is_github_property(self):
+        url = ParsedRepoUrl(
+            source=ChangeSource.GITHUB,
+            host="github.com",
+            owner="owner",
+            repo="repo",
+            project="owner/repo",
+            original_url="https://github.com/owner/repo",
+        )
+        assert url.is_github is True
+
+
+# ---------------------------------------------------------------------------
+# CLI: merge command with repository URLs
+# ---------------------------------------------------------------------------
+
+
+class TestMergeRepoUrl:
+    """Tests for the merge command when given a repository URL."""
+
+    runner: CliRunner = CliRunner()
+
+    def setup_method(self):
+        self.runner = CliRunner()
+
+    def test_repo_url_is_accepted(self):
+        """Verify that a repo URL doesn't produce 'Invalid URL' error."""
+        # Without a valid token the command will fail, but it should NOT
+        # fail with "Invalid URL" — it should get past URL parsing.
+        result = self.runner.invoke(
+            app,
+            [
+                "merge",
+                "https://github.com/owner/repo/pulls",
+                "--token",
+                "fake_token",
+            ],
+        )
+        # Should not see the URL parse error
+        assert "❌ Invalid URL:" not in result.stdout
+
+    def test_repo_url_trailing_slash_accepted(self):
+        result = self.runner.invoke(
+            app,
+            [
+                "merge",
+                "https://github.com/owner/repo/",
+                "--token",
+                "fake_token",
+            ],
+        )
+        assert "❌ Invalid URL:" not in result.stdout
+
+    @patch("dependamerge.cli.GitHubClient")
+    @patch("dependamerge.cli.asyncio.run")
+    def test_repo_merge_automation_only_default(
+        self, mock_asyncio_run, mock_client_class
+    ):
+        """By default only automation PRs should be included."""
+        auto_pr = _make_pr(1, author="dependabot[bot]")
+        # human_pr is filtered out by only_automation=True in the service layer
+        _make_pr(2, author="jsmith", title="Fix README typo")
+
+        mock_client = Mock()
+        mock_client.token = "test_token"
+        mock_client.is_automation_author.side_effect = lambda a: (
+            a
+            in {
+                "dependabot[bot]",
+                "pre-commit-ci[bot]",
+                "renovate[bot]",
+                "github-actions[bot]",
+            }
+        )
+        mock_client_class.return_value = mock_client
+
+        # First asyncio.run call is _check (permissions) — succeed
+        # Second asyncio.run call is _fetch_prs — return auto_pr only
+        # (because only_automation=True filters out human_pr)
+        mock_asyncio_run.side_effect = [
+            # permissions check
+            {"approve": {"has_permission": True}, "merge": {"has_permission": True}},
+            # fetch PRs (only automation)
+            [auto_pr],
+            # parallel merge (preview)
+            [],
+        ]
+
+        result = self.runner.invoke(
+            app,
+            [
+                "merge",
+                "https://github.com/owner/repo/pulls",
+                "--token",
+                "test_token",
+            ],
+        )
+
+        assert "Repository mode" in result.stdout
+
+    @patch("dependamerge.cli.GitHubClient")
+    @patch("dependamerge.cli.asyncio.run")
+    def test_repo_merge_no_open_prs(self, mock_asyncio_run, mock_client_class):
+        """When no matching PRs exist, show appropriate message."""
+        mock_client = Mock()
+        mock_client.token = "test_token"
+        mock_client_class.return_value = mock_client
+
+        mock_asyncio_run.side_effect = [
+            # permissions check
+            {"approve": {"has_permission": True}, "merge": {"has_permission": True}},
+            # fetch PRs
+            [],
+        ]
+
+        result = self.runner.invoke(
+            app,
+            [
+                "merge",
+                "https://github.com/owner/repo",
+                "--token",
+                "test_token",
+            ],
+        )
+
+        assert "No open" in result.stdout
+        assert "PRs found" in result.stdout
+
+    @patch("dependamerge.cli.GitHubClient")
+    @patch("dependamerge.cli.asyncio.run")
+    def test_repo_merge_include_human_prs_flag(
+        self, mock_asyncio_run, mock_client_class
+    ):
+        """--include-human-prs should pass only_automation=False to the service."""
+        auto_pr = _make_pr(1, author="dependabot[bot]")
+        human_pr = _make_pr(2, author="jsmith", title="Fix README typo")
+
+        mock_client = Mock()
+        mock_client.token = "test_token"
+        mock_client.is_automation_author.side_effect = lambda a: (
+            a
+            in {
+                "dependabot[bot]",
+                "pre-commit-ci[bot]",
+                "renovate[bot]",
+                "github-actions[bot]",
+            }
+        )
+        mock_client_class.return_value = mock_client
+
+        mock_asyncio_run.side_effect = [
+            # permissions check
+            {"approve": {"has_permission": True}, "merge": {"has_permission": True}},
+            # fetch PRs (both auto and human since only_automation=False)
+            [auto_pr, human_pr],
+        ]
+
+        result = self.runner.invoke(
+            app,
+            [
+                "merge",
+                "https://github.com/owner/repo",
+                "--token",
+                "test_token",
+                "--include-human-prs",
+            ],
+        )
+
+        # Should show human PRs warning
+        assert "Repository mode" in result.stdout
+
+    @patch("dependamerge.cli.GitHubClient")
+    @patch("dependamerge.cli.asyncio.run")
+    def test_repo_merge_human_prs_no_prompt_when_none_found(
+        self, mock_asyncio_run, mock_client_class
+    ):
+        """Even with --include-human-prs, don't prompt if no human PRs in results."""
+        auto_pr = _make_pr(1, author="dependabot[bot]")
+
+        mock_client = Mock()
+        mock_client.token = "test_token"
+        mock_client.is_automation_author.side_effect = lambda a: (
+            a
+            in {
+                "dependabot[bot]",
+                "pre-commit-ci[bot]",
+                "renovate[bot]",
+                "github-actions[bot]",
+            }
+        )
+        mock_client_class.return_value = mock_client
+
+        mock_asyncio_run.side_effect = [
+            # permissions check
+            {"approve": {"has_permission": True}, "merge": {"has_permission": True}},
+            # fetch PRs (only automation even though flag was given)
+            [auto_pr],
+            # preview merge
+            [],
+        ]
+
+        result = self.runner.invoke(
+            app,
+            [
+                "merge",
+                "https://github.com/owner/repo",
+                "--token",
+                "test_token",
+                "--include-human-prs",
+            ],
+        )
+
+        # Should NOT show the human PR confirmation prompt
+        assert "Human-authored PRs are included" not in result.stdout
+
+    def test_include_human_prs_help_shown(self):
+        """The --include-human-prs flag should appear in help text."""
+        result = self.runner.invoke(app, ["merge", "--help"])
+        assert "--include-human-prs" in result.stdout
+
+    def test_repo_url_formats_in_help(self):
+        """Repository URL format docs should appear in merge command help."""
+        result = self.runner.invoke(app, ["merge", "--help"])
+        assert (
+            "repository URL" in result.stdout.lower()
+            or "Repository URL" in result.stdout
+        )
+
+    def test_invalid_url_still_rejected(self):
+        """A completely invalid URL should still be rejected."""
+        result = self.runner.invoke(
+            app,
+            ["merge", "not-a-url", "--token", "test_token"],
+        )
+        assert result.exit_code == 1
+        assert "❌ Invalid URL:" in result.stdout
+
+    @patch("dependamerge.cli.GitHubClient")
+    @patch("dependamerge.cli.asyncio.run")
+    def test_repo_merge_shows_pr_classification(
+        self, mock_asyncio_run, mock_client_class
+    ):
+        """Output should classify PRs as automation vs human."""
+        auto_pr = _make_pr(1, author="dependabot[bot]")
+        human_pr = _make_pr(2, author="jsmith", title="Fix README")
+
+        mock_client = Mock()
+        mock_client.token = "test_token"
+        mock_client.is_automation_author.side_effect = lambda a: (
+            a
+            in {
+                "dependabot[bot]",
+                "pre-commit-ci[bot]",
+                "renovate[bot]",
+                "github-actions[bot]",
+            }
+        )
+        mock_client_class.return_value = mock_client
+
+        mock_asyncio_run.side_effect = [
+            # permissions check
+            {"approve": {"has_permission": True}, "merge": {"has_permission": True}},
+            # fetch PRs (both types with --include-human-prs)
+            [auto_pr, human_pr],
+        ]
+
+        result = self.runner.invoke(
+            app,
+            [
+                "merge",
+                "https://github.com/owner/repo",
+                "--token",
+                "test_token",
+                "--include-human-prs",
+            ],
+        )
+
+        # Should show counts
+        assert "Automation PRs:" in result.stdout
+        assert "Human PRs:" in result.stdout
+
+    @patch("dependamerge.cli.GitHubClient")
+    @patch("dependamerge.cli.asyncio.run")
+    def test_repo_merge_no_confirm_merges_directly(
+        self, mock_asyncio_run, mock_client_class
+    ):
+        """With --no-confirm, should skip preview and merge directly."""
+        from dependamerge.merge_manager import MergeResult, MergeStatus
+
+        auto_pr = _make_pr(1, author="dependabot[bot]")
+
+        mock_client = Mock()
+        mock_client.token = "test_token"
+        mock_client.is_automation_author.side_effect = lambda a: (
+            a
+            in {
+                "dependabot[bot]",
+                "pre-commit-ci[bot]",
+                "renovate[bot]",
+                "github-actions[bot]",
+            }
+        )
+        mock_client_class.return_value = mock_client
+
+        merge_result = MergeResult(
+            pr_info=auto_pr,
+            status=MergeStatus.MERGED,
+        )
+
+        mock_asyncio_run.side_effect = [
+            # permissions check
+            {"approve": {"has_permission": True}, "merge": {"has_permission": True}},
+            # fetch PRs
+            [auto_pr],
+            # actual merge (not preview)
+            [merge_result],
+        ]
+
+        result = self.runner.invoke(
+            app,
+            [
+                "merge",
+                "https://github.com/owner/repo",
+                "--token",
+                "test_token",
+                "--no-confirm",
+            ],
+        )
+
+        assert "Final Results:" in result.stdout
+
+
+# ---------------------------------------------------------------------------
+# URL routing: PR URLs should still work
+# ---------------------------------------------------------------------------
+
+
+class TestMergeUrlRouting:
+    """Verify that PR URLs and repo URLs are routed correctly."""
+
+    runner: CliRunner = CliRunner()
+
+    def setup_method(self):
+        self.runner = CliRunner()
+
+    @patch("dependamerge.cli.GitHubClient")
+    def test_pr_url_still_works(self, mock_client_class):
+        """A normal PR URL should still route to the original merge flow."""
+        mock_client = Mock()
+        mock_client.token = "test_token"
+        mock_client.parse_pr_url.return_value = ("owner", "repo", 42)
+        mock_client.get_pull_request_info.side_effect = Exception("simulated failure")
+        mock_client_class.return_value = mock_client
+
+        self.runner.invoke(
+            app,
+            [
+                "merge",
+                "https://github.com/owner/repo/pull/42",
+                "--token",
+                "test_token",
+            ],
+        )
+
+        # Should have called parse_pr_url (the old path), not repo path
+        mock_client.parse_pr_url.assert_called_once()
+
+    def test_gerrit_url_still_routes(self):
+        """A Gerrit URL should still route to the Gerrit handler."""
+        result = self.runner.invoke(
+            app,
+            [
+                "merge",
+                "https://gerrit.example.org/c/project/+/12345",
+                "--token",
+                "test_token",
+            ],
+        )
+        # Should attempt Gerrit flow (and fail on credentials, not URL parsing)
+        assert "❌ Invalid URL:" not in result.stdout
+
+
+# ---------------------------------------------------------------------------
+# Confirmation hash for repo mode
+# ---------------------------------------------------------------------------
+
+
+class TestRepoConfirmationHash:
+    """Verify the confirmation hash generation for repo-scoped merges."""
+
+    def test_hash_is_deterministic(self):
+        """Same inputs should always produce the same hash."""
+        combined = "repo-merge:owner/repo:3"
+        h1 = hashlib.sha256(combined.encode("utf-8")).hexdigest()[:16]
+        h2 = hashlib.sha256(combined.encode("utf-8")).hexdigest()[:16]
+        assert h1 == h2
+        assert len(h1) == 16
+
+    def test_hash_varies_with_repo(self):
+        c1 = "repo-merge:owner/repo-a:3"
+        c2 = "repo-merge:owner/repo-b:3"
+        h1 = hashlib.sha256(c1.encode("utf-8")).hexdigest()[:16]
+        h2 = hashlib.sha256(c2.encode("utf-8")).hexdigest()[:16]
+        assert h1 != h2
+
+    def test_hash_varies_with_count(self):
+        c1 = "repo-merge:owner/repo:3"
+        c2 = "repo-merge:owner/repo:5"
+        h1 = hashlib.sha256(c1.encode("utf-8")).hexdigest()[:16]
+        h2 = hashlib.sha256(c2.encode("utf-8")).hexdigest()[:16]
+        assert h1 != h2

--- a/tests/test_repo_merge.py
+++ b/tests/test_repo_merge.py
@@ -23,6 +23,29 @@ from dependamerge.url_parser import (
 # ---------------------------------------------------------------------------
 
 
+def _mock_asyncio_run(side_effects: list[object]):
+    """Create a mock for asyncio.run that properly closes coroutines.
+
+    When asyncio.run is mocked, the coroutine object passed to it is never
+    awaited and gets garbage-collected, producing RuntimeWarning.  This
+    helper closes each coroutine before returning the canned value so the
+    warning is never emitted.
+    """
+    call_index = 0
+
+    def _side_effect(coro):
+        nonlocal call_index
+        # Close the coroutine so Python doesn't warn about it
+        coro.close()
+        if call_index < len(side_effects):
+            result = side_effects[call_index]
+            call_index += 1
+            return result
+        return None
+
+    return _side_effect
+
+
 def _make_pr(
     number: int,
     author: str = "dependabot[bot]",
@@ -177,10 +200,25 @@ class TestMergeRepoUrl:
     def setup_method(self):
         self.runner = CliRunner()
 
-    def test_repo_url_is_accepted(self):
+    @patch("dependamerge.cli.asyncio.run")
+    @patch("dependamerge.cli.GitHubClient")
+    def test_repo_url_is_accepted(self, mock_client_class, mock_asyncio_run):
         """Verify that a repo URL doesn't produce 'Invalid URL' error."""
-        # Without a valid token the command will fail, but it should NOT
-        # fail with "Invalid URL" — it should get past URL parsing.
+        mock_client = Mock()
+        mock_client.token = "fake_token"
+        mock_client_class.return_value = mock_client
+
+        # Permissions check, then fetch PRs
+        mock_asyncio_run.side_effect = _mock_asyncio_run(
+            [
+                {
+                    "approve": {"has_permission": True},
+                    "merge": {"has_permission": True},
+                },
+                [],
+            ]
+        )
+
         result = self.runner.invoke(
             app,
             [
@@ -193,7 +231,25 @@ class TestMergeRepoUrl:
         # Should not see the URL parse error
         assert "❌ Invalid URL:" not in result.stdout
 
-    def test_repo_url_trailing_slash_accepted(self):
+    @patch("dependamerge.cli.asyncio.run")
+    @patch("dependamerge.cli.GitHubClient")
+    def test_repo_url_trailing_slash_accepted(
+        self, mock_client_class, mock_asyncio_run
+    ):
+        mock_client = Mock()
+        mock_client.token = "fake_token"
+        mock_client_class.return_value = mock_client
+
+        mock_asyncio_run.side_effect = _mock_asyncio_run(
+            [
+                {
+                    "approve": {"has_permission": True},
+                    "merge": {"has_permission": True},
+                },
+                [],
+            ]
+        )
+
         result = self.runner.invoke(
             app,
             [
@@ -231,14 +287,19 @@ class TestMergeRepoUrl:
         # First asyncio.run call is _check (permissions) — succeed
         # Second asyncio.run call is _fetch_prs — return auto_pr only
         # (because only_automation=True filters out human_pr)
-        mock_asyncio_run.side_effect = [
-            # permissions check
-            {"approve": {"has_permission": True}, "merge": {"has_permission": True}},
-            # fetch PRs (only automation)
-            [auto_pr],
-            # parallel merge (preview)
-            [],
-        ]
+        mock_asyncio_run.side_effect = _mock_asyncio_run(
+            [
+                # permissions check
+                {
+                    "approve": {"has_permission": True},
+                    "merge": {"has_permission": True},
+                },
+                # fetch PRs (only automation)
+                [auto_pr],
+                # parallel merge (preview)
+                [],
+            ]
+        )
 
         result = self.runner.invoke(
             app,
@@ -260,12 +321,17 @@ class TestMergeRepoUrl:
         mock_client.token = "test_token"
         mock_client_class.return_value = mock_client
 
-        mock_asyncio_run.side_effect = [
-            # permissions check
-            {"approve": {"has_permission": True}, "merge": {"has_permission": True}},
-            # fetch PRs
-            [],
-        ]
+        mock_asyncio_run.side_effect = _mock_asyncio_run(
+            [
+                # permissions check
+                {
+                    "approve": {"has_permission": True},
+                    "merge": {"has_permission": True},
+                },
+                # fetch PRs
+                [],
+            ]
+        )
 
         result = self.runner.invoke(
             app,
@@ -302,12 +368,17 @@ class TestMergeRepoUrl:
         )
         mock_client_class.return_value = mock_client
 
-        mock_asyncio_run.side_effect = [
-            # permissions check
-            {"approve": {"has_permission": True}, "merge": {"has_permission": True}},
-            # fetch PRs (both auto and human since only_automation=False)
-            [auto_pr, human_pr],
-        ]
+        mock_asyncio_run.side_effect = _mock_asyncio_run(
+            [
+                # permissions check
+                {
+                    "approve": {"has_permission": True},
+                    "merge": {"has_permission": True},
+                },
+                # fetch PRs (both auto and human since only_automation=False)
+                [auto_pr, human_pr],
+            ]
+        )
 
         result = self.runner.invoke(
             app,
@@ -344,14 +415,19 @@ class TestMergeRepoUrl:
         )
         mock_client_class.return_value = mock_client
 
-        mock_asyncio_run.side_effect = [
-            # permissions check
-            {"approve": {"has_permission": True}, "merge": {"has_permission": True}},
-            # fetch PRs (only automation even though flag was given)
-            [auto_pr],
-            # preview merge
-            [],
-        ]
+        mock_asyncio_run.side_effect = _mock_asyncio_run(
+            [
+                # permissions check
+                {
+                    "approve": {"has_permission": True},
+                    "merge": {"has_permission": True},
+                },
+                # fetch PRs (only automation even though flag was given)
+                [auto_pr],
+                # preview merge
+                [],
+            ]
+        )
 
         result = self.runner.invoke(
             app,
@@ -376,7 +452,7 @@ class TestMergeRepoUrl:
         """Repository URL format docs should appear in merge command help."""
         result = self.runner.invoke(app, ["merge", "--help"])
         assert (
-            "repository URL" in result.stdout.lower()
+            "repository url" in result.stdout.lower()
             or "Repository URL" in result.stdout
         )
 
@@ -411,12 +487,17 @@ class TestMergeRepoUrl:
         )
         mock_client_class.return_value = mock_client
 
-        mock_asyncio_run.side_effect = [
-            # permissions check
-            {"approve": {"has_permission": True}, "merge": {"has_permission": True}},
-            # fetch PRs (both types with --include-human-prs)
-            [auto_pr, human_pr],
-        ]
+        mock_asyncio_run.side_effect = _mock_asyncio_run(
+            [
+                # permissions check
+                {
+                    "approve": {"has_permission": True},
+                    "merge": {"has_permission": True},
+                },
+                # fetch PRs (both types with --include-human-prs)
+                [auto_pr, human_pr],
+            ]
+        )
 
         result = self.runner.invoke(
             app,
@@ -461,14 +542,19 @@ class TestMergeRepoUrl:
             status=MergeStatus.MERGED,
         )
 
-        mock_asyncio_run.side_effect = [
-            # permissions check
-            {"approve": {"has_permission": True}, "merge": {"has_permission": True}},
-            # fetch PRs
-            [auto_pr],
-            # actual merge (not preview)
-            [merge_result],
-        ]
+        mock_asyncio_run.side_effect = _mock_asyncio_run(
+            [
+                # permissions check
+                {
+                    "approve": {"has_permission": True},
+                    "merge": {"has_permission": True},
+                },
+                # fetch PRs
+                [auto_pr],
+                # actual merge (not preview)
+                [merge_result],
+            ]
+        )
 
         result = self.runner.invoke(
             app,

--- a/tests/test_repo_merge.py
+++ b/tests/test_repo_merge.py
@@ -4,6 +4,7 @@
 """Tests for repository-scoped bulk merge feature."""
 
 import hashlib
+import re
 from unittest.mock import Mock, patch
 
 import pytest
@@ -21,6 +22,11 @@ from dependamerge.url_parser import (
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
+
+def _strip_ansi(text: str) -> str:
+    """Remove ANSI escape sequences from text."""
+    return re.sub(r"\x1b\[[0-9;]*m", "", text)
 
 
 def _mock_asyncio_run(side_effects: list[object]):
@@ -41,7 +47,10 @@ def _mock_asyncio_run(side_effects: list[object]):
             result = side_effects[call_index]
             call_index += 1
             return result
-        return None
+        raise AssertionError(
+            f"Unexpected asyncio.run call #{call_index + 1} "
+            f"(only {len(side_effects)} side-effects provided)"
+        )
 
     return _side_effect
 
@@ -142,9 +151,50 @@ class TestParseRepoUrl:
         with pytest.raises(UrlParseError, match="URL cannot be empty"):
             parse_repo_url("   ")
 
-    def test_repo_url_non_github_raises(self):
-        with pytest.raises(UrlParseError, match="only supported for GitHub"):
+    def test_repo_url_gerrit_style_raises(self):
+        with pytest.raises(UrlParseError, match="only supported for github.com"):
+            parse_repo_url("https://gerrit.example.org/c/project/+/12345")
+
+    def test_repo_url_gerrit_style_no_plus_rejected(self):
+        """A non-github.com host is rejected regardless of path shape."""
+        with pytest.raises(UrlParseError, match="only supported for github.com"):
+            parse_repo_url("https://gerrit.example.org/c/repo")
+
+    def test_repo_url_ghe_rejected(self):
+        """GHE hosts are not github.com subdomains — rejected at parse time."""
+        with pytest.raises(UrlParseError, match="only supported for github.com"):
+            parse_repo_url("https://github.enterprise.com/owner/repo")
+
+    def test_repo_url_github_subdomain_accepted(self):
+        """Actual github.com subdomains (e.g. foo.github.com) are accepted."""
+        result = parse_repo_url("https://foo.github.com/owner/repo")
+        assert result.source == ChangeSource.GITHUB
+        assert result.host == "foo.github.com"
+        assert result.owner == "owner"
+        assert result.repo == "repo"
+
+    def test_repo_url_non_github_host_rejected(self):
+        # Non-github.com hosts are rejected at parse time to prevent misrouting
+        with pytest.raises(UrlParseError, match="only supported for github.com"):
             parse_repo_url("https://gitlab.com/owner/repo")
+
+    def test_repo_url_extra_segments_raises(self):
+        with pytest.raises(UrlParseError, match="Invalid GitHub repository URL"):
+            parse_repo_url("https://github.com/owner/repo/issues")
+
+    def test_repo_url_settings_raises(self):
+        with pytest.raises(UrlParseError, match="Invalid GitHub repository URL"):
+            parse_repo_url("https://github.com/owner/repo/settings")
+
+    def test_repo_url_pr_url_raises(self):
+        with pytest.raises(UrlParseError, match="looks like a pull request URL"):
+            parse_repo_url("https://github.com/owner/repo/pull/123")
+
+    def test_repo_url_owner_named_pull_accepted(self):
+        # An owner literally named "pull" should not be rejected
+        result = parse_repo_url("https://github.com/pull/repo")
+        assert result.owner == "pull"
+        assert result.repo == "repo"
 
     def test_repo_url_too_short_raises(self):
         with pytest.raises(UrlParseError, match="Invalid GitHub repository URL"):
@@ -167,7 +217,8 @@ class TestParseRepoUrl:
     def test_repo_url_case_insensitive_host(self):
         result = parse_repo_url("https://GitHub.COM/Owner/Repo")
         assert result.host == "github.com"
-        # Owner/repo are case-sensitive on GitHub
+        # Owner/repo casing is preserved as provided (GitHub resolves
+        # casing server-side, but we store what the user gave us)
         assert result.owner == "Owner"
         assert result.repo == "Repo"
 
@@ -214,6 +265,7 @@ class TestMergeRepoUrl:
                 {
                     "approve": {"has_permission": True},
                     "merge": {"has_permission": True},
+                    "branch_protection": {"has_permission": True},
                 },
                 [],
             ]
@@ -229,6 +281,7 @@ class TestMergeRepoUrl:
             ],
         )
         # Should not see the URL parse error
+        assert result.exit_code == 0, f"CLI failed: {result.stdout}"
         assert "❌ Invalid URL:" not in result.stdout
 
     @patch("dependamerge.cli.asyncio.run")
@@ -245,6 +298,7 @@ class TestMergeRepoUrl:
                 {
                     "approve": {"has_permission": True},
                     "merge": {"has_permission": True},
+                    "branch_protection": {"has_permission": True},
                 },
                 [],
             ]
@@ -259,6 +313,7 @@ class TestMergeRepoUrl:
                 "fake_token",
             ],
         )
+        assert result.exit_code == 0, f"CLI failed: {result.stdout}"
         assert "❌ Invalid URL:" not in result.stdout
 
     @patch("dependamerge.cli.GitHubClient")
@@ -293,6 +348,7 @@ class TestMergeRepoUrl:
                 {
                     "approve": {"has_permission": True},
                     "merge": {"has_permission": True},
+                    "branch_protection": {"has_permission": True},
                 },
                 # fetch PRs (only automation)
                 [auto_pr],
@@ -311,6 +367,7 @@ class TestMergeRepoUrl:
             ],
         )
 
+        assert result.exit_code == 0, f"CLI failed: {result.stdout}"
         assert "Repository mode" in result.stdout
 
     @patch("dependamerge.cli.GitHubClient")
@@ -327,6 +384,7 @@ class TestMergeRepoUrl:
                 {
                     "approve": {"has_permission": True},
                     "merge": {"has_permission": True},
+                    "branch_protection": {"has_permission": True},
                 },
                 # fetch PRs
                 [],
@@ -343,6 +401,7 @@ class TestMergeRepoUrl:
             ],
         )
 
+        assert result.exit_code == 0, f"CLI failed: {result.stdout}"
         assert "No open" in result.stdout
         assert "PRs found" in result.stdout
 
@@ -374,9 +433,12 @@ class TestMergeRepoUrl:
                 {
                     "approve": {"has_permission": True},
                     "merge": {"has_permission": True},
+                    "branch_protection": {"has_permission": True},
                 },
                 # fetch PRs (both auto and human since only_automation=False)
                 [auto_pr, human_pr],
+                # preview merge phase (returns MergeResult list)
+                [],
             ]
         )
 
@@ -391,6 +453,7 @@ class TestMergeRepoUrl:
             ],
         )
 
+        assert result.exit_code == 0
         # Should show human PRs warning
         assert "Repository mode" in result.stdout
 
@@ -421,6 +484,7 @@ class TestMergeRepoUrl:
                 {
                     "approve": {"has_permission": True},
                     "merge": {"has_permission": True},
+                    "branch_protection": {"has_permission": True},
                 },
                 # fetch PRs (only automation even though flag was given)
                 [auto_pr],
@@ -440,21 +504,21 @@ class TestMergeRepoUrl:
             ],
         )
 
+        assert result.exit_code == 0, f"CLI failed: {result.stdout}"
         # Should NOT show the human PR confirmation prompt
         assert "Human-authored PRs are included" not in result.stdout
 
     def test_include_human_prs_help_shown(self):
         """The --include-human-prs flag should appear in help text."""
         result = self.runner.invoke(app, ["merge", "--help"])
-        assert "--include-human-prs" in result.stdout
+        plain = _strip_ansi(result.stdout)
+        assert "--include-human-prs" in plain
 
     def test_repo_url_formats_in_help(self):
         """Repository URL format docs should appear in merge command help."""
         result = self.runner.invoke(app, ["merge", "--help"])
-        assert (
-            "repository url" in result.stdout.lower()
-            or "Repository URL" in result.stdout
-        )
+        plain = _strip_ansi(result.stdout)
+        assert "repository url" in plain.lower() or "Repository URL" in plain
 
     def test_invalid_url_still_rejected(self):
         """A completely invalid URL should still be rejected."""
@@ -493,9 +557,12 @@ class TestMergeRepoUrl:
                 {
                     "approve": {"has_permission": True},
                     "merge": {"has_permission": True},
+                    "branch_protection": {"has_permission": True},
                 },
                 # fetch PRs (both types with --include-human-prs)
                 [auto_pr, human_pr],
+                # preview merge phase (returns MergeResult list)
+                [],
             ]
         )
 
@@ -510,6 +577,7 @@ class TestMergeRepoUrl:
             ],
         )
 
+        assert result.exit_code == 0
         # Should show counts
         assert "Automation PRs:" in result.stdout
         assert "Human PRs:" in result.stdout
@@ -548,6 +616,7 @@ class TestMergeRepoUrl:
                 {
                     "approve": {"has_permission": True},
                     "merge": {"has_permission": True},
+                    "branch_protection": {"has_permission": True},
                 },
                 # fetch PRs
                 [auto_pr],
@@ -567,6 +636,7 @@ class TestMergeRepoUrl:
             ],
         )
 
+        assert result.exit_code == 0, f"CLI failed: {result.stdout}"
         assert "Final Results:" in result.stdout
 
 


### PR DESCRIPTION
## Summary

This PR adds repository-scoped bulk merge support, fixes critical token permission validation, and improves merge reliability. It includes 6 atomic commits covering one pre-existing feature, one new feature, and four bug fixes discovered during development and live testing.

---

## New Features

### Repository-scoped bulk merge (`8c36c3d`)

Adds support for merging all automation PRs in a single repository by providing a repository URL instead of a specific PR URL.

**Accepted URL formats:**
```
dependamerge merge --no-confirm https://github.com/owner/repo
dependamerge merge --no-confirm https://github.com/owner/repo/
dependamerge merge --no-confirm https://github.com/owner/repo/pulls
```

Previously, these URLs were rejected with "Invalid GitHub PR URL format". Now they trigger a new code path that:

1. Fetches all open PRs in the specified repository
2. Filters to automation PRs only (dependabot, renovate, pre-commit-ci, etc.)
3. Classifies and displays PRs as 🤖 Automation or 👤 Human
4. Approves and merges matching PRs in bulk using existing merge infrastructure

**`--include-human-prs` flag:** Optionally includes human-authored PRs. Confirmation is only prompted when human PRs are actually found in the results, not merely because the flag was provided.

No org-wide scanning is needed — the tool goes directly to the target repository.

**Changes:**
- `url_parser.py`: New `ParsedRepoUrl` dataclass and `parse_repo_url()` function
- `github_service.py`: New `fetch_repo_open_prs()` method on `GitHubService`
- `cli.py`: New `--include-human-prs` flag, `_handle_repo_merge()` flow, URL routing
- `tests/test_repo_merge.py`: 33 new tests covering URL parsing, CLI integration, routing, and confirmation

### Cache org settings and user login (`5edb513`)

Pre-existing feature commit: caches organisation-level settings and authenticated user login to eliminate redundant API calls during bulk operations.

---

## Bug Fixes

### Fix automation PR classification in repo mode (`a1ca060`)

**Problem:** All dependabot PRs were classified as "👤 Human" in repository mode output.

**Root cause:** The display classification used `GitHubClient.is_automation_author()` which requires exact matches like `dependabot[bot]`. However, the GraphQL API (used by the repo-mode fetch) returns authors without the `[bot]` suffix (e.g. `dependabot`).

**Fix:** Replaced with a local helper using `AUTOMATION_TOOLS` substring matching, consistent with `GitHubService.fetch_repo_open_prs()` and `GitHubService._is_automation_author()`.

Also refactored tests to use a `_mock_asyncio_run()` helper that properly closes coroutine objects passed to the mocked `asyncio.run`, eliminating `RuntimeWarning: coroutine was never awaited` warnings that leaked across test boundaries.

### Fix token permission checks for fine-grained PATs (`195abf7`)

**Problem:** Token permission pre-flight check reported "✅ Token has required permissions" even when the token was scoped to a different GitHub organisation, leading to bulk merge failures.

**Root cause:** The previous check used `GET /repos/{owner}/{repo}` and inspected `permissions.push`. For fine-grained PATs, GitHub returns the *user's* org-level permissions regardless of token scope, producing false positives.

**Fix:** Replaced with two reliable, side-effect-free checks:

| Check | Endpoint | Verifies |
|---|---|---|
| Collaborator permission | `GET /repos/{o}/{r}/collaborators/{user}/permission` | Repo access + write/admin role |
| Branch protection | `GET /repos/{o}/{r}/branches/{branch}/protection` | Administration: Read |

Empirically validated with three token configurations:
- Wrong org token → correctly blocked with actionable guidance
- Same org, no permissions → correctly blocked
- Correct token → all checks pass

**Note:** Workflows: Read+Write cannot be independently verified via pre-flight API probes — it is enforced by GitHub at merge time, and the existing `_parse_permission_error` handler already surfaces this clearly.

### Fix pre-commit.ci polling timeout (`d10b199`)

**Problem:** After issuing a `pre-commit.ci run` comment to retrigger a stuck job, the tool only waited 30 seconds before giving up and reporting the PR as unmergeable.

**Fix:** Increased `max_polls` from 6 to 60 (60 × 5s = 300s / 5 minutes), matching real-world pre-commit.ci execution times.

### Serialise repo-mode merges (`0e139aa`)

**Problem:** With concurrency=10 and all PRs targeting the same repository, multiple PRs were approved and merged simultaneously. GitHub's branch protection evaluator couldn't propagate approvals fast enough, causing ~40% of merges to fail with "branch protection" errors despite having a green merge button.

**Fix:** Reduced concurrency to 1 for repo-scoped merges, serialising approve→delay→merge for each PR. The org-wide merge flow retains concurrency=10 since PRs are spread across different repositories.

---

## Additional cleanup

- Fixed bare `dict` type annotations in `merge_manager.py` (basedpyright warnings)
- Updated `test_cli.py` for changed error message on invalid URLs
- All pre-commit hooks pass: ruff, ruff format, mypy, basedpyright, codespell, pytest
