### PR TITLE
Feat(merge): centralise merge timing and add auto-merge

### DIFF
--- a/src/dependamerge/cli.py
+++ b/src/dependamerge/cli.py
@@ -53,7 +53,11 @@ from .github_async import (
 )
 from .github_client import GitHubClient
 from .github_service import AUTOMATION_TOOLS
-from .merge_manager import AsyncMergeManager, MergeResult
+from .merge_manager import (
+    DEFAULT_MERGE_TIMEOUT,
+    AsyncMergeManager,
+    MergeResult,
+)
 from .models import ComparisonResult, PullRequestInfo
 from .netrc import (
     NetrcParseError,
@@ -854,14 +858,20 @@ def _execute_confirmed_merge(
     final_blocked = sum(
         1 for r in real_results if r.status.value == "blocked"
     )
-    console.print(
-        f"\n🚀 Final Results: {final_merged} merged, "
-        f"{final_failed} failed"
+    final_auto_merge = sum(
+        1 for r in real_results if r.status.value == "auto_merge_pending"
     )
+    parts = [f"{final_merged} merged"]
+    if final_auto_merge > 0:
+        parts.append(f"{final_auto_merge} auto-merge pending")
+    parts.append(f"{final_failed} failed")
+    console.print(f"\n🚀 Final Results: {', '.join(parts)}")
     if final_skipped > 0:
         console.print(f"⏭️  Skipped {final_skipped} PRs")
     if final_blocked > 0:
         console.print(f"🛑 Blocked {final_blocked} PRs")
+    if final_auto_merge > 0:
+        console.print(f"⏳ Auto-merge pending for {final_auto_merge} PRs")
 
 
 def _display_merge_results(
@@ -881,6 +891,9 @@ def _display_merge_results(
     blocked_count = sum(
         1 for r in merge_results if r.status.value == "blocked"
     )
+    auto_merge_count = sum(
+        1 for r in merge_results if r.status.value == "auto_merge_pending"
+    )
 
     if failed_count > 0:
         if not no_confirm:
@@ -893,12 +906,15 @@ def _display_merge_results(
         console.print(f"⏭️  Skipped {skipped_count} PRs")
     if blocked_count > 0:
         console.print(f"🛑 Blocked {blocked_count} PRs")
+    if auto_merge_count > 0:
+        console.print(f"⏳ Auto-merge pending for {auto_merge_count} PRs")
 
     if no_confirm:
-        console.print(
-            f"📈 Final Results: {merged_count} merged, "
-            f"{failed_count} failed"
-        )
+        parts = [f"{merged_count} merged"]
+        if auto_merge_count > 0:
+            parts.append(f"{auto_merge_count} auto-merge pending")
+        parts.append(f"{failed_count} failed")
+        console.print(f"📈 Final Results: {', '.join(parts)}")
 
 
 def _handle_repo_merge(
@@ -1215,14 +1231,20 @@ def _execute_repo_confirmed_merge(
     final_blocked = sum(
         1 for r in real_results if r.status.value == "blocked"
     )
-    console.print(
-        f"\n🚀 Final Results: {final_merged} merged, "
-        f"{final_failed} failed"
+    final_auto_merge = sum(
+        1 for r in real_results if r.status.value == "auto_merge_pending"
     )
+    parts = [f"{final_merged} merged"]
+    if final_auto_merge > 0:
+        parts.append(f"{final_auto_merge} auto-merge pending")
+    parts.append(f"{final_failed} failed")
+    console.print(f"\n🚀 Final Results: {', '.join(parts)}")
     if final_skipped > 0:
         console.print(f"⏭️  Skipped {final_skipped} PRs")
     if final_blocked > 0:
         console.print(f"🛑 Blocked {final_blocked} PRs")
+    if final_auto_merge > 0:
+        console.print(f"⏳ Auto-merge pending for {final_auto_merge} PRs")
 
 
 def _handle_gerrit_merge(
@@ -1461,9 +1483,13 @@ def merge(
         help="Do not attempt to automatically fix out-of-date branches",
     ),
     merge_timeout: float = typer.Option(
-        300.0,
+        DEFAULT_MERGE_TIMEOUT,
         "--merge-timeout",
-        help="Timeout in seconds for async merge operations (rebase, pre-commit.ci, recreate). Default: 300",
+        help=(
+            "Timeout in seconds for async merge operations (rebase, "
+            "pre-commit.ci, recreate). Default: "
+            f"{DEFAULT_MERGE_TIMEOUT:.0f}"
+        ),
     ),
     show_progress: bool = typer.Option(
         True, "--progress/--no-progress", help="Show real-time progress updates"

--- a/src/dependamerge/cli.py
+++ b/src/dependamerge/cli.py
@@ -319,6 +319,7 @@ class _MergeContext:
     token: str | None
     override: str | None
     no_fix: bool
+    merge_timeout: float
     show_progress: bool
     debug_matching: bool
     dismiss_copilot: bool
@@ -734,6 +735,7 @@ def _run_parallel_merge(
             max_retries=MAX_RETRIES,
             concurrency=concurrency,
             fix_out_of_date=not ctx.no_fix,
+            merge_timeout=ctx.merge_timeout,
             progress_tracker=ctx.progress_tracker,
             preview_mode=preview,
             dismiss_copilot=ctx.dismiss_copilot,
@@ -1458,6 +1460,11 @@ def merge(
         "--no-fix",
         help="Do not attempt to automatically fix out-of-date branches",
     ),
+    merge_timeout: float = typer.Option(
+        300.0,
+        "--merge-timeout",
+        help="Timeout in seconds for async merge operations (rebase, pre-commit.ci, recreate). Default: 300",
+    ),
     show_progress: bool = typer.Option(
         True, "--progress/--no-progress", help="Show real-time progress updates"
     ),
@@ -1655,6 +1662,7 @@ def merge(
             token=token,
             override=override,
             no_fix=no_fix,
+            merge_timeout=merge_timeout,
             show_progress=show_progress,
             debug_matching=debug_matching,
             dismiss_copilot=dismiss_copilot,
@@ -1720,6 +1728,7 @@ def merge(
         token=token,
         override=override,
         no_fix=no_fix,
+        merge_timeout=merge_timeout,
         show_progress=show_progress,
         debug_matching=debug_matching,
         dismiss_copilot=dismiss_copilot,

--- a/src/dependamerge/github_async.py
+++ b/src/dependamerge/github_async.py
@@ -817,6 +817,75 @@ class GitHubAsync:
                 else:
                     raise e from inner_e
 
+
+    async def enable_auto_merge(
+        self, pull_request_node_id: str, merge_method: str = "MERGE"
+    ) -> bool:
+        """
+        Enable auto-merge on a pull request via GraphQL.
+
+        Auto-merge will automatically merge the PR once all required
+        branch protection rules are satisfied.
+
+        Args:
+            pull_request_node_id: The GraphQL node ID of the pull request.
+            merge_method: Merge method - "MERGE", "SQUASH", or "REBASE".
+                Lowercase values ("merge", "squash", "rebase") are
+                automatically uppercased.
+
+        Returns:
+            True if auto-merge was successfully enabled, False otherwise.
+        """
+        from .github_graphql import ENABLE_AUTO_MERGE
+
+        # Normalise to the GraphQL enum (uppercase)
+        graphql_method = merge_method.upper()
+        if graphql_method not in ("MERGE", "SQUASH", "REBASE"):
+            self.log.warning(
+                "Invalid merge method for auto-merge: %s; defaulting to MERGE",
+                merge_method,
+            )
+            graphql_method = "MERGE"
+
+        try:
+            result = await self.graphql(
+                ENABLE_AUTO_MERGE,
+                {
+                    "pullRequestId": pull_request_node_id,
+                    "mergeMethod": graphql_method,
+                },
+            )
+            auto_merge_data = (
+                result.get("enablePullRequestAutoMerge", {})
+                .get("pullRequest", {})
+                .get("autoMergeRequest")
+            )
+            if auto_merge_data:
+                self.log.debug(
+                    "Auto-merge enabled for PR %s (method=%s, enabledAt=%s)",
+                    pull_request_node_id,
+                    auto_merge_data.get("mergeMethod"),
+                    auto_merge_data.get("enabledAt"),
+                )
+                return True
+            self.log.debug(
+                "Auto-merge response missing autoMergeRequest for PR %s",
+                pull_request_node_id,
+            )
+            return False
+        except Exception as e:
+            error_msg = str(e)
+            # Common reasons auto-merge can't be enabled:
+            # - Repository doesn't have auto-merge enabled in settings
+            # - PR has conflicts
+            # - Required status checks not configured
+            self.log.debug(
+                "Could not enable auto-merge for PR %s: %s",
+                pull_request_node_id,
+                error_msg,
+            )
+            return False
+
     async def get_pull_request_review_comments(
         self, owner: str, repo: str, number: int
     ) -> list[dict[str, Any]]:

--- a/src/dependamerge/github_client.py
+++ b/src/dependamerge/github_client.py
@@ -136,6 +136,7 @@ class GitHubClient:
 
                 return PullRequestInfo(
                     number=int(pr.get("number", pr_number)),
+                    node_id=pr.get("node_id"),  # REST API uses "node_id" key
                     title=pr.get("title") or "",
                     body=pr.get("body"),
                     author=((pr.get("user") or {}).get("login") or ""),

--- a/src/dependamerge/github_graphql.py
+++ b/src/dependamerge/github_graphql.py
@@ -18,6 +18,7 @@ __all__ = [
     "ORG_REPOS_ONLY",
     "ORG_REPOS_WITH_OPEN_PRS",
     "REPO_OPEN_PRS_PAGE",
+    "ENABLE_AUTO_MERGE",
     "GET_BRANCH_PROTECTION",
 ]
 
@@ -68,6 +69,7 @@ query($org: String!, $reposCursor: String) {
             endCursor
           }
           nodes {
+            id
             number
             title
             body
@@ -155,6 +157,7 @@ query($owner: String!, $name: String!, $prsCursor: String, $prsPageSize: Int!, $
         endCursor
       }
       nodes {
+        id
         number
         title
         body
@@ -297,6 +300,24 @@ mutation DismissPullRequestReview($reviewId: ID!, $message: String!) {
       id
       state
       author { login }
+    }
+  }
+}
+"""
+
+# GraphQL mutation to enable auto-merge on a pull request
+ENABLE_AUTO_MERGE = """
+mutation EnableAutoMerge($pullRequestId: ID!, $mergeMethod: PullRequestMergeMethod) {
+  enablePullRequestAutoMerge(input: {
+    pullRequestId: $pullRequestId
+    mergeMethod: $mergeMethod
+  }) {
+    pullRequest {
+      autoMergeRequest {
+        enabledAt
+        enabledBy { login }
+        mergeMethod
+      }
     }
   }
 }

--- a/src/dependamerge/github_service.py
+++ b/src/dependamerge/github_service.py
@@ -500,6 +500,7 @@ class GitHubService:
 
         return PullRequestInfo(
             number=int(pr.get("number", 0)),
+            node_id=pr.get("id"),  # GraphQL node ID for mutations
             title=pr.get("title") or "",
             body=(pr.get("body") or None),
             author=((pr.get("author") or {}).get("login") or "unknown"),

--- a/src/dependamerge/merge_manager.py
+++ b/src/dependamerge/merge_manager.py
@@ -40,6 +40,18 @@ from .netrc import NetrcParseError, resolve_gerrit_credentials
 from .output_utils import log_and_print
 from .progress_tracker import MergeProgressTracker
 
+# ---------------------------------------------------------------------------
+# Centralised timing constants for all async merge operations.
+#
+# Every polling loop in this module (post-rebase status checks,
+# pre-commit.ci re-runs, @dependabot recreate, recreated-PR readiness)
+# derives its iteration count from these two values so that the timeout
+# is consistent and easy to adjust from a single place or via the
+# ``--merge-timeout`` CLI flag.
+# ---------------------------------------------------------------------------
+DEFAULT_MERGE_TIMEOUT: float = 300.0  # seconds (5 minutes)
+DEFAULT_MERGE_RECHECK_INTERVAL: float = 10.0  # seconds between polls
+
 
 class MergeStatus(Enum):
     """Status of a PR merge operation."""
@@ -83,6 +95,7 @@ class AsyncMergeManager:
         max_retries: int = 2,
         concurrency: int = 5,
         fix_out_of_date: bool = False,
+        merge_timeout: float = DEFAULT_MERGE_TIMEOUT,
         progress_tracker: MergeProgressTracker | None = None,
         preview_mode: bool = False,
         dismiss_copilot: bool = False,
@@ -104,6 +117,19 @@ class AsyncMergeManager:
         self.no_netrc = no_netrc
         self.netrc_file = netrc_file
         self.log = logging.getLogger(__name__)
+
+        # Centralised merge-operation timing
+        # Coerce merge_timeout to float to guard against Typer OptionInfo
+        # objects that leak through when the CLI function is called directly
+        # (e.g. from tests) without the Typer argument parser.
+        try:
+            self._merge_timeout = float(merge_timeout)
+        except (TypeError, ValueError):
+            self._merge_timeout = DEFAULT_MERGE_TIMEOUT
+        self._merge_recheck_interval = DEFAULT_MERGE_RECHECK_INTERVAL
+        self._merge_poll_max_attempts = max(
+            1, int(self._merge_timeout / self._merge_recheck_interval)
+        )
 
         # Track merge operations
         self._merge_semaphore = asyncio.Semaphore(concurrency)
@@ -127,6 +153,10 @@ class AsyncMergeManager:
 
         # Track PRs that were just approved (for post-approval merge retry)
         self._recently_approved: set[str] = set()
+
+        # Track PRs where auto-merge has been enabled so that
+        # post-timeout merge attempts can be skipped gracefully.
+        self._auto_merge_enabled: set[str] = set()
 
         # Delay (seconds) after submitting a new approval before attempting merge.
         # GitHub needs time to propagate the approval to branch-protection evaluation.
@@ -906,65 +936,79 @@ class AsyncMergeManager:
                             repo_owner, repo_name, pr_info.number
                         )
 
+                        # Enable auto-merge so the PR merges even if we
+                        # time out waiting for status checks.
+                        auto_merge_ok = await self._enable_auto_merge_for_pr(
+                            pr_info, repo_owner, repo_name
+                        )
+                        if auto_merge_ok:
+                            self.log.debug(
+                                "Auto-merge enabled after rebase for %s/%s#%s",
+                                repo_owner,
+                                repo_name,
+                                pr_info.number,
+                            )
+
                         # Wait for GitHub to process the update and run checks
                         self._console.print(
                             "⏳ Waiting for checks to complete after rebase..."
                         )
-                        await asyncio.sleep(5.0)
+                        await asyncio.sleep(self._merge_recheck_interval)
 
                         # Re-check PR status after rebase with extended retry logic
-                        # Poll for status checks to complete after rebase (max 2 minutes)
                         # Initialize variables before the loop
                         updated_mergeable: bool | None = pr_info.mergeable
                         updated_mergeable_state: str | None = pr_info.mergeable_state
 
-                        # Wait up to 2 minutes for rebase to complete and PR state to stabilize
-                        for check_attempt in range(24):
+                        for check_attempt in range(self._merge_poll_max_attempts):
                             updated_pr_data = await self._github_client.get(
                                 f"/repos/{repo_owner}/{repo_name}/pulls/{pr_info.number}"
                             )
 
-                            # Extract mergeable state from API response
-                            # The GitHub PR API returns a dict, but we need to check type for MyPy
                             if isinstance(updated_pr_data, dict):
                                 updated_mergeable = updated_pr_data.get("mergeable")
                                 updated_mergeable_state = updated_pr_data.get(
                                     "mergeable_state"
                                 )
                             else:
-                                # This should not happen for a single PR request, but handle for type safety
                                 updated_mergeable = None
                                 updated_mergeable_state = None
 
-                            # Wait for status checks to complete - not just for "behind" to clear
                             if updated_mergeable_state == "clean":
-                                # Perfect - PR is ready to merge
                                 break
                             elif updated_mergeable_state == "behind":
-                                # Still processing rebase
-                                if check_attempt < 23:
+                                if check_attempt < self._merge_poll_max_attempts - 1:
                                     self.log.debug(
-                                        f"PR still processing rebase, waiting... (attempt {check_attempt + 1}/24)"
+                                        "PR still processing rebase, waiting... "
+                                        "(attempt %d/%d)",
+                                        check_attempt + 1,
+                                        self._merge_poll_max_attempts,
                                     )
-                                    await asyncio.sleep(5.0)
+                                    await asyncio.sleep(self._merge_recheck_interval)
                             elif updated_mergeable_state == "blocked":
-                                # Status checks are running - need to wait longer
-                                if check_attempt < 23:
+                                if check_attempt < self._merge_poll_max_attempts - 1:
                                     self.log.debug(
-                                        f"PR status checks running after rebase, waiting... (attempt {check_attempt + 1}/24)"
+                                        "PR status checks running after rebase, "
+                                        "waiting... (attempt %d/%d)",
+                                        check_attempt + 1,
+                                        self._merge_poll_max_attempts,
                                     )
-                                    await asyncio.sleep(5.0)
+                                    await asyncio.sleep(self._merge_recheck_interval)
                                 else:
-                                    # Timeout waiting for status checks
                                     self.log.warning(
-                                        f"Timeout waiting for status checks to complete for PR {pr_info.repository_full_name}#{pr_info.number}. Proceeding with merge attempt."
+                                        "Timeout waiting for status checks to "
+                                        "complete for PR %s#%s. %s",
+                                        pr_info.repository_full_name,
+                                        pr_info.number,
+                                        "Auto-merge is enabled."
+                                        if auto_merge_ok
+                                        else "Proceeding with merge attempt.",
                                     )
                                     break
                             else:
-                                # Other states (dirty, unstable, etc.) - exit early
                                 break
 
-                        # Update our PR info with the latest state (variables are guaranteed to be set by loop initialization)
+                        # Update our PR info with the latest state
                         pr_info.mergeable = updated_mergeable
                         pr_info.mergeable_state = updated_mergeable_state
 
@@ -1067,13 +1111,35 @@ class AsyncMergeManager:
                         f"Merging PR {pr_info.number} in {pr_info.repository_full_name}"
                     )
 
-                merged = await self._merge_pr_with_retry(pr_info, repo_owner, repo_name)
+                # If auto-merge is enabled and we timed out waiting
+                # for status checks, skip the manual merge attempt —
+                # GitHub will merge automatically when checks pass.
+                pr_key = f"{repo_owner}/{repo_name}#{pr_info.number}"
+                if (
+                    pr_key in self._auto_merge_enabled
+                    and pr_info.mergeable_state == "blocked"
+                ):
+                    merged = None  # Sentinel: auto-merge pending
+                else:
+                    merged = await self._merge_pr_with_retry(
+                        pr_info, repo_owner, repo_name
+                    )
 
-                if merged:
+                if merged is None:
+                    # Auto-merge is active — report success (async)
                     result.status = MergeStatus.MERGED
                     if self.progress_tracker:
                         self.progress_tracker.merge_success()
-                    # Single line summary for successful merge
+                    log_and_print(
+                        self.log,
+                        self._console,
+                        f"⏳ Auto-merge enabled: {pr_info.html_url} [waiting for checks]",
+                        level="debug",
+                    )
+                elif merged:
+                    result.status = MergeStatus.MERGED
+                    if self.progress_tracker:
+                        self.progress_tracker.merge_success()
                     log_and_print(
                         self.log,
                         self._console,
@@ -1288,6 +1354,59 @@ class AsyncMergeManager:
                 )
                 return True
         return False
+
+    async def _enable_auto_merge_for_pr(
+        self, pr_info: PullRequestInfo, owner: str, repo: str
+    ) -> bool:
+        """Enable auto-merge on a PR so it merges when checks pass.
+
+        This is a best-effort operation: if auto-merge is unavailable
+        (e.g. the repository hasn't enabled it, or the PR already has
+        auto-merge active) the failure is logged at debug level and
+        the caller falls through to manual polling/merge.
+
+        Args:
+            pr_info: Pull request information (must have ``node_id``).
+            owner: Repository owner.
+            repo: Repository name.
+
+        Returns:
+            True if auto-merge was successfully enabled, False otherwise.
+        """
+        if not self._github_client:
+            return False
+
+        if not pr_info.node_id:
+            self.log.debug(
+                "Cannot enable auto-merge for %s/%s#%s: missing node_id",
+                owner,
+                repo,
+                pr_info.number,
+            )
+            return False
+
+        pr_key = f"{owner}/{repo}#{pr_info.number}"
+
+        # Already enabled in this run — skip duplicate API call
+        if pr_key in self._auto_merge_enabled:
+            return True
+
+        cache_key = f"{owner}/{repo}"
+        merge_method = self._pr_merge_methods.get(
+            cache_key, self.default_merge_method
+        )
+
+        enabled = await self._github_client.enable_auto_merge(
+            pr_info.node_id, merge_method
+        )
+        if enabled:
+            self._auto_merge_enabled.add(pr_key)
+            self.log.debug(
+                "Auto-merge enabled for %s (method=%s)",
+                pr_key,
+                merge_method,
+            )
+        return enabled
 
     async def _check_merge_requirements(
         self, pr_info: PullRequestInfo
@@ -1558,9 +1677,9 @@ class AsyncMergeManager:
         # pre-commit.ci can take up to five minutes to run and report back,
         # so we need a generous timeout to avoid prematurely marking PRs as
         # unmergeable when the check simply hasn't finished yet.
-        max_polls = 60  # 60 × 5s = 300s
+        max_polls = self._merge_poll_max_attempts
         for attempt in range(max_polls):
-            await asyncio.sleep(5.0)
+            await asyncio.sleep(self._merge_recheck_interval)
             try:
                 status_data = await self._github_client.get(
                     f"/repos/{repo_owner}/{repo_name}/commits/{pr_info.head_sha}/status"
@@ -1600,7 +1719,7 @@ class AsyncMergeManager:
                 self.log.debug(
                     f"Still waiting for pre-commit.ci on "
                     f"{pr_info.repository_full_name}#{pr_info.number} "
-                    f"({(attempt + 1) * 5}s elapsed)"
+                    f"({(attempt + 1) * self._merge_recheck_interval:.0f}s elapsed)"
                 )
 
         self.log.warning(
@@ -1739,12 +1858,12 @@ class AsyncMergeManager:
 
         # 6. Poll for the old PR to close and a replacement to appear.
         #    Dependabot typically responds within 30-90 seconds.
-        #    We poll for up to ~3 minutes (36 × 5s = 180s).
-        max_polls = 36
+        #    We poll using the centralised merge timeout.
+        max_polls = self._merge_poll_max_attempts
         old_pr_closed = False
 
         for attempt in range(max_polls):
-            await asyncio.sleep(5.0)
+            await asyncio.sleep(self._merge_recheck_interval)
 
             # 6a. Check if the old PR has been closed
             if not old_pr_closed:
@@ -1759,7 +1878,7 @@ class AsyncMergeManager:
                                 self.log,
                                 self._console,
                                 f"✅ Old PR {pr_info.repository_full_name}#{pr_info.number} "
-                                f"closed by dependabot ({(attempt + 1) * 5}s elapsed)",
+                                f"closed by dependabot ({(attempt + 1) * self._merge_recheck_interval:.0f}s elapsed)",
                                 level="info",
                             )
                 except Exception as e:
@@ -1817,12 +1936,12 @@ class AsyncMergeManager:
                         e,
                     )
 
-            if attempt % 6 == 5:
+            if attempt % 3 == 2:
                 self.log.debug(
-                    "Still waiting for dependabot recreate on %s#%s (%ds elapsed, old_pr_closed=%s)",
+                    "Still waiting for dependabot recreate on %s#%s (%.0fs elapsed, old_pr_closed=%s)",
                     pr_info.repository_full_name,
                     pr_info.number,
-                    (attempt + 1) * 5,
+                    (attempt + 1) * self._merge_recheck_interval,
                     old_pr_closed,
                 )
 
@@ -1869,10 +1988,36 @@ class AsyncMergeManager:
             level="info",
         )
 
-        # Poll for the new PR to become mergeable (up to ~3 minutes)
-        max_check_polls = 36  # 36 × 5s = 180s
+        # Enable auto-merge on the recreated PR so it merges
+        # even if we time out waiting for status checks.
+        if pr_data.get("node_id"):
+            from .models import PullRequestInfo as _PRI  # noqa: PLC0415
+
+            # We don't have a full PullRequestInfo yet, but we can
+            # construct a minimal one for the auto-merge helper.
+            _tmp_pr = _PRI(
+                number=new_number,
+                node_id=pr_data.get("node_id"),
+                title=pr_data.get("title", ""),
+                body=pr_data.get("body"),
+                author=(pr_data.get("user", {}).get("login", "")),
+                head_sha=(pr_data.get("head", {}).get("sha", "")),
+                base_branch=(pr_data.get("base", {}).get("ref", "")),
+                head_branch=(pr_data.get("head", {}).get("ref", "")),
+                state="open",
+                mergeable=None,
+                mergeable_state=None,
+                behind_by=None,
+                files_changed=[],
+                repository_full_name=full_name,
+                html_url=html_url,
+            )
+            await self._enable_auto_merge_for_pr(_tmp_pr, repo_owner, repo_name)
+
+        # Poll for the new PR to become mergeable
+        max_check_polls = self._merge_poll_max_attempts
         for check_attempt in range(max_check_polls):
-            await asyncio.sleep(5.0)
+            await asyncio.sleep(self._merge_recheck_interval)
             try:
                 refreshed = await self._github_client.get(
                     f"/repos/{repo_owner}/{repo_name}/pulls/{new_number}"
@@ -1923,6 +2068,7 @@ class AsyncMergeManager:
 
                     return PullRequestInfo(
                         number=new_number,
+                        node_id=refreshed.get("node_id"),
                         title=refreshed.get("title", ""),
                         body=refreshed.get("body"),
                         author=(refreshed.get("user", {}).get("login", "")),
@@ -1947,14 +2093,14 @@ class AsyncMergeManager:
                     return None
 
                 # blocked / behind / unknown — keep polling
-                if check_attempt % 6 == 5:
+                if check_attempt % 3 == 2:
                     self.log.debug(
                         "Waiting for checks on recreated PR %s#%s "
-                        "(state=%s, %ds elapsed)",
+                        "(state=%s, %.0fs elapsed)",
                         full_name,
                         new_number,
                         mergeable_state,
-                        (check_attempt + 1) * 5,
+                        (check_attempt + 1) * self._merge_recheck_interval,
                     )
 
             except Exception as e:
@@ -2472,7 +2618,7 @@ class AsyncMergeManager:
                 )
                 await self._github_client.update_branch(owner, repo, pr_info.number)
                 # Wait a moment for GitHub to process the update
-                await asyncio.sleep(2.0)
+                await asyncio.sleep(self._merge_recheck_interval)
                 return True
             except Exception as e:
                 self.log.error(

--- a/src/dependamerge/merge_manager.py
+++ b/src/dependamerge/merge_manager.py
@@ -61,6 +61,7 @@ class MergeStatus(Enum):
     APPROVED = "approved"
     MERGING = "merging"
     MERGED = "merged"
+    AUTO_MERGE_PENDING = "auto_merge_pending"
     FAILED = "failed"
     SKIPPED = "skipped"
     BLOCKED = "blocked"
@@ -119,16 +120,34 @@ class AsyncMergeManager:
         self.log = logging.getLogger(__name__)
 
         # Centralised merge-operation timing
-        # Coerce merge_timeout to float to guard against Typer OptionInfo
-        # objects that leak through when the CLI function is called directly
-        # (e.g. from tests) without the Typer argument parser.
+        # Coerce merge_timeout to float and validate, guarding against Typer
+        # OptionInfo objects that leak through when the CLI function is called
+        # directly (e.g. from tests) without the Typer argument parser.
         try:
-            self._merge_timeout = float(merge_timeout)
+            _mt = float(merge_timeout)
+            if not math.isfinite(_mt) or _mt <= 0:
+                raise ValueError(f"out of range: {_mt}")
+            self._merge_timeout = _mt
         except (TypeError, ValueError):
+            self.log.warning(
+                "Invalid merge_timeout=%r; falling back to default of %.0f seconds",
+                merge_timeout,
+                DEFAULT_MERGE_TIMEOUT,
+            )
             self._merge_timeout = DEFAULT_MERGE_TIMEOUT
-        self._merge_recheck_interval = DEFAULT_MERGE_RECHECK_INTERVAL
+        # Clamp the per-iteration sleep so a small ``merge_timeout``
+        # (< DEFAULT_MERGE_RECHECK_INTERVAL) does not over-sleep and
+        # blow past the user-specified total timeout. For typical
+        # values (>= 10s), this is a no-op and keeps the default
+        # 10s polling cadence.
+        self._merge_recheck_interval = min(
+            DEFAULT_MERGE_RECHECK_INTERVAL, self._merge_timeout
+        )
+        # Use math.ceil so the effective poll window is at least
+        # the configured ``merge_timeout`` — plain ``int()`` would
+        # truncate (e.g. 301/10 -> 30 attempts -> only 300s).
         self._merge_poll_max_attempts = max(
-            1, int(self._merge_timeout / self._merge_recheck_interval)
+            1, math.ceil(self._merge_timeout / self._merge_recheck_interval)
         )
 
         # Track merge operations
@@ -282,11 +301,18 @@ class AsyncMergeManager:
             # merge_success() and merge_failure() already increment
             # completed_prs for MERGED/FAILED outcomes.  Catch the
             # remaining terminal states here so PR-level progress
-            # reaches 100% even when some PRs are blocked or skipped.
+            # reaches 100% even when some PRs are blocked, skipped,
+            # or have auto-merge pending (where neither merge_success
+            # nor merge_failure is called because the merge hasn't
+            # actually happened yet — GitHub will merge it later).
             if (
                 self.progress_tracker
                 and result.status
-                in (MergeStatus.BLOCKED, MergeStatus.SKIPPED)
+                in (
+                    MergeStatus.BLOCKED,
+                    MergeStatus.SKIPPED,
+                    MergeStatus.AUTO_MERGE_PENDING,
+                )
             ):
                 self.progress_tracker.pr_completed()
             return result
@@ -1111,14 +1137,65 @@ class AsyncMergeManager:
                         f"Merging PR {pr_info.number} in {pr_info.repository_full_name}"
                     )
 
-                # If auto-merge is enabled and we timed out waiting
-                # for status checks, skip the manual merge attempt —
-                # GitHub will merge automatically when checks pass.
+                # If auto-merge is enabled and the PR is blocked
+                # *specifically* by pending required checks, skip
+                # the manual merge attempt — GitHub will merge
+                # automatically once those checks complete.
+                #
+                # The ``mergeable_state == "blocked"`` +
+                # ``mergeable is True`` combination is necessary
+                # but not sufficient: the same combination also
+                # applies when the block reason is "requires
+                # approval" or similar branch-protection rules
+                # that auto-merge cannot satisfy on its own.
+                # Consult ``analyze_block_reason()`` so we only
+                # skip when the reason mentions pending required
+                # checks.
+                #
+                # Do NOT skip when:
+                #   * mergeable is False (blocked by failing
+                #     checks) — the user may want a forced
+                #     manual attempt to surface the failure.
+                #   * force_level == "all" — force semantics
+                #     intentionally proceed despite blocked
+                #     state and must not be overridden by
+                #     auto-merge.
+                #   * the block reason is something other than
+                #     pending required checks (for example,
+                #     missing approvals or other branch
+                #     protection requirements).
                 pr_key = f"{repo_owner}/{repo_name}#{pr_info.number}"
+                auto_merge_pending_checks = False
                 if (
                     pr_key in self._auto_merge_enabled
                     and pr_info.mergeable_state == "blocked"
+                    and pr_info.mergeable is True
+                    and self.force_level != "all"
                 ):
+                    block_reason: str | None = None
+                    if self._github_client is not None:
+                        try:
+                            block_reason = (
+                                await self._github_client.analyze_block_reason(
+                                    repo_owner,
+                                    repo_name,
+                                    pr_info.number,
+                                    pr_info.head_sha,
+                                )
+                            )
+                        except Exception as exc:
+                            self.log.debug(
+                                "analyze_block_reason failed for %s: %s",
+                                pr_key,
+                                exc,
+                            )
+                    auto_merge_pending_checks = (
+                        block_reason is not None
+                        and "pending required check"
+                        in block_reason.lower()
+                    )
+
+                if auto_merge_pending_checks:
                     merged = None  # Sentinel: auto-merge pending
                 else:
                     merged = await self._merge_pr_with_retry(
@@ -1126,10 +1203,8 @@ class AsyncMergeManager:
                     )
 
                 if merged is None:
-                    # Auto-merge is active — report success (async)
-                    result.status = MergeStatus.MERGED
-                    if self.progress_tracker:
-                        self.progress_tracker.merge_success()
+                    # Auto-merge is active — PR will merge asynchronously
+                    result.status = MergeStatus.AUTO_MERGE_PENDING
                     log_and_print(
                         self.log,
                         self._console,
@@ -1962,7 +2037,10 @@ class AsyncMergeManager:
         """
         Wait for the recreated PR's status checks to complete.
 
-        Polls up to ~3 minutes for the new PR to reach a mergeable state.
+        Polls the new PR using the shared merge timeout settings. The
+        total wait here is controlled by ``self._merge_poll_max_attempts
+        * self._merge_recheck_interval`` (default: ~5 minutes), so
+        ``--merge-timeout`` also affects this loop.
 
         Args:
             repo_owner: Repository owner.
@@ -1991,19 +2069,17 @@ class AsyncMergeManager:
         # Enable auto-merge on the recreated PR so it merges
         # even if we time out waiting for status checks.
         if pr_data.get("node_id"):
-            from .models import PullRequestInfo as _PRI  # noqa: PLC0415
-
             # We don't have a full PullRequestInfo yet, but we can
             # construct a minimal one for the auto-merge helper.
-            _tmp_pr = _PRI(
+            _tmp_pr = PullRequestInfo(
                 number=new_number,
                 node_id=pr_data.get("node_id"),
                 title=pr_data.get("title", ""),
                 body=pr_data.get("body"),
-                author=(pr_data.get("user", {}).get("login", "")),
-                head_sha=(pr_data.get("head", {}).get("sha", "")),
-                base_branch=(pr_data.get("base", {}).get("ref", "")),
-                head_branch=(pr_data.get("head", {}).get("ref", "")),
+                author=((pr_data.get("user") or {}).get("login", "")),
+                head_sha=((pr_data.get("head") or {}).get("sha", "")),
+                base_branch=((pr_data.get("base") or {}).get("ref", "")),
+                head_branch=((pr_data.get("head") or {}).get("ref", "")),
                 state="open",
                 mergeable=None,
                 mergeable_state=None,
@@ -2071,10 +2147,10 @@ class AsyncMergeManager:
                         node_id=refreshed.get("node_id"),
                         title=refreshed.get("title", ""),
                         body=refreshed.get("body"),
-                        author=(refreshed.get("user", {}).get("login", "")),
-                        head_sha=(refreshed.get("head", {}).get("sha", "")),
-                        base_branch=(refreshed.get("base", {}).get("ref", "")),
-                        head_branch=(refreshed.get("head", {}).get("ref", "")),
+                        author=((refreshed.get("user") or {}).get("login", "")),
+                        head_sha=((refreshed.get("head") or {}).get("sha", "")),
+                        base_branch=((refreshed.get("base") or {}).get("ref", "")),
+                        head_branch=((refreshed.get("head") or {}).get("ref", "")),
                         state=refreshed.get("state", "open"),
                         mergeable=mergeable,
                         mergeable_state=mergeable_state,
@@ -2618,7 +2694,7 @@ class AsyncMergeManager:
                 )
                 await self._github_client.update_branch(owner, repo, pr_info.number)
                 # Wait a moment for GitHub to process the update
-                await asyncio.sleep(self._merge_recheck_interval)
+                await asyncio.sleep(min(2.0, self._merge_recheck_interval))
                 return True
             except Exception as e:
                 self.log.error(
@@ -2863,6 +2939,7 @@ class AsyncMergeManager:
             return {
                 "total": 0,
                 "merged": 0,
+                "auto_merge_pending": 0,
                 "failed": 0,
                 "skipped": 0,
                 "success_rate": 0.0,
@@ -2871,6 +2948,9 @@ class AsyncMergeManager:
 
         total = len(self._results)
         merged = sum(1 for r in self._results if r.status == MergeStatus.MERGED)
+        auto_merge_pending = sum(
+            1 for r in self._results if r.status == MergeStatus.AUTO_MERGE_PENDING
+        )
         failed = sum(1 for r in self._results if r.status == MergeStatus.FAILED)
         skipped = sum(1 for r in self._results if r.status == MergeStatus.SKIPPED)
 
@@ -2882,6 +2962,7 @@ class AsyncMergeManager:
         return {
             "total": total,
             "merged": merged,
+            "auto_merge_pending": auto_merge_pending,
             "failed": failed,
             "skipped": skipped,
             "success_rate": success_rate,
@@ -2900,9 +2981,19 @@ class AsyncMergeManager:
 
     def get_successful_prs(self) -> list[MergeResult]:
         """
-        Get list of successful merge results.
+        Get list of successful or auto-merge-pending results.
+
+        "Successful" here covers both PRs that were merged directly
+        (``MergeStatus.MERGED``) and PRs where GitHub auto-merge was
+        enabled and the PR is expected to merge once all required
+        checks pass (``MergeStatus.AUTO_MERGE_PENDING``).
 
         Returns:
             List of MergeResult objects that were merged successfully
+            or have auto-merge pending.
         """
-        return [r for r in self._results if r.status == MergeStatus.MERGED]
+        return [
+            r
+            for r in self._results
+            if r.status in (MergeStatus.MERGED, MergeStatus.AUTO_MERGE_PENDING)
+        ]

--- a/src/dependamerge/models.py
+++ b/src/dependamerge/models.py
@@ -49,6 +49,7 @@ class PullRequestInfo(BaseModel):
     """Represents pull request information."""
 
     number: int
+    node_id: str | None = None
     title: str
     body: str | None
     author: str

--- a/tests/test_auto_merge.py
+++ b/tests/test_auto_merge.py
@@ -1,0 +1,761 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2025 The Linux Foundation
+
+"""
+Unit tests for auto-merge functionality in AsyncMergeManager.
+
+Covers:
+- Enabling auto-merge via GraphQL (success, missing node_id, idempotent,
+  graceful failure).
+- Merge-flow behaviour when auto-merge is active (blocked vs clean).
+- Centralised timing defaults and custom merge-timeout computation.
+- Invalid merge-timeout fallback to the default.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from dependamerge.github2gerrit_detector import GitHub2GerritDetectionResult
+from dependamerge.merge_manager import MergeStatus
+from dependamerge.models import PullRequestInfo
+from tests.conftest import make_merge_manager
+
+# ---------------------------------------------------------------------------
+# Module-level default PullRequestInfo instance
+# ---------------------------------------------------------------------------
+
+_DEFAULT_PR = PullRequestInfo(
+    number=42,
+    node_id="PR_kwDOTestNode42",
+    title="Bump foo from 1.0 to 2.0",
+    body="Dependabot PR",
+    author="dependabot[bot]",
+    head_sha="abc123def456",
+    base_branch="main",
+    head_branch="dependabot/pip/foo-2.0",
+    state="open",
+    mergeable=True,
+    mergeable_state="blocked",
+    behind_by=0,
+    files_changed=[],
+    repository_full_name="owner/repo",
+    html_url="https://github.com/owner/repo/pull/42",
+    reviews=[],
+    review_comments=[],
+)
+
+
+# ---------------------------------------------------------------------------
+# 1. _enable_auto_merge_for_pr - success path
+# ---------------------------------------------------------------------------
+
+
+class TestEnableAutoMergeSuccess:
+    """Verify that _enable_auto_merge_for_pr enables auto-merge."""
+
+    @pytest.mark.asyncio
+    async def test_enable_auto_merge_success(self) -> None:
+        """Enable auto-merge returns True and tracks the PR key."""
+        mgr, client = make_merge_manager()
+        pr = _DEFAULT_PR.model_copy()
+
+        client.enable_auto_merge = AsyncMock(return_value=True)
+
+        result = await mgr._enable_auto_merge_for_pr(pr, "owner", "repo")
+
+        assert result is True
+        assert "owner/repo#42" in mgr._auto_merge_enabled
+        client.enable_auto_merge.assert_called_once_with("PR_kwDOTestNode42", "merge")
+
+
+# ---------------------------------------------------------------------------
+# 2. _enable_auto_merge_for_pr - missing node_id
+# ---------------------------------------------------------------------------
+
+
+class TestEnableAutoMergeNoNodeId:
+    """When node_id is None, auto-merge cannot be enabled."""
+
+    @pytest.mark.asyncio
+    async def test_enable_auto_merge_no_node_id(self) -> None:
+        """Return False when the PR has no node_id."""
+        mgr, client = make_merge_manager()
+        pr = _DEFAULT_PR.model_copy(update={"node_id": None})
+
+        result = await mgr._enable_auto_merge_for_pr(pr, "owner", "repo")
+
+        assert result is False
+        assert len(mgr._auto_merge_enabled) == 0
+
+
+# ---------------------------------------------------------------------------
+# 3. _enable_auto_merge_for_pr - idempotent
+# ---------------------------------------------------------------------------
+
+
+class TestEnableAutoMergeIdempotent:
+    """Calling enable twice should only hit the API once."""
+
+    @pytest.mark.asyncio
+    async def test_enable_auto_merge_idempotent(self) -> None:
+        """Second call returns True without calling the API again."""
+        mgr, client = make_merge_manager()
+        pr = _DEFAULT_PR.model_copy()
+
+        # Pre-populate the tracking set
+        mgr._auto_merge_enabled.add("owner/repo#42")
+
+        client.enable_auto_merge = AsyncMock(return_value=True)
+
+        result = await mgr._enable_auto_merge_for_pr(pr, "owner", "repo")
+
+        assert result is True
+        client.enable_auto_merge.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# 4. _enable_auto_merge_for_pr - GraphQL failure
+# ---------------------------------------------------------------------------
+
+
+class TestEnableAutoMergeFailureGraceful:
+    """When the GraphQL call fails, return False without raising."""
+
+    @pytest.mark.asyncio
+    async def test_enable_auto_merge_failure_graceful(self) -> None:
+        """Return False and do not track the PR when enable fails."""
+        mgr, client = make_merge_manager()
+        pr = _DEFAULT_PR.model_copy()
+
+        client.enable_auto_merge = AsyncMock(return_value=False)
+
+        result = await mgr._enable_auto_merge_for_pr(pr, "owner", "repo")
+
+        assert result is False
+        assert "owner/repo#42" not in mgr._auto_merge_enabled
+
+
+# ---------------------------------------------------------------------------
+# 5. Merge skipped when auto-merge active and blocked
+# ---------------------------------------------------------------------------
+
+
+class TestMergeSkippedWhenAutoMergeActiveAndBlocked:
+    """When auto-merge is enabled and PR is blocked, skip manual merge."""
+
+    @pytest.mark.asyncio
+    async def test_merge_skipped_when_auto_merge_active_and_blocked(
+        self,
+    ) -> None:
+        """Auto-merge pending: _merge_pr_with_retry is NOT called."""
+        mgr, client = make_merge_manager(preview_mode=False)
+        pr = _DEFAULT_PR.model_copy(
+            update={
+                "mergeable_state": "blocked",
+                "mergeable": True,
+                "state": "open",
+            }
+        )
+
+        # Pre-populate auto-merge tracking
+        mgr._auto_merge_enabled.add("owner/repo#42")
+
+        # Stub GitHub client methods used during the flow
+        client.get = AsyncMock(return_value={})
+        client.get_required_status_checks = AsyncMock(return_value=[])
+        # The skip gate consults analyze_block_reason; return a reason
+        # that indicates pending required checks so the skip fires.
+        client.analyze_block_reason = AsyncMock(
+            return_value="Blocked by pending required check: pre-commit.ci"
+        )
+
+        # Patch the manager methods that _merge_single_pr calls
+        # before reaching the auto-merge gate.
+        no_g2g = GitHub2GerritDetectionResult()
+        with (
+            patch.object(
+                mgr,
+                "_detect_github2gerrit",
+                new_callable=AsyncMock,
+                return_value=no_g2g,
+            ),
+            patch.object(
+                mgr,
+                "_get_merge_method_for_repo",
+                new_callable=AsyncMock,
+                return_value="merge",
+            ),
+            patch.object(
+                mgr,
+                "_trigger_stale_precommit_ci",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+            patch.object(
+                mgr,
+                "_check_merge_requirements",
+                new_callable=AsyncMock,
+                return_value=(True, ""),
+            ),
+            patch.object(
+                mgr,
+                "_approve_pr",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
+            patch.object(
+                mgr,
+                "_merge_pr_with_retry",
+                new_callable=AsyncMock,
+                return_value=True,
+            ) as mock_merge_retry,
+        ):
+            result = await mgr._merge_single_pr(pr)
+
+        assert result.status == MergeStatus.AUTO_MERGE_PENDING
+        mock_merge_retry.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# 6. Merge proceeds when auto-merge active and state is clean
+# ---------------------------------------------------------------------------
+
+
+class TestMergeProceedsWhenAutoMergeActiveAndClean:
+    """When auto-merge is active but PR is clean, merge proceeds."""
+
+    @pytest.mark.asyncio
+    async def test_merge_proceeds_when_auto_merge_active_and_clean(
+        self,
+    ) -> None:
+        """Manual merge still happens when mergeable_state is clean."""
+        mgr, client = make_merge_manager(preview_mode=False)
+        pr = _DEFAULT_PR.model_copy(
+            update={
+                "mergeable_state": "clean",
+                "mergeable": True,
+                "state": "open",
+            }
+        )
+
+        # Pre-populate auto-merge tracking
+        mgr._auto_merge_enabled.add("owner/repo#42")
+
+        client.get = AsyncMock(return_value={})
+        client.get_required_status_checks = AsyncMock(return_value=[])
+
+        no_g2g = GitHub2GerritDetectionResult()
+        with (
+            patch.object(
+                mgr,
+                "_detect_github2gerrit",
+                new_callable=AsyncMock,
+                return_value=no_g2g,
+            ),
+            patch.object(
+                mgr,
+                "_get_merge_method_for_repo",
+                new_callable=AsyncMock,
+                return_value="merge",
+            ),
+            patch.object(
+                mgr,
+                "_trigger_stale_precommit_ci",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+            patch.object(
+                mgr,
+                "_check_merge_requirements",
+                new_callable=AsyncMock,
+                return_value=(True, ""),
+            ),
+            patch.object(
+                mgr,
+                "_approve_pr",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
+            patch.object(
+                mgr,
+                "_merge_pr_with_retry",
+                new_callable=AsyncMock,
+                return_value=True,
+            ) as mock_merge_retry,
+        ):
+            result = await mgr._merge_single_pr(pr)
+
+        assert result.status == MergeStatus.MERGED
+        mock_merge_retry.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# 7. Centralised timing - defaults
+# ---------------------------------------------------------------------------
+
+
+class TestCentralisedTimingDefaults:
+    """Verify timing constants are correctly computed from defaults."""
+
+    def test_centralised_timing_defaults(self) -> None:
+        """Default timeout, recheck interval, and poll max are correct."""
+        mgr, _client = make_merge_manager()
+
+        assert mgr._merge_timeout == 300.0
+        assert mgr._merge_recheck_interval == 10.0
+        assert mgr._merge_poll_max_attempts == 30
+
+
+# ---------------------------------------------------------------------------
+# 8. Custom merge timeout
+# ---------------------------------------------------------------------------
+
+
+class TestCustomMergeTimeout:
+    """Verify a custom merge_timeout correctly computes poll max."""
+
+    def test_custom_merge_timeout(self) -> None:
+        """600s timeout with 10s interval yields 60 poll attempts."""
+        mgr, _client = make_merge_manager(merge_timeout=600.0)
+
+        assert mgr._merge_timeout == 600.0
+        assert mgr._merge_poll_max_attempts == 60
+
+
+# ---------------------------------------------------------------------------
+# 9. Invalid merge-timeout fallback
+# ---------------------------------------------------------------------------
+
+
+class TestInvalidMergeTimeoutFallback:
+    """Invalid merge_timeout values must fall back to the default."""
+
+    def test_negative_merge_timeout_fallback(self) -> None:
+        """Negative timeout falls back to 300.0."""
+        mgr, _client = make_merge_manager(merge_timeout=-1.0)
+
+        assert mgr._merge_timeout == 300.0
+
+    def test_inf_merge_timeout_fallback(self) -> None:
+        """Infinity falls back to 300.0."""
+        mgr, _client = make_merge_manager(merge_timeout=float("inf"))
+
+        assert mgr._merge_timeout == 300.0
+
+    def test_nan_merge_timeout_fallback(self) -> None:
+        """NaN falls back to 300.0."""
+        mgr, _client = make_merge_manager(merge_timeout=float("nan"))
+
+        assert mgr._merge_timeout == 300.0
+
+
+# ---------------------------------------------------------------------------
+# 10. Auto-merge skip gate: do NOT skip when mergeable is False
+# ---------------------------------------------------------------------------
+
+
+class TestAutoMergeSkipGateMergeableFalse:
+    """Blocked + mergeable=False (failing checks) must NOT skip manual merge."""
+
+    @pytest.mark.asyncio
+    async def test_manual_merge_runs_when_blocked_by_failing_checks(
+        self,
+    ) -> None:
+        """Failing checks: auto-merge gate must not override; retry is called."""
+        mgr, client = make_merge_manager(preview_mode=False)
+        pr = _DEFAULT_PR.model_copy(
+            update={
+                "mergeable_state": "blocked",
+                "mergeable": False,
+                "state": "open",
+            }
+        )
+
+        mgr._auto_merge_enabled.add("owner/repo#42")
+
+        client.get = AsyncMock(return_value={})
+        client.get_required_status_checks = AsyncMock(return_value=[])
+
+        no_g2g = GitHub2GerritDetectionResult()
+        with (
+            patch.object(
+                mgr,
+                "_detect_github2gerrit",
+                new_callable=AsyncMock,
+                return_value=no_g2g,
+            ),
+            patch.object(
+                mgr,
+                "_get_merge_method_for_repo",
+                new_callable=AsyncMock,
+                return_value="merge",
+            ),
+            patch.object(
+                mgr,
+                "_trigger_stale_precommit_ci",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+            patch.object(
+                mgr,
+                "_check_merge_requirements",
+                new_callable=AsyncMock,
+                return_value=(True, ""),
+            ),
+            patch.object(
+                mgr,
+                "_approve_pr",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
+            patch.object(
+                mgr,
+                "_merge_pr_with_retry",
+                new_callable=AsyncMock,
+                return_value=True,
+            ) as mock_merge_retry,
+        ):
+            result = await mgr._merge_single_pr(pr)
+
+        assert result.status == MergeStatus.MERGED
+        mock_merge_retry.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# 11. Auto-merge skip gate: force=all must proceed with manual merge
+# ---------------------------------------------------------------------------
+
+
+class TestAutoMergeSkipGateForceAll:
+    """--force=all must proceed with manual merge even with auto-merge active."""
+
+    @pytest.mark.asyncio
+    async def test_manual_merge_runs_with_force_all(self) -> None:
+        """force_level='all': auto-merge gate must not override."""
+        mgr, client = make_merge_manager(preview_mode=False, force_level="all")
+        pr = _DEFAULT_PR.model_copy(
+            update={
+                "mergeable_state": "blocked",
+                "mergeable": True,
+                "state": "open",
+            }
+        )
+
+        mgr._auto_merge_enabled.add("owner/repo#42")
+
+        client.get = AsyncMock(return_value={})
+        client.get_required_status_checks = AsyncMock(return_value=[])
+
+        no_g2g = GitHub2GerritDetectionResult()
+        with (
+            patch.object(
+                mgr,
+                "_detect_github2gerrit",
+                new_callable=AsyncMock,
+                return_value=no_g2g,
+            ),
+            patch.object(
+                mgr,
+                "_get_merge_method_for_repo",
+                new_callable=AsyncMock,
+                return_value="merge",
+            ),
+            patch.object(
+                mgr,
+                "_trigger_stale_precommit_ci",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+            patch.object(
+                mgr,
+                "_check_merge_requirements",
+                new_callable=AsyncMock,
+                return_value=(True, ""),
+            ),
+            patch.object(
+                mgr,
+                "_approve_pr",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
+            patch.object(
+                mgr,
+                "_merge_pr_with_retry",
+                new_callable=AsyncMock,
+                return_value=True,
+            ) as mock_merge_retry,
+        ):
+            result = await mgr._merge_single_pr(pr)
+
+        assert result.status == MergeStatus.MERGED
+        mock_merge_retry.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# 12. Poll-max ceiling: non-multiple timeouts round up, not down
+# ---------------------------------------------------------------------------
+
+
+class TestMergePollMaxAttemptsCeiling:
+    """Non-multiple merge_timeout must round UP via math.ceil, not truncate."""
+
+    def test_poll_max_rounds_up_for_non_multiple_timeout(self) -> None:
+        """301s/10s must yield 31 attempts (not 30 via truncation)."""
+        mgr, _client = make_merge_manager(merge_timeout=301.0)
+
+        assert mgr._merge_timeout == 301.0
+        assert mgr._merge_poll_max_attempts == 31
+
+    def test_poll_max_exact_multiple_unchanged(self) -> None:
+        """Exact multiple (300s/10s) still yields 30 attempts."""
+        mgr, _client = make_merge_manager(merge_timeout=300.0)
+
+        assert mgr._merge_poll_max_attempts == 30
+
+
+# ---------------------------------------------------------------------------
+# 13. Recheck-interval clamping for small merge_timeout values
+# ---------------------------------------------------------------------------
+
+
+class TestRecheckIntervalClamping:
+    """merge_timeout < default interval must clamp the per-iteration sleep."""
+
+    def test_recheck_interval_clamped_for_small_timeout(self) -> None:
+        """merge_timeout=3s clamps interval to 3s so loops don't oversleep."""
+        mgr, _client = make_merge_manager(merge_timeout=3.0)
+
+        assert mgr._merge_timeout == 3.0
+        assert mgr._merge_recheck_interval == 3.0
+        # ceil(3/3) = 1 attempt — total wait still equals merge_timeout
+        assert mgr._merge_poll_max_attempts == 1
+
+    def test_recheck_interval_unchanged_for_large_timeout(self) -> None:
+        """merge_timeout >= default interval keeps the default 10s cadence."""
+        mgr, _client = make_merge_manager(merge_timeout=600.0)
+
+        assert mgr._merge_recheck_interval == 10.0
+        assert mgr._merge_poll_max_attempts == 60
+
+
+# ---------------------------------------------------------------------------
+# 14. AUTO_MERGE_PENDING triggers progress tracker pr_completed()
+# ---------------------------------------------------------------------------
+
+
+class TestAutoMergePendingCompletesProgress:
+    """AUTO_MERGE_PENDING status must bump PR-level progress to completed."""
+
+    @pytest.mark.asyncio
+    async def test_auto_merge_pending_calls_pr_completed(self) -> None:
+        """pr_completed() is called so PR progress reaches 100%."""
+        tracker = MagicMock()
+        mgr, client = make_merge_manager(preview_mode=False, progress_tracker=tracker)
+        pr = _DEFAULT_PR.model_copy(
+            update={
+                "mergeable_state": "blocked",
+                "mergeable": True,
+                "state": "open",
+            }
+        )
+
+        mgr._auto_merge_enabled.add("owner/repo#42")
+
+        client.get = AsyncMock(return_value={})
+        client.get_required_status_checks = AsyncMock(return_value=[])
+        # The skip gate consults analyze_block_reason; return a reason
+        # that indicates pending required checks so the skip fires.
+        client.analyze_block_reason = AsyncMock(
+            return_value="Blocked by pending required check: pre-commit.ci"
+        )
+
+        no_g2g = GitHub2GerritDetectionResult()
+        with (
+            patch.object(
+                mgr,
+                "_detect_github2gerrit",
+                new_callable=AsyncMock,
+                return_value=no_g2g,
+            ),
+            patch.object(
+                mgr,
+                "_get_merge_method_for_repo",
+                new_callable=AsyncMock,
+                return_value="merge",
+            ),
+            patch.object(
+                mgr,
+                "_trigger_stale_precommit_ci",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+            patch.object(
+                mgr,
+                "_check_merge_requirements",
+                new_callable=AsyncMock,
+                return_value=(True, ""),
+            ),
+            patch.object(
+                mgr,
+                "_approve_pr",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
+            patch.object(
+                mgr,
+                "_merge_pr_with_retry",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
+        ):
+            result = await mgr._merge_single_pr_with_semaphore(pr)
+
+        assert result.status == MergeStatus.AUTO_MERGE_PENDING
+        tracker.pr_completed.assert_called_once()
+        tracker.merge_success.assert_not_called()
+        tracker.merge_failure.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# 15. Auto-merge skip gate: only skip on pending required checks
+# ---------------------------------------------------------------------------
+
+
+class TestAutoMergeSkipGateBlockReason:
+    """Skip gate must consult analyze_block_reason and only skip on pending checks."""
+
+    @pytest.mark.asyncio
+    async def test_manual_merge_runs_when_blocked_by_missing_approvals(
+        self,
+    ) -> None:
+        """Block reason = 'requires approval': manual merge must still run."""
+        mgr, client = make_merge_manager(preview_mode=False)
+        pr = _DEFAULT_PR.model_copy(
+            update={
+                "mergeable_state": "blocked",
+                "mergeable": True,
+                "state": "open",
+            }
+        )
+
+        mgr._auto_merge_enabled.add("owner/repo#42")
+
+        client.get = AsyncMock(return_value={})
+        client.get_required_status_checks = AsyncMock(return_value=[])
+        # Block reason is NOT pending required checks — skip must not fire.
+        client.analyze_block_reason = AsyncMock(
+            return_value="Blocked by branch protection (requires approval)"
+        )
+
+        no_g2g = GitHub2GerritDetectionResult()
+        with (
+            patch.object(
+                mgr,
+                "_detect_github2gerrit",
+                new_callable=AsyncMock,
+                return_value=no_g2g,
+            ),
+            patch.object(
+                mgr,
+                "_get_merge_method_for_repo",
+                new_callable=AsyncMock,
+                return_value="merge",
+            ),
+            patch.object(
+                mgr,
+                "_trigger_stale_precommit_ci",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+            patch.object(
+                mgr,
+                "_check_merge_requirements",
+                new_callable=AsyncMock,
+                return_value=(True, ""),
+            ),
+            patch.object(
+                mgr,
+                "_approve_pr",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
+            patch.object(
+                mgr,
+                "_merge_pr_with_retry",
+                new_callable=AsyncMock,
+                return_value=True,
+            ) as mock_merge_retry,
+        ):
+            result = await mgr._merge_single_pr(pr)
+
+        assert result.status == MergeStatus.MERGED
+        mock_merge_retry.assert_called_once()
+        # analyze_block_reason was consulted before deciding to proceed
+        client.analyze_block_reason.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_manual_merge_runs_when_analyze_block_reason_fails(
+        self,
+    ) -> None:
+        """If analyze_block_reason raises, fall back to manual merge attempt."""
+        mgr, client = make_merge_manager(preview_mode=False)
+        pr = _DEFAULT_PR.model_copy(
+            update={
+                "mergeable_state": "blocked",
+                "mergeable": True,
+                "state": "open",
+            }
+        )
+
+        mgr._auto_merge_enabled.add("owner/repo#42")
+
+        client.get = AsyncMock(return_value={})
+        client.get_required_status_checks = AsyncMock(return_value=[])
+        client.analyze_block_reason = AsyncMock(side_effect=RuntimeError("boom"))
+
+        no_g2g = GitHub2GerritDetectionResult()
+        with (
+            patch.object(
+                mgr,
+                "_detect_github2gerrit",
+                new_callable=AsyncMock,
+                return_value=no_g2g,
+            ),
+            patch.object(
+                mgr,
+                "_get_merge_method_for_repo",
+                new_callable=AsyncMock,
+                return_value="merge",
+            ),
+            patch.object(
+                mgr,
+                "_trigger_stale_precommit_ci",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+            patch.object(
+                mgr,
+                "_check_merge_requirements",
+                new_callable=AsyncMock,
+                return_value=(True, ""),
+            ),
+            patch.object(
+                mgr,
+                "_approve_pr",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
+            patch.object(
+                mgr,
+                "_merge_pr_with_retry",
+                new_callable=AsyncMock,
+                return_value=True,
+            ) as mock_merge_retry,
+        ):
+            result = await mgr._merge_single_pr(pr)
+
+        # Defensive fallback: proceed with manual merge rather than
+        # silently marking as AUTO_MERGE_PENDING.
+        assert result.status == MergeStatus.MERGED
+        mock_merge_retry.assert_called_once()

--- a/tests/test_precommit_ci_trigger.py
+++ b/tests/test_precommit_ci_trigger.py
@@ -359,18 +359,18 @@ class TestPollingBehavior:
 
         pending = {"statuses": [{"context": "pre-commit.ci - pr", "state": "pending"}]}
 
-        # step 2 + step 3 + 60 poll iterations (max_polls = 60)
+        # step 2 + step 3 + 30 poll iterations (max_polls = 300s / 10s = 30)
         client.get.side_effect = [
             {"statuses": []},
             [],
-        ] + [pending] * 60
+        ] + [pending] * 30
 
         with patch("asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
             result = await mgr._trigger_stale_precommit_ci(pr)
 
         assert result is False
         # Should have slept once per poll
-        assert mock_sleep.call_count == 60
+        assert mock_sleep.call_count == 30
 
     @pytest.mark.asyncio
     async def test_polling_handles_api_errors_gracefully(self):


### PR DESCRIPTION
## Summary

Replace six independent hardcoded polling timeouts with two centralised constants and a dynamically computed poll max. All async merge operations now share the same timing. Add GitHub auto-merge support so PRs that time out waiting for status checks still merge automatically.

## Problem

Two PRs failed to merge because they were behind their base branch and needed rebasing. Both repositories have branch protection requiring `pre-commit.ci - pr` to pass. After rebase, pre-commit.ci needs to re-run on the new commit (up to **5 minutes**), but the rebase wait loop only waited **~2 minutes** (24 × 5s = 120s), causing a timeout followed by a doomed 405 merge attempt.

## Changes

### Centralised Timing Constants

| Constant | Value | Purpose |
|----------|-------|---------|
| `DEFAULT_MERGE_TIMEOUT` | 300s | Total timeout for all async merge operations |
| `DEFAULT_MERGE_RECHECK_INTERVAL` | 10s | Polling interval (was 5s) |
| `MERGE_POLL_MAX_ATTEMPTS` | Computed: `math.ceil(timeout / interval)` | No longer hardcoded |

### Before → After (polling loops)

| Operation | Before | After |
|-----------|--------|-------|
| Rebase wait | 120s (24 × 5s) | 300s (30 × 10s) |
| Pre-commit.ci wait | 300s (60 × 5s) | 300s (30 × 10s) |
| Dependabot recreate | 180s (36 × 5s) | 300s (30 × 10s) |
| Recreated PR checks | 180s (36 × 5s) | 300s (30 × 10s) |

### New Features

- **`--merge-timeout` CLI flag**: Override the 300s default timeout
- **Auto-merge via GraphQL**: When a rebase or recreate triggers async status checks, auto-merge is enabled on the PR so GitHub merges it automatically when all branch protection rules are satisfied — even if we time out waiting
- **Skip redundant merge attempts**: When auto-merge is active and the PR is still blocked after polling, the manual merge call is skipped entirely (no more 405 errors). The skip gate is tight: it only applies when blocked by *pending* required checks (`mergeable is True`) and `--force=all` was not used — so force semantics and failing-checks visibility are preserved.

### Files Changed (9)

- `src/dependamerge/models.py` — Add `node_id` field to `PullRequestInfo`
- `src/dependamerge/github_graphql.py` — Add `id` to PR queries + `ENABLE_AUTO_MERGE` mutation
- `src/dependamerge/github_async.py` — Add `enable_auto_merge()` method
- `src/dependamerge/github_service.py` — Populate `node_id` from GraphQL
- `src/dependamerge/github_client.py` — Populate `node_id` from REST
- `src/dependamerge/cli.py` — Add `--merge-timeout` option (uses shared `DEFAULT_MERGE_TIMEOUT`)
- `src/dependamerge/merge_manager.py` — Core refactoring (constants, auto-merge, polling alignment, `math.ceil` poll-max, `AUTO_MERGE_PENDING` status)
- `tests/test_precommit_ci_trigger.py` — Update test for new poll count (30 vs 60)
- `tests/test_auto_merge.py` — New targeted tests for the auto-merge enable path, skip-gate logic (mergeable, force_level), timing defaults/overrides/invalid-fallback, and the `math.ceil` poll-max ceiling

## How This Fixes the Original Failures

For `checkout-gerrit-change-action#83` and `gerrit-review-action#88`:

1. **Longer wait**: Rebase poll now waits 300s (aligned with pre-commit.ci)
2. **Auto-merge safety net**: Even if the poll times out, auto-merge is enabled so GitHub merges it later
3. **No wasted 405**: Instead of forcing a doomed merge attempt, reports "auto-merge enabled" and moves on