### PR TITLE
Fix(ci): Surface Grype findings on audit failure

### DIFF
--- a/.github/workflows/build-test-release.yaml
+++ b/.github/workflows/build-test-release.yaml
@@ -230,33 +230,67 @@ jobs:
             sbom-cyclonedx.xml
           retention-days: 45
 
+      - name: "SBOM summary"
+        run: |
+            # SBOM summary
+            {
+              echo "## SBOM Summary"
+              echo "SBOM count: ${{ steps.sbom.outputs.component_count }}"
+              echo "Tool used: ${{ steps.sbom.outputs.dependency_manager }}"
+            } >> "$GITHUB_STEP_SUMMARY"
+
+  grype:
+    name: 'Grype Audit SBOM'
+    runs-on: ubuntu-latest
+    needs: 'sbom'
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      # Harden the runner used by this workflow
+      # yamllint disable-line rule:line-length
+      - uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df  # v2.18.0
+        with:
+          egress-policy: 'audit'
+
+      - name: "Download SBOM artefact"
+        # yamllint disable-line rule:line-length
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53  # v6.0.0
+        with:
+          name: sbom-files
+
       - name: "Security scan with Grype (SARIF)"
         # yamllint disable-line rule:line-length
         uses: anchore/scan-action@e1165082ffb1fe366ebaf02d8526e7c4989ea9d2  # v7.4.0
         id: grype-sarif
-        # The first Grype scan should not abort the job on failure so that
-        # subsequent steps can collect artefacts and display human-readable
-        # results; the final check step will fail the job if needed
+        # SARIF output is produced purely for artefact upload (code
+        # scanning ingestion); this step must not fail the job so the
+        # Table step below can render the CVE list in its own log.
         continue-on-error: true
         with:
-          sbom: "${{ steps.sbom.outputs.sbom_json_path }}"
+          sbom: "sbom-cyclonedx.json"
           output-format: "sarif"
           output-file: "grype-results.sarif"
-          fail-build: "true"
+          fail-build: "false"
 
+      # The Table scan owns the pass/fail verdict for the job. Its step
+      # log contains the human-readable CVE table, so when this step
+      # turns red in the PR Checks UI, clicking through to the workflow
+      # log immediately shows the offending packages and CVEs.
+      #
+      # The NO_BLOCK_AUDIT_FAIL repository variable (when set to 'true')
+      # disables failure propagation so releases can proceed when blocked
+      # by newly discovered CVEs in transitive dependencies.
       - name: "Security scan with Grype (Text/Table)"
         # yamllint disable-line rule:line-length
         uses: anchore/scan-action@e1165082ffb1fe366ebaf02d8526e7c4989ea9d2  # v7.4.0
         id: grype-table
         if: always()
         with:
-          sbom: "${{ steps.sbom.outputs.sbom_json_path }}"
+          sbom: "sbom-cyclonedx.json"
           output-format: "table"
           output-file: "grype-results.txt"
-          # This scan produces human-readable output only; fail-build
-          # is false because the SARIF scan above captures the pass/fail
-          # outcome, checked by the final "Check Grype scan results" step
-          fail-build: "false"
+          fail-build: "${{ vars.NO_BLOCK_AUDIT_FAIL != 'true' }}"
 
       - name: "Upload Grype scan results"
         # yamllint disable-line rule:line-length
@@ -268,43 +302,22 @@ jobs:
             grype-results.sarif
             grype-results.txt
           retention-days: 90
+          if-no-files-found: ignore
 
       - name: "Grype summary"
         if: always()
         run: |
             # Grype summary
             {
-              echo "## SBOM Summary"
-              echo "SBOM count: ${{ steps.sbom.outputs.component_count }}"
-              echo "Tool used: ${{ steps.sbom.outputs.dependency_manager }}"
-              echo ""
               echo "## Grype Vulnerability Scan"
               if [ -f grype-results.txt ]; then
+                echo '```'
                 cat grype-results.txt
+                echo '```'
               else
                 echo "No scan results available"
               fi
             } >> "$GITHUB_STEP_SUMMARY"
-            if [ -f grype-results.txt ]; then
-              echo "--- Grype scan results ---"
-              cat grype-results.txt
-            fi
-
-      # Fails the job if Grype found vulnerabilities, unless the
-      # NO_BLOCK_AUDIT_FAIL repository variable is set to 'true'.
-      # This allows releases to proceed when blocked by newly
-      # discovered CVEs in transitive dependencies.
-      - name: "Check Grype scan results"
-        if: >-
-          steps.grype-sarif.outcome == 'failure'
-          && vars.NO_BLOCK_AUDIT_FAIL != 'true'
-        run: |
-            # Check Grype scan results
-            echo "::error::Grype found vulnerabilities" \
-              "at or above severity threshold"
-            echo "Review the Grype Summary above or download the" \
-              "grype-scan-results artifact for details"
-            exit 1
 
   # NOTE: PyPI (test and production) will reject duplicate uploads for the
   # same package version. This means the publishing steps below are NOT

--- a/.github/workflows/build-test-release.yaml
+++ b/.github/workflows/build-test-release.yaml
@@ -273,6 +273,20 @@ jobs:
           output-file: "grype-results.sarif"
           fail-build: "false"
 
+      - name: "Security scan with Grype (JSON)"
+        # yamllint disable-line rule:line-length
+        uses: anchore/scan-action@e1165082ffb1fe366ebaf02d8526e7c4989ea9d2  # v7.4.0
+        id: grype-json
+        # JSON output drives the Markdown table rendered in the job
+        # step summary; it must not fail the job, so fail-build is
+        # false and failures are tolerated.
+        continue-on-error: true
+        with:
+          sbom: "sbom-cyclonedx.json"
+          output-format: "json"
+          output-file: "grype-results.json"
+          fail-build: "false"
+
       # The Table scan owns the pass/fail verdict for the job. Its step
       # log contains the human-readable CVE table, so when this step
       # turns red in the PR Checks UI, clicking through to the workflow
@@ -300,6 +314,7 @@ jobs:
           name: grype-scan-results
           path: |
             grype-results.sarif
+            grype-results.json
             grype-results.txt
           retention-days: 90
           if-no-files-found: ignore
@@ -307,16 +322,66 @@ jobs:
       - name: "Grype summary"
         if: always()
         run: |
-            # Grype summary
+            # Render a Markdown table of Grype matches in the job
+            # step summary. The CVE data is sourced from the JSON
+            # scan output (grype-results.json) and processed with
+            # jq so that multi-word cells cannot accidentally break
+            # the Markdown table column layout. Any literal pipe
+            # characters present in cell content are escaped.
             {
               echo "## Grype Vulnerability Scan"
-              if [ -f grype-results.txt ]; then
-                echo '```'
-                cat grype-results.txt
-                echo '```'
-              else
+              echo ""
+              if [ ! -f grype-results.json ]; then
                 echo "No scan results available"
+                exit 0
               fi
+              match_count=$(jq '.matches | length' grype-results.json)
+              if [ "${match_count}" = "0" ]; then
+                echo "No vulnerabilities found at or above the" \
+                  "configured severity threshold."
+                exit 0
+              fi
+              echo "Found ${match_count} matching Grype record(s)."
+              echo ""
+              echo "| Package | Installed | Fixed In | Type |" \
+                "Vulnerability | Severity | EPSS | Risk |"
+              echo "| --- | --- | --- | --- | --- | --- | --- | --- |"
+              jq -r '
+                def esc: tostring | gsub("\\|"; "\\|");
+                # Round a numeric value to two decimal places.
+                def round2:
+                  . * 100
+                  | (if . >= 0 then floor else -((-. | floor))
+                    end)
+                  / 100;
+                def epss_pct:
+                  ( .vulnerability.epss // [] ) as $e
+                  | if ($e | length) == 0 then "-"
+                    else ( $e[0].epss // 0 ) as $p
+                      | if $p == 0 then "0%"
+                        elif ($p * 100) < 0.01 then "<0.01%"
+                        else ( ($p * 100) | round2 | tostring
+                               + "%" ) end
+                    end;
+                def risk_fmt:
+                  .vulnerability.risk
+                  | if . == null then "-"
+                    elif type == "number" then
+                      (round2 | tostring)
+                    else (. | tostring) end;
+                .matches[] |
+                [ (.artifact.name // "-" | esc),
+                  (.artifact.version // "-" | esc),
+                  ( ( .vulnerability.fix.versions // [] )
+                    | if length == 0 then "-"
+                      else join(", ") end | esc ),
+                  (.artifact.type // "-" | esc),
+                  (.vulnerability.id // "-" | esc),
+                  (.vulnerability.severity // "-" | esc),
+                  epss_pct,
+                  risk_fmt
+                ] | "| " + join(" | ") + " |"
+              ' grype-results.json
             } >> "$GITHUB_STEP_SUMMARY"
 
   # NOTE: PyPI (test and production) will reject duplicate uploads for the

--- a/.github/workflows/build-test-release.yaml
+++ b/.github/workflows/build-test-release.yaml
@@ -267,16 +267,18 @@ jobs:
       # Only the final Text/Table scan is left outside the pair, so
       # it is the sole source of the job's single failure annotation.
       #
-      # The token is randomised per run to prevent a (malicious)
-      # dependency from re-enabling workflow-command parsing
-      # prematurely via a crafted log line.
+      # The token below is a fixed literal rather than a randomised
+      # per-run value: writing a randomised value through step
+      # outputs causes the runner to auto-mask it as '***' in the
+      # log stream, which breaks stop-commands end-token matching.
+      # The threat model here (hostile transitive dependency
+      # prematurely re-enabling workflow commands by echoing the
+      # token) is negligible for this workflow.
       - name: "Mute annotations for artefact-only scans"
-        id: mute-token
         run: |
-            # Generate a per-run token and suspend workflow-command parsing
-            token="grype-quiet-$(openssl rand -hex 16)"
-            echo "token=${token}" >> "$GITHUB_OUTPUT"
-            echo "::stop-commands::${token}"
+            # Suspend workflow-command parsing until the matching
+            # resume step below
+            echo "::stop-commands::grype-quiet-annotations"
 
       - name: "Security scan with Grype (SARIF)"
         # yamllint disable-line rule:line-length
@@ -312,11 +314,9 @@ jobs:
       # with commands disabled.
       - name: "Resume annotation parsing"
         if: always()
-        env:
-          MUTE_TOKEN: "${{ steps.mute-token.outputs.token }}"
         run: |
             # Resume workflow-command parsing
-            echo "::${MUTE_TOKEN}::"
+            echo "::grype-quiet-annotations::"
 
       # The Table scan owns the pass/fail verdict for the job. Its
       # step log contains the human-readable CVE table, so when this

--- a/.github/workflows/build-test-release.yaml
+++ b/.github/workflows/build-test-release.yaml
@@ -259,6 +259,25 @@ jobs:
         with:
           name: sbom-files
 
+      # The SARIF and JSON Grype scans below emit workflow commands
+      # (::warning::Failed minimum severity level...) that the runner
+      # would otherwise lift into duplicate job annotations. Wrap
+      # those scans in a ::stop-commands::/::<token>:: pair so the
+      # commands are logged verbatim but not surfaced as annotations.
+      # Only the final Text/Table scan is left outside the pair, so
+      # it is the sole source of the job's single failure annotation.
+      #
+      # The token is randomised per run to prevent a (malicious)
+      # dependency from re-enabling workflow-command parsing
+      # prematurely via a crafted log line.
+      - name: "Mute annotations for artefact-only scans"
+        id: mute-token
+        run: |
+            # Generate a per-run token and suspend workflow-command parsing
+            token="grype-quiet-$(openssl rand -hex 16)"
+            echo "token=${token}" >> "$GITHUB_OUTPUT"
+            echo "::stop-commands::${token}"
+
       - name: "Security scan with Grype (SARIF)"
         # yamllint disable-line rule:line-length
         uses: anchore/scan-action@e1165082ffb1fe366ebaf02d8526e7c4989ea9d2  # v7.4.0
@@ -286,6 +305,18 @@ jobs:
           output-format: "json"
           output-file: "grype-results.json"
           fail-build: "false"
+
+      # Resume workflow-command parsing. Guarded by `if: always()` so
+      # that even if a preceding scan step failed unexpectedly we do
+      # not leave later steps in this (or any subsequent) job running
+      # with commands disabled.
+      - name: "Resume annotation parsing"
+        if: always()
+        env:
+          MUTE_TOKEN: "${{ steps.mute-token.outputs.token }}"
+        run: |
+            # Resume workflow-command parsing
+            echo "::${MUTE_TOKEN}::"
 
       # The Table scan owns the pass/fail verdict for the job. Its
       # step log contains the human-readable CVE table, so when this

--- a/.github/workflows/build-test-release.yaml
+++ b/.github/workflows/build-test-release.yaml
@@ -249,7 +249,7 @@ jobs:
     steps:
       # Harden the runner used by this workflow
       # yamllint disable-line rule:line-length
-      - uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df  # v2.18.0
+      - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40  # v2.19.0
         with:
           egress-policy: 'audit'
 
@@ -259,85 +259,69 @@ jobs:
         with:
           name: sbom-files
 
-      # The SARIF and JSON Grype scans below emit workflow commands
-      # (::warning::Failed minimum severity level...) that the runner
-      # would otherwise lift into duplicate job annotations. Wrap
-      # those scans in a ::stop-commands::/::<token>:: pair so the
-      # commands are logged verbatim but not surfaced as annotations.
-      # Only the final Text/Table scan is left outside the pair, so
-      # it is the sole source of the job's single failure annotation.
-      #
-      # The token below is a fixed literal rather than a randomised
-      # per-run value: writing a randomised value through step
-      # outputs causes the runner to auto-mask it as '***' in the
-      # log stream, which breaks stop-commands end-token matching.
-      # The threat model here (hostile transitive dependency
-      # prematurely re-enabling workflow commands by echoing the
-      # token) is negligible for this workflow.
-      - name: "Mute annotations for artefact-only scans"
-        run: |
-            # Suspend workflow-command parsing until the matching
-            # resume step below
-            echo "::stop-commands::grype-quiet-annotations"
-
-      - name: "Security scan with Grype (SARIF)"
+      - name: "Install Grype"
+        id: grype
         # yamllint disable-line rule:line-length
-        uses: anchore/scan-action@e1165082ffb1fe366ebaf02d8526e7c4989ea9d2  # v7.4.0
-        id: grype-sarif
-        # SARIF output is produced purely for artefact upload; this
-        # step must not fail the job so the Table step below can
-        # render the CVE list in its own log.
-        continue-on-error: true
+        uses: anchore/scan-action/download-grype@e1165082ffb1fe366ebaf02d8526e7c4989ea9d2  # v7.4.0
         with:
-          sbom: "sbom-cyclonedx.json"
-          output-format: "sarif"
-          output-file: "grype-results.sarif"
-          fail-build: "false"
+          cache-db: "true"
 
-      - name: "Security scan with Grype (JSON)"
-        # yamllint disable-line rule:line-length
-        uses: anchore/scan-action@e1165082ffb1fe366ebaf02d8526e7c4989ea9d2  # v7.4.0
-        id: grype-json
-        # JSON output drives the Markdown table rendered in the job
-        # step summary; it must not fail the job, so fail-build is
-        # false and failures are tolerated.
-        continue-on-error: true
-        with:
-          sbom: "sbom-cyclonedx.json"
-          output-format: "json"
-          output-file: "grype-results.json"
-          fail-build: "false"
-
-      # Resume workflow-command parsing. Guarded by `if: always()` so
-      # that even if a preceding scan step failed unexpectedly we do
-      # not leave later steps in this (or any subsequent) job running
-      # with commands disabled.
-      - name: "Resume annotation parsing"
-        if: always()
-        run: |
-            # Resume workflow-command parsing
-            echo "::grype-quiet-annotations::"
-
-      # The Table scan owns the pass/fail verdict for the job. Its
-      # step log contains the human-readable CVE table, so when this
-      # step turns red in the workflow run's Actions/Checks UI,
-      # clicking through to the workflow log immediately shows the
-      # offending packages and CVEs.
-      #
       # The NO_BLOCK_AUDIT_FAIL repository variable (when set to
       # 'true') disables failure propagation so releases can proceed
       # when blocked by newly discovered CVEs in transitive
-      # dependencies.
-      - name: "Security scan with Grype (Text/Table)"
-        # yamllint disable-line rule:line-length
-        uses: anchore/scan-action@e1165082ffb1fe366ebaf02d8526e7c4989ea9d2  # v7.4.0
-        id: grype-table
-        if: always()
-        with:
-          sbom: "sbom-cyclonedx.json"
-          output-format: "table"
-          output-file: "grype-results.txt"
-          fail-build: "${{ vars.NO_BLOCK_AUDIT_FAIL != 'true' }}"
+      # dependencies. Without the override, this step turns red in
+      # the workflow run's Actions/Checks UI and is the sole source
+      # of the job's failure annotation; the CVE table is printed
+      # directly into the step log by echoing grype-results.txt.
+      - name: "Grype audit SBOM"
+        id: grype-audit
+        env:
+          GRYPE_CMD: "${{ steps.grype.outputs.cmd }}"
+          NO_BLOCK_AUDIT_FAIL: >-
+            ${{ vars.NO_BLOCK_AUDIT_FAIL == 'true' }}
+        run: |
+            # Run grype once, emitting all three output formats
+            # Render the human-readable table in this step's log
+            set +e
+            "${GRYPE_CMD}" \
+              -o "sarif=grype-results.sarif" \
+              -o "json=grype-results.json" \
+              -o "table=grype-results.txt" \
+              --fail-on medium \
+              "sbom:sbom-cyclonedx.json"
+            grype_exit=$?
+            set -e
+
+            echo "--- Grype scan results ---"
+            if [ -f grype-results.txt ]; then
+              cat grype-results.txt
+            else
+              echo "No table output produced"
+            fi
+
+            # grype returns 2 when it finds vulnerabilities at or
+            # above the configured --fail-on threshold; any other
+            # non-zero exit is treated as a grype failure.
+            if [ "${grype_exit}" = "0" ]; then
+              echo "No vulnerabilities at or above 'medium'"
+              exit 0
+            fi
+            if [ "${grype_exit}" != "2" ]; then
+              echo "::error::Grype exited with code ${grype_exit}"
+              exit "${grype_exit}"
+            fi
+
+            if [ "${NO_BLOCK_AUDIT_FAIL}" = "true" ]; then
+              echo "::warning::Grype found vulnerabilities at or" \
+                "above the 'medium' threshold, but" \
+                "NO_BLOCK_AUDIT_FAIL is set so the job will not" \
+                "fail."
+              exit 0
+            fi
+            echo "::error::Grype found vulnerabilities at or above" \
+              "the 'medium' severity threshold. See the table" \
+              "above for the offending packages and CVEs."
+            exit 1
 
       - name: "Upload Grype scan results"
         # yamllint disable-line rule:line-length

--- a/.github/workflows/build-test-release.yaml
+++ b/.github/workflows/build-test-release.yaml
@@ -255,7 +255,7 @@ jobs:
 
       - name: "Download SBOM artefact"
         # yamllint disable-line rule:line-length
-        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53  # v6.0.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
           name: sbom-files
 
@@ -263,9 +263,9 @@ jobs:
         # yamllint disable-line rule:line-length
         uses: anchore/scan-action@e1165082ffb1fe366ebaf02d8526e7c4989ea9d2  # v7.4.0
         id: grype-sarif
-        # SARIF output is produced purely for artefact upload (code
-        # scanning ingestion); this step must not fail the job so the
-        # Table step below can render the CVE list in its own log.
+        # SARIF output is produced purely for artefact upload; this
+        # step must not fail the job so the Table step below can
+        # render the CVE list in its own log.
         continue-on-error: true
         with:
           sbom: "sbom-cyclonedx.json"
@@ -287,14 +287,16 @@ jobs:
           output-file: "grype-results.json"
           fail-build: "false"
 
-      # The Table scan owns the pass/fail verdict for the job. Its step
-      # log contains the human-readable CVE table, so when this step
-      # turns red in the PR Checks UI, clicking through to the workflow
-      # log immediately shows the offending packages and CVEs.
+      # The Table scan owns the pass/fail verdict for the job. Its
+      # step log contains the human-readable CVE table, so when this
+      # step turns red in the workflow run's Actions/Checks UI,
+      # clicking through to the workflow log immediately shows the
+      # offending packages and CVEs.
       #
-      # The NO_BLOCK_AUDIT_FAIL repository variable (when set to 'true')
-      # disables failure propagation so releases can proceed when blocked
-      # by newly discovered CVEs in transitive dependencies.
+      # The NO_BLOCK_AUDIT_FAIL repository variable (when set to
+      # 'true') disables failure propagation so releases can proceed
+      # when blocked by newly discovered CVEs in transitive
+      # dependencies.
       - name: "Security scan with Grype (Text/Table)"
         # yamllint disable-line rule:line-length
         uses: anchore/scan-action@e1165082ffb1fe366ebaf02d8526e7c4989ea9d2  # v7.4.0
@@ -317,7 +319,7 @@ jobs:
             grype-results.json
             grype-results.txt
           retention-days: 90
-          if-no-files-found: ignore
+          if-no-files-found: warn
 
       - name: "Grype summary"
         if: always()
@@ -348,12 +350,9 @@ jobs:
               echo "| --- | --- | --- | --- | --- | --- | --- | --- |"
               jq -r '
                 def esc: tostring | gsub("\\|"; "\\|");
-                # Round a numeric value to two decimal places.
-                def round2:
-                  . * 100
-                  | (if . >= 0 then floor else -((-. | floor))
-                    end)
-                  / 100;
+                # Round a numeric value to two decimal places
+                # using half-up rounding via jq built-in `round`.
+                def round2: (. * 100 | round) / 100;
                 def epss_pct:
                   ( .vulnerability.epss // [] ) as $e
                   | if ($e | length) == 0 then "-"
@@ -396,6 +395,7 @@ jobs:
       - 'tag-validate'
       - 'python-tests'
       - 'python-audit'
+      - 'grype'
     environment:
       name: 'development'
     permissions:

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -263,30 +263,70 @@ jobs:
             sbom-cyclonedx.xml
           retention-days: 45
 
+      - name: "SBOM summary"
+        run: |
+            # SBOM summary
+            {
+              echo "## SBOM Summary"
+              echo "SBOM count: ${{ steps.sbom.outputs.component_count }}"
+              echo "Tool used: ${{ steps.sbom.outputs.dependency_manager }}"
+            } >> "$GITHUB_STEP_SUMMARY"
+
+  grype:
+    name: 'Grype Audit SBOM'
+    runs-on: ubuntu-latest
+    needs: 'sbom'
+    if: ${{ !cancelled() && needs.sbom.result == 'success' }}
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      # Harden the runner used by this workflow
+      # yamllint disable-line rule:line-length
+      - uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df  # v2.18.0
+        with:
+          egress-policy: 'audit'
+
+      - name: "Download SBOM artefact"
+        # yamllint disable-line rule:line-length
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+        with:
+          name: sbom-files
+
       - name: "Security scan with Grype (SARIF)"
         # yamllint disable-line rule:line-length
         uses: anchore/scan-action@e1165082ffb1fe366ebaf02d8526e7c4989ea9d2  # v7.4.0
         id: grype-sarif
-        # The first Grype scan should not abort the job on failure so that
-        # subsequent steps can collect artefacts and display human-readable
-        # results; the final check step will fail the job if needed
+        # SARIF output is produced purely for artefact upload; this
+        # step must not fail the job so the Table step below can
+        # render the CVE list in its own log.
         continue-on-error: true
         with:
-          sbom: "${{ steps.sbom.outputs.sbom_json_path }}"
+          sbom: "sbom-cyclonedx.json"
           output-format: "sarif"
           output-file: "grype-results.sarif"
-          fail-build: "true"
+          fail-build: "false"
 
+      # The Table scan owns the pass/fail verdict for the job. Its
+      # step log contains the human-readable CVE table, so when this
+      # step turns red in the PR Checks UI, clicking through to the
+      # workflow log immediately shows the offending packages and
+      # CVEs.
+      #
+      # The NO_BLOCK_AUDIT_FAIL repository variable (when set to
+      # 'true') disables failure propagation so pull requests can
+      # proceed when blocked by newly discovered CVEs in transitive
+      # dependencies.
       - name: "Security scan with Grype (Text/Table)"
         # yamllint disable-line rule:line-length
         uses: anchore/scan-action@e1165082ffb1fe366ebaf02d8526e7c4989ea9d2  # v7.4.0
         id: grype-table
         if: always()
         with:
-          sbom: "${{ steps.sbom.outputs.sbom_json_path }}"
+          sbom: "sbom-cyclonedx.json"
           output-format: "table"
           output-file: "grype-results.txt"
-          fail-build: "false"
+          fail-build: "${{ vars.NO_BLOCK_AUDIT_FAIL != 'true' }}"
 
       - name: "Upload Grype scan results"
         # yamllint disable-line rule:line-length
@@ -298,36 +338,19 @@ jobs:
             grype-results.sarif
             grype-results.txt
           retention-days: 90
+          if-no-files-found: warn
 
       - name: "Grype summary"
         if: always()
         run: |
             # Grype summary
             {
-              echo "## SBOM Summary"
-              echo "SBOM count: ${{ steps.sbom.outputs.component_count }}"
-              echo "Tool used: ${{ steps.sbom.outputs.dependency_manager }}"
-              echo ""
               echo "## Grype Vulnerability Scan"
               if [ -f grype-results.txt ]; then
+                echo '```'
                 cat grype-results.txt
+                echo '```'
               else
                 echo "No scan results available"
               fi
             } >> "$GITHUB_STEP_SUMMARY"
-            if [ -f grype-results.txt ]; then
-              echo "--- Grype scan results ---"
-              cat grype-results.txt
-            fi
-
-      - name: "Check Grype scan results"
-        if: >-
-          steps.grype-sarif.outcome == 'failure'
-          && vars.NO_BLOCK_AUDIT_FAIL != 'true'
-        run: |
-            # Check Grype scan results
-            echo "::error::Grype found vulnerabilities" \
-              "at or above severity threshold"
-            echo "Review the Grype Summary above or download the" \
-              "grype-scan-results artifact for details"
-            exit 1

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -293,6 +293,25 @@ jobs:
         with:
           name: sbom-files
 
+      # The SARIF and JSON Grype scans below emit workflow commands
+      # (::warning::Failed minimum severity level...) that the runner
+      # would otherwise lift into duplicate job annotations. Wrap
+      # those scans in a ::stop-commands::/::<token>:: pair so the
+      # commands are logged verbatim but not surfaced as annotations.
+      # Only the final Text/Table scan is left outside the pair, so
+      # it is the sole source of the job's single failure annotation.
+      #
+      # The token is randomised per run to prevent a (malicious)
+      # dependency from re-enabling workflow-command parsing
+      # prematurely via a crafted log line.
+      - name: "Mute annotations for artefact-only scans"
+        id: mute-token
+        run: |
+            # Generate a per-run token and suspend workflow-command parsing
+            token="grype-quiet-$(openssl rand -hex 16)"
+            echo "token=${token}" >> "$GITHUB_OUTPUT"
+            echo "::stop-commands::${token}"
+
       - name: "Security scan with Grype (SARIF)"
         # yamllint disable-line rule:line-length
         uses: anchore/scan-action@e1165082ffb1fe366ebaf02d8526e7c4989ea9d2  # v7.4.0
@@ -320,6 +339,18 @@ jobs:
           output-format: "json"
           output-file: "grype-results.json"
           fail-build: "false"
+
+      # Resume workflow-command parsing. Guarded by `if: always()` so
+      # that even if a preceding scan step failed unexpectedly we do
+      # not leave later steps in this (or any subsequent) job running
+      # with commands disabled.
+      - name: "Resume annotation parsing"
+        if: always()
+        env:
+          MUTE_TOKEN: "${{ steps.mute-token.outputs.token }}"
+        run: |
+            # Resume workflow-command parsing
+            echo "::${MUTE_TOKEN}::"
 
       # The Table scan owns the pass/fail verdict for the job. Its
       # step log contains the human-readable CVE table, so when this

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -283,7 +283,7 @@ jobs:
     steps:
       # Harden the runner used by this workflow
       # yamllint disable-line rule:line-length
-      - uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df  # v2.18.0
+      - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40  # v2.19.0
         with:
           egress-policy: 'audit'
 
@@ -293,85 +293,69 @@ jobs:
         with:
           name: sbom-files
 
-      # The SARIF and JSON Grype scans below emit workflow commands
-      # (::warning::Failed minimum severity level...) that the runner
-      # would otherwise lift into duplicate job annotations. Wrap
-      # those scans in a ::stop-commands::/::<token>:: pair so the
-      # commands are logged verbatim but not surfaced as annotations.
-      # Only the final Text/Table scan is left outside the pair, so
-      # it is the sole source of the job's single failure annotation.
-      #
-      # The token below is a fixed literal rather than a randomised
-      # per-run value: writing a randomised value through step
-      # outputs causes the runner to auto-mask it as '***' in the
-      # log stream, which breaks stop-commands end-token matching.
-      # The threat model here (hostile transitive dependency
-      # prematurely re-enabling workflow commands by echoing the
-      # token) is negligible for this workflow.
-      - name: "Mute annotations for artefact-only scans"
-        run: |
-            # Suspend workflow-command parsing until the matching
-            # resume step below
-            echo "::stop-commands::grype-quiet-annotations"
-
-      - name: "Security scan with Grype (SARIF)"
+      - name: "Install Grype"
+        id: grype
         # yamllint disable-line rule:line-length
-        uses: anchore/scan-action@e1165082ffb1fe366ebaf02d8526e7c4989ea9d2  # v7.4.0
-        id: grype-sarif
-        # SARIF output is produced purely for artefact upload; this
-        # step must not fail the job so the Table step below can
-        # render the CVE list in its own log.
-        continue-on-error: true
+        uses: anchore/scan-action/download-grype@e1165082ffb1fe366ebaf02d8526e7c4989ea9d2  # v7.4.0
         with:
-          sbom: "sbom-cyclonedx.json"
-          output-format: "sarif"
-          output-file: "grype-results.sarif"
-          fail-build: "false"
+          cache-db: "true"
 
-      - name: "Security scan with Grype (JSON)"
-        # yamllint disable-line rule:line-length
-        uses: anchore/scan-action@e1165082ffb1fe366ebaf02d8526e7c4989ea9d2  # v7.4.0
-        id: grype-json
-        # JSON output drives the Markdown table rendered in the job
-        # step summary; it must not fail the job, so fail-build is
-        # false and failures are tolerated.
-        continue-on-error: true
-        with:
-          sbom: "sbom-cyclonedx.json"
-          output-format: "json"
-          output-file: "grype-results.json"
-          fail-build: "false"
-
-      # Resume workflow-command parsing. Guarded by `if: always()` so
-      # that even if a preceding scan step failed unexpectedly we do
-      # not leave later steps in this (or any subsequent) job running
-      # with commands disabled.
-      - name: "Resume annotation parsing"
-        if: always()
-        run: |
-            # Resume workflow-command parsing
-            echo "::grype-quiet-annotations::"
-
-      # The Table scan owns the pass/fail verdict for the job. Its
-      # step log contains the human-readable CVE table, so when this
-      # step turns red in the PR Checks UI, clicking through to the
-      # workflow log immediately shows the offending packages and
-      # CVEs.
-      #
       # The NO_BLOCK_AUDIT_FAIL repository variable (when set to
       # 'true') disables failure propagation so pull requests can
       # proceed when blocked by newly discovered CVEs in transitive
-      # dependencies.
-      - name: "Security scan with Grype (Text/Table)"
-        # yamllint disable-line rule:line-length
-        uses: anchore/scan-action@e1165082ffb1fe366ebaf02d8526e7c4989ea9d2  # v7.4.0
-        id: grype-table
-        if: always()
-        with:
-          sbom: "sbom-cyclonedx.json"
-          output-format: "table"
-          output-file: "grype-results.txt"
-          fail-build: "${{ vars.NO_BLOCK_AUDIT_FAIL != 'true' }}"
+      # dependencies. Without the override, this step turns red in
+      # the PR Checks UI and is the sole source of the job's
+      # failure annotation; the CVE table is printed directly into
+      # the step log by echoing grype-results.txt.
+      - name: "Grype audit SBOM"
+        id: grype-audit
+        env:
+          GRYPE_CMD: "${{ steps.grype.outputs.cmd }}"
+          NO_BLOCK_AUDIT_FAIL: >-
+            ${{ vars.NO_BLOCK_AUDIT_FAIL == 'true' }}
+        run: |
+            # Run grype once, emitting all three output formats
+            # Render the human-readable table in this step's log
+            set +e
+            "${GRYPE_CMD}" \
+              -o "sarif=grype-results.sarif" \
+              -o "json=grype-results.json" \
+              -o "table=grype-results.txt" \
+              --fail-on medium \
+              "sbom:sbom-cyclonedx.json"
+            grype_exit=$?
+            set -e
+
+            echo "--- Grype scan results ---"
+            if [ -f grype-results.txt ]; then
+              cat grype-results.txt
+            else
+              echo "No table output produced"
+            fi
+
+            # grype returns 2 when it finds vulnerabilities at or
+            # above the configured --fail-on threshold; any other
+            # non-zero exit is treated as a grype failure.
+            if [ "${grype_exit}" = "0" ]; then
+              echo "No vulnerabilities at or above 'medium'"
+              exit 0
+            fi
+            if [ "${grype_exit}" != "2" ]; then
+              echo "::error::Grype exited with code ${grype_exit}"
+              exit "${grype_exit}"
+            fi
+
+            if [ "${NO_BLOCK_AUDIT_FAIL}" = "true" ]; then
+              echo "::warning::Grype found vulnerabilities at or" \
+                "above the 'medium' threshold, but" \
+                "NO_BLOCK_AUDIT_FAIL is set so the job will not" \
+                "fail."
+              exit 0
+            fi
+            echo "::error::Grype found vulnerabilities at or above" \
+              "the 'medium' severity threshold. See the table" \
+              "above for the offending packages and CVEs."
+            exit 1
 
       - name: "Upload Grype scan results"
         # yamllint disable-line rule:line-length
@@ -389,11 +373,11 @@ jobs:
       - name: "Grype summary"
         if: always()
         run: |
-            # Render a Markdown table of Grype matches in the job
-            # step summary. The CVE data is sourced from the JSON
-            # scan output (grype-results.json) and processed with
-            # jq so that multi-word cells cannot accidentally break
-            # the Markdown table column layout. Any literal pipe
+            # Render a Markdown table of output in step summary.
+            # The CVE data is sourced from the JSON scan output
+            # (grype-results.json) and processed with jq so that
+            # multi-word cells cannot accidentally break the
+            # Markdown table column layout. Any literal pipe
             # characters present in cell content are escaped.
             {
               echo "## Grype Vulnerability Scan"

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -307,6 +307,20 @@ jobs:
           output-file: "grype-results.sarif"
           fail-build: "false"
 
+      - name: "Security scan with Grype (JSON)"
+        # yamllint disable-line rule:line-length
+        uses: anchore/scan-action@e1165082ffb1fe366ebaf02d8526e7c4989ea9d2  # v7.4.0
+        id: grype-json
+        # JSON output drives the Markdown table rendered in the job
+        # step summary; it must not fail the job, so fail-build is
+        # false and failures are tolerated.
+        continue-on-error: true
+        with:
+          sbom: "sbom-cyclonedx.json"
+          output-format: "json"
+          output-file: "grype-results.json"
+          fail-build: "false"
+
       # The Table scan owns the pass/fail verdict for the job. Its
       # step log contains the human-readable CVE table, so when this
       # step turns red in the PR Checks UI, clicking through to the
@@ -336,6 +350,7 @@ jobs:
           name: grype-scan-results
           path: |
             grype-results.sarif
+            grype-results.json
             grype-results.txt
           retention-days: 90
           if-no-files-found: warn
@@ -343,14 +358,61 @@ jobs:
       - name: "Grype summary"
         if: always()
         run: |
-            # Grype summary
+            # Render a Markdown table of Grype matches in the job
+            # step summary. The CVE data is sourced from the JSON
+            # scan output (grype-results.json) and processed with
+            # jq so that multi-word cells cannot accidentally break
+            # the Markdown table column layout. Any literal pipe
+            # characters present in cell content are escaped.
             {
               echo "## Grype Vulnerability Scan"
-              if [ -f grype-results.txt ]; then
-                echo '```'
-                cat grype-results.txt
-                echo '```'
-              else
+              echo ""
+              if [ ! -f grype-results.json ]; then
                 echo "No scan results available"
+                exit 0
               fi
+              match_count=$(jq '.matches | length' grype-results.json)
+              if [ "${match_count}" = "0" ]; then
+                echo "No vulnerabilities found at or above the" \
+                  "configured severity threshold."
+                exit 0
+              fi
+              echo "Found ${match_count} matching Grype record(s)."
+              echo ""
+              echo "| Package | Installed | Fixed In | Type |" \
+                "Vulnerability | Severity | EPSS | Risk |"
+              echo "| --- | --- | --- | --- | --- | --- | --- | --- |"
+              jq -r '
+                def esc: tostring | gsub("\\|"; "\\|");
+                # Round a numeric value to two decimal places
+                # using half-up rounding via jq built-in `round`.
+                def round2: (. * 100 | round) / 100;
+                def epss_pct:
+                  ( .vulnerability.epss // [] ) as $e
+                  | if ($e | length) == 0 then "-"
+                    else ( $e[0].epss // 0 ) as $p
+                      | if $p == 0 then "0%"
+                        elif ($p * 100) < 0.01 then "<0.01%"
+                        else ( ($p * 100) | round2 | tostring
+                               + "%" ) end
+                    end;
+                def risk_fmt:
+                  .vulnerability.risk
+                  | if . == null then "-"
+                    elif type == "number" then
+                      (round2 | tostring)
+                    else (. | tostring) end;
+                .matches[] |
+                [ (.artifact.name // "-" | esc),
+                  (.artifact.version // "-" | esc),
+                  ( ( .vulnerability.fix.versions // [] )
+                    | if length == 0 then "-"
+                      else join(", ") end | esc ),
+                  (.artifact.type // "-" | esc),
+                  (.vulnerability.id // "-" | esc),
+                  (.vulnerability.severity // "-" | esc),
+                  epss_pct,
+                  risk_fmt
+                ] | "| " + join(" | ") + " |"
+              ' grype-results.json
             } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -301,16 +301,18 @@ jobs:
       # Only the final Text/Table scan is left outside the pair, so
       # it is the sole source of the job's single failure annotation.
       #
-      # The token is randomised per run to prevent a (malicious)
-      # dependency from re-enabling workflow-command parsing
-      # prematurely via a crafted log line.
+      # The token below is a fixed literal rather than a randomised
+      # per-run value: writing a randomised value through step
+      # outputs causes the runner to auto-mask it as '***' in the
+      # log stream, which breaks stop-commands end-token matching.
+      # The threat model here (hostile transitive dependency
+      # prematurely re-enabling workflow commands by echoing the
+      # token) is negligible for this workflow.
       - name: "Mute annotations for artefact-only scans"
-        id: mute-token
         run: |
-            # Generate a per-run token and suspend workflow-command parsing
-            token="grype-quiet-$(openssl rand -hex 16)"
-            echo "token=${token}" >> "$GITHUB_OUTPUT"
-            echo "::stop-commands::${token}"
+            # Suspend workflow-command parsing until the matching
+            # resume step below
+            echo "::stop-commands::grype-quiet-annotations"
 
       - name: "Security scan with Grype (SARIF)"
         # yamllint disable-line rule:line-length
@@ -346,11 +348,9 @@ jobs:
       # with commands disabled.
       - name: "Resume annotation parsing"
         if: always()
-        env:
-          MUTE_TOKEN: "${{ steps.mute-token.outputs.token }}"
         run: |
             # Resume workflow-command parsing
-            echo "::${MUTE_TOKEN}::"
+            echo "::grype-quiet-annotations::"
 
       # The Table scan owns the pass/fail verdict for the job. Its
       # step log contains the human-readable CVE table, so when this


### PR DESCRIPTION
## Summary

Improves the SBOM/Grype audit workflow so that, when a vulnerability
scan fails, the failing check surfaces the actual CVE/package
information directly in its log, and the job step summary presents the
findings as a proper Markdown table.

Applies to both `build-test.yaml` (PR CI) and
`build-test-release.yaml` (tag-push release CI).

## Problem

When the Grype audit of the SBOM failed on a PR, the job that produced
useful console output (`Security scan with Grype (Text/Table)`) was
marked as successful, while the other (`Security scan with Grype
(SARIF)`)
owned the failure but its log only contained the terse
`Failed minimum severity level` message with no CVE context.

Additionally:

- The job was named `Generate SBOM`, so failures looked like the SBOM
  could not be generated, when in reality the generation succeeded and
  it was the audit of the SBOM that failed.
- The step summary dumped raw Grype table text (with whitespace-only
  column alignment) into `$GITHUB_STEP_SUMMARY`, producing a
  hard-to-read wall of text.
- Running three separate `anchore/scan-action` invocations (SARIF,
  JSON, Text/Table) produced three duplicate
  `Failed minimum severity level…` job annotations, one per
  invocation, with none of them carrying the CVE context.

## Changes

### Split `sbom` into `sbom` + `grype` jobs

- The workflow now has separate `Generate SBOM` and `Grype Audit SBOM`
  jobs, with the `grype` job depending on `sbom` and consuming the
  uploaded `sbom-files` artefact. Failures are now clearly attributed
  to whichever job actually failed.
- `grype` is added to the `test-pypi` job's `needs` list so
  vulnerability findings gate publishing (and transitively, the
  production `pypi` publish). The existing `NO_BLOCK_AUDIT_FAIL`
  repository-variable override still allows releases to proceed when
  blocked by newly discovered CVEs in transitive dependencies.

### Single-step Grype invocation

- Replaced the three `anchore/scan-action` invocations with a single
  Grype run driven by `anchore/scan-action/download-grype` plus a
  shell step we fully control. Grype is executed once with
  `-o sarif=… -o json=… -o table=…`, producing all three output
  formats at once.
- The step prints the human-readable table into its own log, so
  clicking through to a failing check in the Actions UI immediately
  shows the offending packages and CVEs.
- The step then evaluates Grype's exit code and emits exactly one
  `::error::` (or `::warning::` when `NO_BLOCK_AUDIT_FAIL='true'`)
  with the reason for the failure. No duplicate annotations.

### Markdown-table job step summary

- The step summary renders a proper Markdown table sourced from
  `grype-results.json` and processed with `jq`. Parsing structured
  JSON avoids the alignment/cell-delimiter hazards that a naive split
  of the pre-formatted Grype text would introduce; any literal pipe
  characters in cell content are escaped as `\|`.
- EPSS probabilities are formatted as percentages to two decimal
  places (with a `<0.01%` threshold for very small non-zero values),
  and risk scores are rounded to two decimals to avoid IEEE-754 float
  representation artefacts.

### Other workflow-quality fixes

- Reworded the SARIF-output comment to drop the misleading
  _"code scanning ingestion"_ phrasing, since this workflow doesn't
  invoke `github/codeql-action/upload-sarif`.
- `if-no-files-found` on the Grype artefact upload changed from
  `ignore` to `warn` so missing expected outputs surface in logs
  instead of being silently tolerated.

## Verification

The new behaviour was verified end to end on the fork PR
(`modeseven-lfit/dependamerge#1`) by temporarily forcing the
transitive `h11` dependency to `0.12.0` via a `[tool.uv]`
`override-dependencies` pin, which triggered
[GHSA-vqfr-h8mv-ghfj](https://github.com/advisories/GHSA-vqfr-h8mv-ghfj)
(Critical) in the Grype audit. The verification commits (the `h11`
pin and a temporary `pull_request` trigger relaxation) have been
removed; this branch contains only the actual fix commits, rebased
onto `upstream/main`.

During verification:

- The `Generate SBOM` job succeeded.
- The `Grype Audit SBOM` job failed with one informative failure
  annotation naming the CVE, plus the runner's generic
  `Process completed with exit code 1` status annotation (which is
  always emitted for a failing step and cannot be suppressed without
  also suppressing job failure).
- The job step summary rendered the CVE as a Markdown table.
- The `grype-scan-results` artefact contained SARIF, JSON, and
  table-text files.

The `jq` pipeline was also verified locally against a Grype JSON scan
of an intentionally vulnerable environment (`cryptography==41.0.0` +
`pytest==7.0.0`, 11 matches); sample output:

| Package | Installed | Fixed In | Type | Vulnerability | Severity | EPSS | Risk |
| --- | --- | --- | --- | --- | --- | --- | --- |
| cryptography | 41.0.0 | 41.0.2 | python | GHSA-cf7p-gm2m-833m | High | 1.09% | 0.85 |
| cryptography | 41.0.0 | 42.0.4 | python | GHSA-6vqw-3v5j-54x4 | High | 0.42% | 0.31 |
| cryptography | 41.0.0 | 46.0.5 | python | GHSA-r6ph-v2qm-q3c2 | High | <0.01% | 0 |
| pytest | 7.0.0 | 9.0.3 | python | GHSA-6w46-j5rx-g56g | Medium | <0.01% | 0 |

The pipe-escape path also produces the Markdown-correct
single-backslash escape (e.g. a hypothetical package name
`pytest|weird` renders as `pytest\|weird`).
