### PR TITLE
Fix(merge): Enable auto-merge for blocked PRs

### DIFF
--- a/docs/TESTING_WAIT_STATUS_TICKER.md
+++ b/docs/TESTING_WAIT_STATUS_TICKER.md
@@ -1,0 +1,223 @@
+<!--
+SPDX-FileCopyrightText: 2026 The Linux Foundation
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Testing the wait-status ticker (countdown UI)
+
+This document captures options for **manually verifying** the
+single-line Rich countdown introduced in PR #270:
+
+```text
+⏳ Waiting for N PRs to complete checks [Ns]
+```
+
+The ticker fires when a specific set of conditions line up at once,
+which makes ad-hoc verification fiddly. This doc lays out four
+approaches — ranked by effort vs. fidelity — so we can pick one when
+we want to confirm the UX in a real terminal.
+
+## What we're trying to verify
+
+The ticker (`AsyncMergeManager._wait_status_ticker()`) updates
+the progress display when **all** of the following are true:
+
+1. `self._waiting_prs` has at least one entry. Step 5.5 is the sole
+   producer; it adds entries when a PR meets every condition of
+   `should_wait` (`mergeable_state` in
+   `("blocked", "behind", "unstable")`, not in `_rebased_prs`,
+   `force_level != "all"`, not in preview mode, and — for
+   `blocked` PRs — `analyze_block_reason()` indicates pending
+   required checks). The current code does **not** filter on the
+   `mergeable` boolean: GitHub returns `mergeable=False` transiently
+   while computing or when a non-required check failed, so Step 5.5
+   accepts `True`, `False`, and `None` to give auto-merge a chance
+   to rescue the PR.
+2. The manager has a `MergeProgressTracker` attached.
+3. The tracker's `rich_available` is `True`. If it isn't, the ticker
+   delegates to a 15-second plain-console fallback
+   (`_wait_status_ticker_plain`).
+4. The displayed message changes between samples (debounced via
+   `last_message != message`), so the seconds counter has
+   to tick down.
+
+The interesting visual transitions are:
+
+- The seconds counter animating in place (`[40s]` → `[39s]` → …).
+- The `N` count decreasing as individual workers finish.
+- The line clearing when the last waiter exits.
+
+## Option A — synthetic real PRs in `lfreleng-actions/test-python-project`
+
+Set up two or more PRs that legitimately end up in the wait loop, and
+run `dependamerge` against them with a short `--merge-timeout` so the
+countdown is observable.
+
+Sketch:
+
+1. Configure branch protection on `main` to require a status check
+   that takes a fixed long duration (e.g. a small GitHub Actions
+   workflow that runs `sleep 45`). Mark it "required".
+2. Open two PRs from short-lived branches.
+3. Land an unrelated commit on `main` so both PRs go `behind`.
+4. Run:
+
+   ```bash
+   dependamerge merge --no-confirm --merge-timeout 60 \
+     https://github.com/lfreleng-actions/test-python-project/pull/<n>
+   ```
+
+5. Watch the terminal. The Rich Live single-line update should show
+   `⏳ Waiting for 2 PRs to complete checks [Ns]` ticking down,
+   then dropping to `1 PR` before clearing.
+
+### Pros (Option A)
+
+- End-to-end validation against real GitHub plumbing (auto-merge
+  enable, `_waiting_prs` registration, ticker render).
+- Exercises the same code path users hit in production.
+
+### Cons (Option A)
+
+- Requires branch-protection rules with a long-running check.
+- Slow iteration loop: each test run takes minutes, and you have
+  little control over GitHub's mergeability-computation timing.
+- Pollutes a real repo with synthetic PRs.
+- If GitHub resolves the rebase to `clean` faster than the slow
+  check fires, Step 5.5 may exit before the wait loop runs and
+  the ticker may not remain on screen long enough to observe.
+- Hard to reproduce edge cases (e.g. all PRs finishing
+  simultaneously, mid-run cancellation, `rich_available=False`).
+
+## Option B — production CLI flag (e.g. `--test-wait-secs N`)
+
+Add a hidden CLI flag (or environment variable) that injects synthetic
+entries into `self._waiting_prs` for a configurable duration without
+touching real GitHub state.
+
+### Pros (Option B)
+
+- Simple to invoke in any environment.
+
+### Cons (Option B)
+
+- Couples test-specific code to the production CLI surface.
+- Risk of users discovering the flag and relying on it.
+- Doesn't fit naturally with the rest of the merge flow (we'd need
+  to short-circuit half the work to inject the entries).
+
+**Recommendation: avoid.** The benefits don't justify the production
+complexity.
+
+## Option C — standalone demo script in `scripts/`
+
+A small, standalone script that:
+
+1. Builds a `MergeProgressTracker`, starts it.
+2. Builds an `AsyncMergeManager` with a dummy token (no API calls
+   happen — we call the ticker method directly).
+3. Wires the tracker into the manager.
+4. Populates `_waiting_prs` directly with three staggered deadlines.
+5. Spawns `_wait_status_ticker()` as a background task.
+6. Removes entries one by one over the run, simulating PRs
+   completing.
+7. Cancels the ticker after removing the last entry.
+
+Invocation:
+
+```bash
+uv run python scripts/demo_wait_ticker.py            # Rich mode (~40s)
+uv run python scripts/demo_wait_ticker.py --plain    # Plain fallback (~50s)
+```
+
+Expected Rich output (single line, animating in place):
+
+```text
+🔬 Demo in demo-org (0/3 PRs, 0%)
+   ⏳ Waiting for 3 PRs to complete checks [40s]
+   ⏱️  Elapsed: 1s
+```
+
+…ticking through `[39s]`, `[38s]`, …, then dropping to
+`2 PRs` / `1 PR` as the staggered deadlines expire, then clearing.
+
+Plain-fallback output (one line every 15 s):
+
+```text
+⏳ Waiting for 3 PRs to complete checks [40s remaining]
+⏳ Waiting for 2 PRs to complete checks [25s remaining]
+⏳ Waiting for 1 PR to complete checks [10s remaining]
+```
+
+### Pros (Option C)
+
+- Zero production code changes.
+- Exercises the actual `_wait_status_ticker()` and
+  `_wait_status_ticker_plain()` code paths, not stand-ins.
+- Reproducible and self-contained; runs in seconds.
+- `--plain` flag exercises the non-Rich fallback explicitly.
+- Straightforward to adapt for new edge cases (cancellation,
+  single PR, rapid additions, etc.).
+
+### Cons (Option C)
+
+- Doesn't exercise the upstream Step 5.5 registration logic
+  (auto-merge enable, REST refresh polling, head_sha capture,
+  closed-state handling). That coverage already lives in
+  `tests/test_auto_merge.py::TestStep5_5EnablesAutoMergeAndTimesOut`
+  and `TestStep5_5HandlesMergeableNone`.
+
+**Recommendation: this is the lowest-friction way to confirm the
+visual behaviour.**
+
+## Option D — same as C but exposed as a hidden CLI command
+
+Expose the demo as `dependamerge demo-ticker` so it's discoverable
+via `dependamerge --help`.
+
+### Pros (Option D)
+
+- Slightly more discoverable than a script in `scripts/`.
+
+### Cons (Option D)
+
+- Adds CLI surface for what is essentially an internal one-off
+  developer tool.
+
+**Recommendation: skip in favour of Option C** unless we accumulate
+more internal demos and want a `demo` subcommand group.
+
+## Recommendation
+
+Use **Option C** as `scripts/demo_wait_ticker.py` (committed
+under `scripts/`, intentionally not packaged) with a `--plain` flag
+that also exercises the non-Rich path.
+
+Avoid Option A as the primary verification mechanism; the timing
+dependencies on real CI infrastructure make it brittle. Keep it in
+mind for cases where a regression seems plausible and we need an
+end-to-end sanity check against a real GitHub run.
+
+### Proposed minimal layout
+
+```text
+scripts/
+  demo_wait_ticker.py     # standalone demo, executable via `uv run python …`
+docs/
+  TESTING_WAIT_STATUS_TICKER.md   # this document
+```
+
+The demo script should:
+
+- Import `AsyncMergeManager` and `MergeProgressTracker` from the
+  installed package (no monkey-patching of production code).
+- Use the same `_waiting_prs` and `_wait_status_ticker` symbols the
+  production code uses.
+- Accept `--plain` to force the plain-console fallback by passing
+  `progress_tracker=None` to the manager OR by toggling
+  `tracker.rich_available = False`.
+- Print clear "started" / "finished" markers so the demo output is
+  unambiguous in CI logs if anyone ever runs it there.
+
+PR #270 ships both the bug fix and this verification harness
+(Option C demo at `scripts/demo_wait_ticker.py` plus this guide).

--- a/scripts/demo_wait_ticker.py
+++ b/scripts/demo_wait_ticker.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2026 The Linux Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""Manual demo for the merge-manager wait-status ticker.
+
+Implements **Option C** from
+``docs/TESTING_WAIT_STATUS_TICKER.md`` — a self-contained script
+that exercises :meth:`AsyncMergeManager._wait_status_ticker` (and
+its plain-console fallback) without making any GitHub API calls.
+
+The script:
+
+1. Builds a real :class:`MergeProgressTracker` and starts it.
+2. Builds a real :class:`AsyncMergeManager` with a dummy token —
+   no network calls are issued, only the ticker method is run.
+3. Wires the tracker into the manager.
+4. Seeds ``self._waiting_prs`` directly with three staggered
+   monotonic deadlines, simulating PRs that are blocked on
+   pending required checks.
+5. Spawns ``_wait_status_ticker()`` as a background task.
+6. Removes entries one by one as their deadlines pass, simulating
+   PRs whose checks complete.
+7. Cancels the ticker once the last entry is gone and stops the
+   tracker.
+
+Usage:
+
+.. code-block:: bash
+
+    uv run python scripts/demo_wait_ticker.py            # Rich
+    uv run python scripts/demo_wait_ticker.py --plain    # Plain
+
+In ``--plain`` mode the tracker's ``rich_available`` attribute is
+set to ``False`` *before* :meth:`MergeProgressTracker.start` so the
+ticker delegates to :meth:`AsyncMergeManager._wait_status_ticker_plain`
+(15-second cadence) and Rich's ``Live`` display never starts. This
+keeps the plain-console output free of interleaved Rich frames.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import sys
+from pathlib import Path
+
+# Make the demo runnable directly (``python scripts/demo_wait_ticker.py``)
+# in addition to ``uv run python scripts/demo_wait_ticker.py`` by ensuring
+# the package source directory is importable when not installed.
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_SRC = _REPO_ROOT / "src"
+if _SRC.is_dir() and str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+from dependamerge.merge_manager import AsyncMergeManager  # noqa: E402
+from dependamerge.progress_tracker import MergeProgressTracker  # noqa: E402
+
+# Three staggered deadlines (seconds from "now") — mirrors the
+# example in docs/TESTING_WAIT_STATUS_TICKER.md.
+_DEADLINES_FROM_NOW: tuple[tuple[str, float], ...] = (
+    ("demo-org/demo-repo#101", 20.0),
+    ("demo-org/demo-repo#102", 30.0),
+    ("demo-org/demo-repo#103", 40.0),
+)
+
+
+async def _drive_demo(manager: AsyncMergeManager) -> None:
+    """Seed ``_waiting_prs`` and drive the ticker through its cycle."""
+    loop = asyncio.get_running_loop()
+    base = loop.time()
+
+    # Seed three waiting PRs with staggered deadlines. We hold the
+    # waiting lock so the ticker can never observe a half-populated
+    # snapshot (defensive — the ticker is robust to either case).
+    async with manager._waiting_lock:
+        for pr_key, offset in _DEADLINES_FROM_NOW:
+            manager._waiting_prs[pr_key] = base + offset
+
+    print(f"[demo] seeded {len(_DEADLINES_FROM_NOW)} waiting PRs; starting ticker")
+
+    ticker_task = asyncio.create_task(
+        manager._wait_status_ticker(),
+        name="demo-wait-ticker",
+    )
+
+    try:
+        # Walk the deadlines in order, removing each entry shortly
+        # after it expires. The ticker's countdown reflects the
+        # *latest* (worst-case) deadline, so as we drop entries the
+        # remaining seconds stay anchored to the entries that are
+        # still present.
+        for pr_key, offset in _DEADLINES_FROM_NOW:
+            removal_at = base + offset + 0.5
+            sleep_for = max(0.0, removal_at - loop.time())
+            await asyncio.sleep(sleep_for)
+            async with manager._waiting_lock:
+                manager._waiting_prs.pop(pr_key, None)
+            remaining = len(manager._waiting_prs)
+            print(
+                f"[demo] simulated completion of {pr_key} ({remaining} still waiting)"
+            )
+
+        # Give the ticker a beat to render the empty-state clear
+        # before we cancel it, so the user actually sees the line
+        # disappear.
+        await asyncio.sleep(1.5)
+    finally:
+        ticker_task.cancel()
+        try:
+            await ticker_task
+        except asyncio.CancelledError:
+            pass
+
+
+async def _amain(plain: bool) -> int:
+    """Entry point coroutine."""
+    print(
+        "[demo] starting wait-ticker demo "
+        f"({'plain console' if plain else 'rich live'} mode)"
+    )
+
+    tracker = MergeProgressTracker(
+        organization="demo-org",
+        operation_label="Demo",
+        operation_icon="🔬",
+    )
+    # Provide some PR-level totals so the heading reads
+    # "Demo in demo-org (0/3 PRs, 0%)" — same shape as production.
+    tracker.total_prs = len(_DEADLINES_FROM_NOW)
+    tracker.completed_prs = 0
+
+    if plain:
+        # Force the ticker into its plain-console fallback path.
+        # ``_wait_status_ticker`` reads ``rich_available`` once at
+        # startup, so we flip it *before* ``tracker.start()`` —
+        # otherwise Rich's ``Live`` display would also begin
+        # rendering, interleaving with the plain-console lines and
+        # making the demo output misleading.
+        tracker.rich_available = False
+
+    tracker.start()
+
+    manager = AsyncMergeManager(
+        token="demo-token-not-used-no-api-calls",
+        progress_tracker=tracker,
+    )
+
+    try:
+        await _drive_demo(manager)
+    finally:
+        try:
+            tracker.stop()
+        except Exception:
+            pass
+
+    print("[demo] finished")
+    return 0
+
+
+def _parse_args(argv: list[str]) -> argparse.Namespace:
+    """Parse command-line arguments."""
+    parser = argparse.ArgumentParser(
+        description=(
+            "Demo the AsyncMergeManager wait-status ticker without "
+            "making any GitHub API calls."
+        ),
+    )
+    parser.add_argument(
+        "--plain",
+        action="store_true",
+        help=(
+            "Force the plain-console fallback ticker (15s cadence) "
+            "instead of the Rich Live single-line update."
+        ),
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Synchronous entry point."""
+    args = _parse_args(sys.argv[1:] if argv is None else argv)
+    try:
+        return asyncio.run(_amain(plain=args.plain))
+    except KeyboardInterrupt:
+        print("\n[demo] interrupted by user")
+        return 130
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/dependamerge/merge_manager.py
+++ b/src/dependamerge/merge_manager.py
@@ -1311,15 +1311,21 @@ class AsyncMergeManager:
             #   * force_level == "all" (force semantics bypass wait)
             #   * Step 5 already ran a rebase + wait for this PR
             #     (avoid doubling the configured merge_timeout)
-            #   * mergeable_state == "behind" but fix_out_of_date is
-            #     False — auto-merge cannot rebase, so waiting would
-            #     be futile and would mask the user's --no-fix intent
             #   * mergeable_state == "blocked" for a reason that
             #     cannot resolve on its own (e.g. "requires approval",
             #     missing code-owner reviews) — waiting would just
             #     delay the inevitable failure/merge by up to
-            #     merge_timeout. Pending required checks and behind
-            #     PRs DO benefit from waiting.
+            #     merge_timeout.
+            #
+            # Note that ``behind`` PRs go through Step 5.5 regardless
+            # of ``fix_out_of_date``: even when we will not rebase the
+            # PR ourselves, enabling auto-merge gives GitHub the chance
+            # to finish merging once required checks land, and the
+            # resulting AUTO_MERGE_PENDING outcome is friendlier than
+            # a 405 manual-merge failure. This also covers the brief
+            # window after Dependabot/pre-commit-ci rebase a PR where
+            # GitHub still reports ``behind`` while it recomputes
+            # mergeability.
             pr_key_for_wait = (
                 f"{repo_owner}/{repo_name}#{pr_info.number}"
             )
@@ -1337,10 +1343,6 @@ class AsyncMergeManager:
                 and pr_info.mergeable_state in ("blocked", "behind")
                 and self.force_level != "all"
                 and not already_rebased
-                and not (
-                    pr_info.mergeable_state == "behind"
-                    and not self.fix_out_of_date
-                )
             )
 
             # For ``blocked`` PRs (but not ``behind``, which only

--- a/src/dependamerge/merge_manager.py
+++ b/src/dependamerge/merge_manager.py
@@ -177,6 +177,13 @@ class AsyncMergeManager:
         # post-timeout merge attempts can be skipped gracefully.
         self._auto_merge_enabled: set[str] = set()
 
+        # Track PRs currently waiting for required checks to complete.
+        # Maps ``pr_key`` -> deadline (monotonic seconds) so the
+        # parallel merge ticker can render an aggregate countdown
+        # without poking inside individual worker tasks.
+        self._waiting_prs: dict[str, float] = {}
+        self._waiting_lock = asyncio.Lock()
+
         # Delay (seconds) after submitting a new approval before attempting merge.
         # GitHub needs time to propagate the approval to branch-protection evaluation.
         default_post_approval_delay = 3.0
@@ -270,8 +277,25 @@ class AsyncMergeManager:
             )
             tasks.append(task)
 
-        # Wait for all tasks to complete
-        results = await asyncio.gather(*tasks, return_exceptions=True)
+        # Background ticker that surfaces a single-line countdown
+        # whenever one or more workers are waiting for required
+        # checks to complete (auto-merge wait loop). The countdown
+        # uses the worst-case (latest) deadline across all waiting
+        # PRs so the user sees the longest remaining wait.
+        ticker_task = asyncio.create_task(
+                self._wait_status_ticker(),
+                name="merge-wait-ticker",
+            )
+
+        try:
+            # Wait for all tasks to complete
+            results = await asyncio.gather(*tasks, return_exceptions=True)
+        finally:
+            ticker_task.cancel()
+            try:
+                await ticker_task
+            except (asyncio.CancelledError, Exception):
+                pass
 
         # Process results and handle exceptions
         final_results: list[MergeResult] = []
@@ -316,6 +340,107 @@ class AsyncMergeManager:
             ):
                 self.progress_tracker.pr_completed()
             return result
+
+    async def _wait_status_ticker(self) -> None:
+        """Update the progress display while PRs wait for required checks.
+
+        Runs as a background task for the lifetime of
+        ``merge_prs_parallel``. Once per second it samples
+        ``self._waiting_prs`` and pushes a single-line status
+        message into the progress tracker (which uses Rich Live
+        for in-place updates) so the user can see how much
+        longer the tool will block before returning the shell
+        prompt.
+
+        The countdown uses the latest (worst-case) deadline across
+        all waiting PRs so the displayed value reflects the longest
+        remaining wait, not an arbitrary one. When no PRs are
+        waiting, the message is cleared.
+        """
+        if not self.progress_tracker:
+            # Fallback: emit a periodic plain console line so the
+            # user still gets feedback even without Rich progress.
+            await self._wait_status_ticker_plain()
+            return
+
+        last_message: str | None = None
+        try:
+            while True:
+                async with self._waiting_lock:
+                    snapshot = dict(self._waiting_prs)
+
+                if snapshot:
+                    now = asyncio.get_event_loop().time()
+                    remaining = max(
+                        0.0,
+                        max(snapshot.values()) - now,
+                    )
+                    count = len(snapshot)
+                    noun = "PR" if count == 1 else "PRs"
+                    message = (
+                        f"⏳ Waiting for {count} {noun} "
+                        f"to complete checks [{int(remaining)}s]"
+                    )
+                else:
+                    message = ""
+
+                if message != last_message:
+                    try:
+                        self.progress_tracker.update_operation(message)
+                    except Exception:
+                        # Defensive: a failing tracker must never
+                        # take down the whole merge run.
+                        pass
+                    last_message = message
+
+                await asyncio.sleep(1.0)
+        except asyncio.CancelledError:
+            # Best-effort clear on shutdown so the final tracker
+            # state isn't stuck on a stale countdown.
+            if last_message:
+                try:
+                    self.progress_tracker.update_operation("")
+                except Exception:
+                    pass
+            raise
+
+    async def _wait_status_ticker_plain(self) -> None:
+        """Plain-text countdown when no Rich progress tracker is present.
+
+        Emits one console line every 15 seconds while PRs are
+        waiting on required checks. Less granular than the Rich
+        in-place update, but still gives the user visibility into
+        why the tool is blocking.
+        """
+        last_emit: float = 0.0
+        try:
+            while True:
+                async with self._waiting_lock:
+                    snapshot = dict(self._waiting_prs)
+
+                if snapshot:
+                    now = asyncio.get_event_loop().time()
+                    if now - last_emit >= 15.0:
+                        remaining = max(
+                            0.0, max(snapshot.values()) - now
+                        )
+                        count = len(snapshot)
+                        noun = "PR" if count == 1 else "PRs"
+                        try:
+                            self._console.print(
+                                f"⏳ Waiting for {count} {noun} "
+                                f"to complete checks "
+                                f"[{int(remaining)}s remaining]"
+                            )
+                        except Exception:
+                            pass
+                        last_emit = now
+                else:
+                    last_emit = 0.0
+
+                await asyncio.sleep(1.0)
+        except asyncio.CancelledError:
+            raise
 
     async def _detect_github2gerrit(
         self,
@@ -977,7 +1102,7 @@ class AsyncMergeManager:
 
                         # Wait for GitHub to process the update and run checks
                         self._console.print(
-                            "⏳ Waiting for checks to complete after rebase..."
+                            "⏳ Auto-merge requested, pending checks after rebase..."
                         )
                         await asyncio.sleep(self._merge_recheck_interval)
 
@@ -1043,28 +1168,28 @@ class AsyncMergeManager:
                             log_and_print(
                                 self.log,
                                 self._console,
-                                f"✅ Rebase successful: {pr_info.html_url}",
+                                f"✅ Rebased: {pr_info.html_url}",
                                 level="debug",
                             )
                         elif pr_info.mergeable_state == "behind":
                             log_and_print(
                                 self.log,
                                 self._console,
-                                f"⚠️  Rebase incomplete: {pr_info.html_url} [still behind after rebase]",
+                                f"⚠️  Rebased: {pr_info.html_url} [still behind after rebase]",
                                 level="debug",
                             )
                         elif pr_info.mergeable_state == "blocked":
                             log_and_print(
                                 self.log,
                                 self._console,
-                                f"⏳ Rebase complete: {pr_info.html_url} [waiting for status checks]",
+                                f"⏳ Rebased: {pr_info.html_url} [waiting for status checks]",
                                 level="debug",
                             )
                         else:
                             log_and_print(
                                 self.log,
                                 self._console,
-                                f"ℹ️  Rebase complete: {pr_info.html_url} [state: {pr_info.mergeable_state}]",
+                                f"ℹ️  Rebased: {pr_info.html_url}",
                                 level="debug",
                             )
 
@@ -1082,6 +1207,98 @@ class AsyncMergeManager:
                             f"❌ Failed: {pr_info.html_url} [rebase error: {e}]"
                         )
                         return result
+
+            # Step 5.5: If the PR is still blocked (e.g. by a pending
+            # required status check such as pre-commit.ci) or behind
+            # base branch after rebase, enable auto-merge and wait
+            # the configured merge timeout for required checks to
+            # complete. This must run for any PR that did NOT enter
+            # Step 5's rebase branch — without this, blocked PRs fall
+            # straight through to a manual merge attempt that 405's
+            # while pre-commit.ci is still pending.
+            #
+            # Skip in preview mode (no side effects) and when force=all
+            # (force semantics intentionally bypass the wait).
+            if (
+                not self.preview_mode
+                and self._github_client is not None
+                and pr_info.mergeable is True
+                and pr_info.mergeable_state in ("blocked", "behind")
+                and self.force_level != "all"
+            ):
+                pr_key_for_wait = (
+                    f"{repo_owner}/{repo_name}#{pr_info.number}"
+                )
+                if pr_key_for_wait not in self._auto_merge_enabled:
+                    auto_ok_pre = await self._enable_auto_merge_for_pr(
+                        pr_info, repo_owner, repo_name
+                    )
+                    if auto_ok_pre:
+                        log_and_print(
+                            self.log,
+                            self._console,
+                            f"⏳ Auto-merge enabled, waiting for checks: "
+                            f"{pr_info.html_url}",
+                            level="debug",
+                        )
+
+                # Poll for state to become "clean" before attempting
+                # the manual merge. If the timeout elapses while still
+                # blocked/behind, the auto-merge skip gate below will
+                # route this PR to AUTO_MERGE_PENDING so GitHub can
+                # complete the merge asynchronously.
+                wait_pr_key = (
+                    f"{repo_owner}/{repo_name}#{pr_info.number}"
+                )
+                wait_deadline = (
+                    asyncio.get_event_loop().time()
+                    + self._merge_timeout
+                )
+                async with self._waiting_lock:
+                    self._waiting_prs[wait_pr_key] = wait_deadline
+                try:
+                    for _wait_attempt in range(
+                        self._merge_poll_max_attempts
+                    ):
+                        if pr_info.mergeable_state == "clean":
+                            break
+                        await asyncio.sleep(self._merge_recheck_interval)
+                        try:
+                            refreshed_wait = await self._github_client.get(
+                                f"/repos/{repo_owner}/{repo_name}/pulls/"
+                                f"{pr_info.number}"
+                            )
+                        except Exception as wait_exc:
+                            self.log.debug(
+                                "Failed to refresh PR state during auto-merge "
+                                "wait for %s/%s#%s: %s",
+                                repo_owner,
+                                repo_name,
+                                pr_info.number,
+                                wait_exc,
+                            )
+                            continue
+                        if isinstance(refreshed_wait, dict):
+                            # Only overwrite when the keys are present, so a
+                            # partial/empty API response does not blank out
+                            # the existing state.
+                            if "mergeable" in refreshed_wait:
+                                pr_info.mergeable = refreshed_wait.get(
+                                    "mergeable"
+                                )
+                            if "mergeable_state" in refreshed_wait:
+                                pr_info.mergeable_state = refreshed_wait.get(
+                                    "mergeable_state"
+                                )
+                            if refreshed_wait.get("state") == "closed":
+                                # PR was merged (auto-merge fired) or closed
+                                # externally — stop waiting.
+                                break
+                        if pr_info.mergeable_state not in ("blocked", "behind"):
+                            break
+                finally:
+                    async with self._waiting_lock:
+                        self._waiting_prs.pop(wait_pr_key, None)
 
             # Step 6: Attempt merge
             result.status = MergeStatus.MERGING
@@ -1168,32 +1385,51 @@ class AsyncMergeManager:
                 auto_merge_pending_checks = False
                 if (
                     pr_key in self._auto_merge_enabled
-                    and pr_info.mergeable_state == "blocked"
+                    and pr_info.mergeable_state in ("blocked", "behind")
                     and pr_info.mergeable is True
                     and self.force_level != "all"
                 ):
-                    block_reason: str | None = None
-                    if self._github_client is not None:
-                        try:
-                            block_reason = (
-                                await self._github_client.analyze_block_reason(
-                                    repo_owner,
-                                    repo_name,
-                                    pr_info.number,
-                                    pr_info.head_sha,
+                    if pr_info.mergeable_state == "behind":
+                        # Still behind after rebase polling timed out;
+                        # auto-merge will pick the PR up once GitHub
+                        # finishes the rebase + required checks.
+                        auto_merge_pending_checks = True
+                    else:
+                        block_reason: str | None = None
+                        if self._github_client is not None:
+                            try:
+                                block_reason = (
+                                    await self._github_client.analyze_block_reason(
+                                        repo_owner,
+                                        repo_name,
+                                        pr_info.number,
+                                        pr_info.head_sha,
+                                    )
                                 )
+                            except Exception as exc:
+                                self.log.debug(
+                                    "analyze_block_reason failed for %s: %s",
+                                    pr_key,
+                                    exc,
+                                )
+                        # Treat any pending-checks-style block reason
+                        # as auto-merge eligible. We previously matched
+                        # only the literal substring "pending required
+                        # check", but analyze_block_reason returns a
+                        # range of phrasings (e.g. "required status
+                        # check\u2026 pending") depending on which
+                        # checks are outstanding.
+                        if block_reason is not None:
+                            reason_lower = block_reason.lower()
+                            auto_merge_pending_checks = (
+                                "pending required check" in reason_lower
+                                or (
+                                    "required" in reason_lower
+                                    and "pending" in reason_lower
+                                )
+                                or "pre-commit.ci" in reason_lower
+                                or "waiting for status" in reason_lower
                             )
-                        except Exception as exc:
-                            self.log.debug(
-                                "analyze_block_reason failed for %s: %s",
-                                pr_key,
-                                exc,
-                            )
-                    auto_merge_pending_checks = (
-                        block_reason is not None
-                        and "pending required check"
-                        in block_reason.lower()
-                    )
 
                 if auto_merge_pending_checks:
                     merged = None  # Sentinel: auto-merge pending
@@ -1481,6 +1717,27 @@ class AsyncMergeManager:
                 pr_key,
                 merge_method,
             )
+            # Post a visible audit-trail comment so reviewers can see
+            # at a glance that dependamerge enabled auto-merge on the
+            # PR. Best-effort: a failure here must not abort the
+            # merge flow, since auto-merge itself is already active.
+            audit_comment = (
+                "🤖 dependamerge: auto-merge enabled "
+                f"(method=`{merge_method}`). The PR will merge "
+                "automatically once all required status checks "
+                "pass and branch protection requirements are met."
+            )
+            try:
+                await self._github_client.post_issue_comment(
+                    owner, repo, pr_info.number, audit_comment
+                )
+            except Exception as comment_exc:
+                self.log.debug(
+                    "Failed to post auto-merge audit comment on "
+                    "%s: %s",
+                    pr_key,
+                    comment_exc,
+                )
         return enabled
 
     async def _check_merge_requirements(

--- a/src/dependamerge/merge_manager.py
+++ b/src/dependamerge/merge_manager.py
@@ -860,10 +860,6 @@ class AsyncMergeManager:
             if pr_info.state != "open":
                 result.status = MergeStatus.FAILED
                 result.error = "PR is already closed"
-                # Log warning separately to avoid duplicate console output
-                self.log.warning(
-                    f"PR {pr_info.repository_full_name}#{pr_info.number} is already closed"
-                )
                 self._console.print(f"🛑 Failed: {pr_info.html_url} [already closed]")
                 return result
 
@@ -1031,10 +1027,6 @@ class AsyncMergeManager:
             if not copilot_processing_successful:
                 result.status = MergeStatus.FAILED
                 result.error = "Copilot review processing incomplete - not approving to avoid pollution"
-                # Log error separately to avoid duplicate console output
-                self.log.error(
-                    f"Failed to process PR {pr_info.repository_full_name}#{pr_info.number}: Copilot review processing incomplete"
-                )
                 self._console.print(
                     f"❌ Failed: {pr_info.html_url} [copilot processing incomplete]"
                 )
@@ -1102,7 +1094,7 @@ class AsyncMergeManager:
 
                         # Wait for GitHub to process the update and run checks
                         self._console.print(
-                            "⏳ Auto-merge requested, pending checks after rebase..."
+                            f"⏳ Waiting: {pr_info.html_url}"
                         )
                         await asyncio.sleep(self._merge_recheck_interval)
 
@@ -1146,15 +1138,24 @@ class AsyncMergeManager:
                                     )
                                     await asyncio.sleep(self._merge_recheck_interval)
                                 else:
-                                    self.log.warning(
-                                        "Timeout waiting for status checks to "
-                                        "complete for PR %s#%s. %s",
-                                        pr_info.repository_full_name,
-                                        pr_info.number,
-                                        "Auto-merge is enabled."
-                                        if auto_merge_ok
-                                        else "Proceeding with merge attempt.",
-                                    )
+                                    if auto_merge_ok:
+                                        log_and_print(
+                                            self.log,
+                                            self._console,
+                                            f"⏳ Auto-merge will complete: "
+                                            f"{pr_info.html_url} "
+                                            "[timeout waiting for checks]",
+                                            level="warning",
+                                        )
+                                    else:
+                                        log_and_print(
+                                            self.log,
+                                            self._console,
+                                            f"⚠️ Proceeding without checks: "
+                                            f"{pr_info.html_url} "
+                                            "[timeout waiting for checks]",
+                                            level="warning",
+                                        )
                                     break
                             else:
                                 break
@@ -1182,7 +1183,7 @@ class AsyncMergeManager:
                             log_and_print(
                                 self.log,
                                 self._console,
-                                f"⏳ Rebased: {pr_info.html_url} [waiting for status checks]",
+                                f"⬆️ Rebased: {pr_info.html_url} [waiting for status checks]",
                                 level="debug",
                             )
                         else:
@@ -1199,10 +1200,6 @@ class AsyncMergeManager:
 
                         if self.progress_tracker:
                             self.progress_tracker.merge_failure()
-                        # Log error separately to avoid duplicate console output
-                        self.log.error(
-                            f"Failed to rebase PR {pr_info.repository_full_name}#{pr_info.number}: {e}"
-                        )
                         self._console.print(
                             f"❌ Failed: {pr_info.html_url} [rebase error: {e}]"
                         )
@@ -1237,8 +1234,7 @@ class AsyncMergeManager:
                         log_and_print(
                             self.log,
                             self._console,
-                            f"⏳ Auto-merge enabled, waiting for checks: "
-                            f"{pr_info.html_url}",
+                            f"🤖 Auto-merge: {pr_info.html_url}",
                             level="debug",
                         )
 
@@ -1439,12 +1435,16 @@ class AsyncMergeManager:
                     )
 
                 if merged is None:
-                    # Auto-merge is active — PR will merge asynchronously
+                    # Auto-merge is active — PR will merge asynchronously.
+                    # The enable was already announced earlier ("🤖 Auto-merge:
+                    # <url>" or via the rebase path); use a neutral
+                    # "Waiting" line here to avoid duplicating that
+                    # announcement.
                     result.status = MergeStatus.AUTO_MERGE_PENDING
                     log_and_print(
                         self.log,
                         self._console,
-                        f"⏳ Auto-merge enabled: {pr_info.html_url} [waiting for checks]",
+                        f"⏳ Waiting: {pr_info.html_url} [pending checks]",
                         level="debug",
                     )
                 elif merged:
@@ -1533,10 +1533,6 @@ class AsyncMergeManager:
                         result.error = "Failed to merge after all retry attempts"
                         if self.progress_tracker:
                             self.progress_tracker.merge_failure()
-                        # Log error separately to avoid duplicate console output
-                        self.log.error(
-                            f"Failed to merge PR {pr_info.repository_full_name}#{pr_info.number}: {failure_reason}"
-                        )
                         self._console.print(
                             f"❌ Failed: {pr_info.html_url} [{failure_reason}]"
                         )
@@ -1550,10 +1546,6 @@ class AsyncMergeManager:
 
             # Extract operation-specific error message
             operation_desc = e.operation.replace("_", " ")
-            # Log error separately to avoid duplicate console output
-            self.log.error(
-                f"Failed to process PR {pr_info.repository_full_name}#{pr_info.number}: Permission denied for {operation_desc}"
-            )
             self._console.print(
                 f"❌ Failed: {pr_info.html_url} [permission denied: {operation_desc}]"
             )
@@ -1576,9 +1568,6 @@ class AsyncMergeManager:
                     self._console.print(f"   • {e.token_type_guidance['fix']}")
 
             self._console.print()
-            self.log.error(
-                f"Permission error processing PR {pr_info.repository_full_name}#{pr_info.number}: {e}"
-            )
 
         except Exception as e:
             result.status = MergeStatus.FAILED
@@ -1587,11 +1576,9 @@ class AsyncMergeManager:
                 self.progress_tracker.merge_failure()
 
             # Provide clean single-line error messages for other errors
-            # Log error separately to avoid duplicate console output
-            self.log.error(
-                f"Failed to process PR {pr_info.repository_full_name}#{pr_info.number}: {e}"
+            self._console.print(
+                f"❌ Failed: {pr_info.html_url} [processing error: {e}]"
             )
-            self._console.print(f"❌ Failed: {pr_info.html_url} [processing error]")
 
         finally:
             result.duration = time.time() - start_time
@@ -1666,6 +1653,61 @@ class AsyncMergeManager:
                 return True
         return False
 
+    async def _post_pr_comment_with_retry(
+        self,
+        owner: str,
+        repo: str,
+        pr_number: int,
+        html_url: str,
+        body: str,
+    ) -> bool:
+        """Post a PR comment with one retry after a 5s pause.
+
+        Used for audit-trail comments (approval, auto-merge enable)
+        that should be visible on the PR. If both attempts fail,
+        emit a single user-visible warning to the console rather
+        than silently failing.
+
+        Args:
+            owner: Repository owner.
+            repo: Repository name.
+            pr_number: Pull request number.
+            html_url: Full PR URL, used for the warning message.
+            body: Markdown body of the comment.
+
+        Returns:
+            True if the comment posted successfully (first or
+            second attempt), False otherwise.
+        """
+        if not self._github_client:
+            return False
+
+        for attempt in (1, 2):
+            try:
+                await self._github_client.post_issue_comment(
+                    owner, repo, pr_number, body
+                )
+                return True
+            except Exception as exc:
+                self.log.debug(
+                    "Audit comment post attempt %d failed for %s: %s",
+                    attempt,
+                    html_url,
+                    exc,
+                )
+                if attempt == 1:
+                    await asyncio.sleep(5.0)
+
+        # Both attempts failed — surface a single line so the
+        # user knows the PR-side audit trail is incomplete.
+        try:
+            self._console.print(
+                f"⚠️ Unable to add pull request comment: {html_url}"
+            )
+        except Exception:
+            pass
+        return False
+
     async def _enable_auto_merge_for_pr(
         self, pr_info: PullRequestInfo, owner: str, repo: str
     ) -> bool:
@@ -1717,27 +1759,16 @@ class AsyncMergeManager:
                 pr_key,
                 merge_method,
             )
-            # Post a visible audit-trail comment so reviewers can see
-            # at a glance that dependamerge enabled auto-merge on the
-            # PR. Best-effort: a failure here must not abort the
-            # merge flow, since auto-merge itself is already active.
+            # Post a visible audit-trail comment so reviewers can
+            # see at a glance that dependamerge enabled auto-merge
+            # on the PR.
             audit_comment = (
-                "🤖 dependamerge: auto-merge enabled "
-                f"(method=`{merge_method}`). The PR will merge "
-                "automatically once all required status checks "
-                "pass and branch protection requirements are met."
+                "🤖 Dependamerge\n"
+                "Enabled auto-merge due to pending updates/checks ⏳"
             )
-            try:
-                await self._github_client.post_issue_comment(
-                    owner, repo, pr_info.number, audit_comment
-                )
-            except Exception as comment_exc:
-                self.log.debug(
-                    "Failed to post auto-merge audit comment on "
-                    "%s: %s",
-                    pr_key,
-                    comment_exc,
-                )
+            await self._post_pr_comment_with_retry(
+                owner, repo, pr_info.number, pr_info.html_url, audit_comment
+            )
         return enabled
 
     async def _check_merge_requirements(
@@ -1990,7 +2021,8 @@ class AsyncMergeManager:
         log_and_print(
             self.log,
             self._console,
-            f"⏳ Triggering pre-commit.ci re-run for {pr_info.repository_full_name}#{pr_info.number} [status never reported]",
+            f"⏳ Triggering pre-commit.ci re-run: {pr_info.html_url} "
+            "[status never reported]",
             level="info",
         )
 
@@ -2027,7 +2059,7 @@ class AsyncMergeManager:
                             log_and_print(
                                 self.log,
                                 self._console,
-                                f"✅ pre-commit.ci passed for {pr_info.repository_full_name}#{pr_info.number}",
+                                f"✅ pre-commit.ci passed: {pr_info.html_url}",
                                 level="info",
                             )
                             return True
@@ -2035,7 +2067,7 @@ class AsyncMergeManager:
                             log_and_print(
                                 self.log,
                                 self._console,
-                                f"❌ pre-commit.ci failed for {pr_info.repository_full_name}#{pr_info.number}",
+                                f"❌ pre-commit.ci failed: {pr_info.html_url}",
                                 level="warning",
                             )
                             return False
@@ -2170,7 +2202,7 @@ class AsyncMergeManager:
         log_and_print(
             self.log,
             self._console,
-            f"🔄 Requesting dependabot recreate for {pr_info.repository_full_name}#{pr_info.number} "
+            f"🔄 Requesting dependabot recreate: {pr_info.html_url} "
             f"[unverified commits: {', '.join(unverified_shas)}]",
             level="info",
         )
@@ -2209,8 +2241,9 @@ class AsyncMergeManager:
                             log_and_print(
                                 self.log,
                                 self._console,
-                                f"✅ Old PR {pr_info.repository_full_name}#{pr_info.number} "
-                                f"closed by dependabot ({(attempt + 1) * self._merge_recheck_interval:.0f}s elapsed)",
+                                f"✅ Old PR closed by dependabot: "
+                                f"{pr_info.html_url} "
+                                f"({(attempt + 1) * self._merge_recheck_interval:.0f}s elapsed)",
                                 level="info",
                             )
                 except Exception as e:
@@ -2319,7 +2352,7 @@ class AsyncMergeManager:
         log_and_print(
             self.log,
             self._console,
-            f"🔍 Found recreated PR {full_name}#{new_number}, waiting for checks...",
+            f"🔍 Found recreated PR, waiting for checks: {html_url}",
             level="info",
         )
 
@@ -2367,7 +2400,7 @@ class AsyncMergeManager:
                     log_and_print(
                         self.log,
                         self._console,
-                        f"✅ Recreated PR {full_name}#{new_number} is ready to merge",
+                        f"✅ Recreated PR is ready to merge: {html_url}",
                         level="info",
                     )
                     # Build a PullRequestInfo for the new PR
@@ -2524,7 +2557,10 @@ class AsyncMergeManager:
                             return False
 
             await self._github_client.approve_pull_request(
-                owner, repo, pr_number, "Auto-approved by dependamerge"
+                owner,
+                repo,
+                pr_number,
+                "🤖 Dependamerge\nApproved this pull request ✅",
             )
             return True
         except Exception as e:

--- a/src/dependamerge/merge_manager.py
+++ b/src/dependamerge/merge_manager.py
@@ -1304,9 +1304,10 @@ class AsyncMergeManager:
                         return result
 
             # Step 5.5: If the PR is still blocked (e.g. by a pending
-            # required status check such as pre-commit.ci) or behind
-            # base branch, enable auto-merge and wait for required
-            # checks to complete. Skipped when:
+            # required status check such as pre-commit.ci), behind
+            # base branch, or unstable (a non-required check failed),
+            # enable auto-merge and wait for required checks to
+            # complete. Skipped when:
             #   * preview_mode (no side effects)
             #   * force_level == "all" (force semantics bypass wait)
             #   * Step 5 already ran a rebase + wait for this PR
@@ -1326,6 +1327,15 @@ class AsyncMergeManager:
             # window after Dependabot/pre-commit-ci rebase a PR where
             # GitHub still reports ``behind`` while it recomputes
             # mergeability.
+            #
+            # We accept any ``mergeable`` value (including ``False``)
+            # when the state is one of these auto-merge-rescuable
+            # states, because GitHub returns ``mergeable=False``
+            # transiently while computing the value or when a
+            # non-required check failed. The block-reason pre-check
+            # below still weeds out genuinely-stuck cases (missing
+            # approvals, etc.) so we don't burn ``merge_timeout`` on
+            # them.
             pr_key_for_wait = (
                 f"{repo_owner}/{repo_name}#{pr_info.number}"
             )
@@ -1333,14 +1343,7 @@ class AsyncMergeManager:
             base_should_wait = (
                 not self.preview_mode
                 and self._github_client is not None
-                # Treat ``mergeable is None`` as 'still computing'
-                # rather than 'not mergeable'. GitHub returns ``null``
-                # transiently while computing mergeability; we only
-                # want to exclude the explicit ``False`` case here so
-                # PRs blocked by pending checks aren't misrouted to
-                # the manual-merge fall-through.
-                and pr_info.mergeable is not False
-                and pr_info.mergeable_state in ("blocked", "behind")
+                and pr_info.mergeable_state in ("blocked", "behind", "unstable")
                 and self.force_level != "all"
                 and not already_rebased
             )
@@ -1484,10 +1487,10 @@ class AsyncMergeManager:
                                 # ``mergeable_state`` for the same
                                 # reason as ``mergeable`` above. The
                                 # subsequent ``not in ("blocked",
-                                # "behind")`` check would otherwise
-                                # break the wait loop early on a
-                                # transient ``null`` returned while
-                                # GitHub is still computing.
+                                # "behind", "unstable")`` check would
+                                # otherwise break the wait loop early
+                                # on a transient ``null`` returned
+                                # while GitHub is still computing.
                                 refreshed_state = refreshed_wait.get(
                                     "mergeable_state"
                                 )
@@ -1514,7 +1517,20 @@ class AsyncMergeManager:
                                 )
                                 pr_info.state = "closed"
                                 break
-                        if pr_info.mergeable_state not in ("blocked", "behind"):
+                        # Continue waiting only while the PR is in a
+                        # state that auto-merge can still rescue. The
+                        # set must mirror the ``base_should_wait``
+                        # entry condition above (blocked / behind /
+                        # unstable); any other value means the PR has
+                        # either become mergeable, has been closed,
+                        # or has hit a state Step 5.5 cannot help
+                        # with, so we should exit the wait loop and
+                        # let downstream steps decide.
+                        if pr_info.mergeable_state not in (
+                            "blocked",
+                            "behind",
+                            "unstable",
+                        ):
                             break
                 finally:
                     async with self._waiting_lock:
@@ -1601,51 +1617,56 @@ class AsyncMergeManager:
                         f"Merging PR {pr_info.number} in {pr_info.repository_full_name}"
                     )
 
-                # If auto-merge is enabled and the PR is blocked
-                # *specifically* by pending required checks, skip
-                # the manual merge attempt — GitHub will merge
-                # automatically once those checks complete.
+                # If auto-merge is enabled and the PR is in a state
+                # that auto-merge can rescue (blocked, behind, or
+                # unstable), skip the manual merge attempt — GitHub
+                # will merge automatically once branch protection is
+                # satisfied.
                 #
-                # The ``mergeable_state == "blocked"`` +
-                # ``mergeable is True`` combination is necessary
-                # but not sufficient: the same combination also
-                # applies when the block reason is "requires
-                # approval" or similar branch-protection rules
-                # that auto-merge cannot satisfy on its own.
-                # Consult ``analyze_block_reason()`` so we only
-                # skip when the reason mentions pending required
-                # checks.
+                # We accept any ``mergeable`` value (including
+                # ``False``) here for the same reason Step 5.5 does:
+                # ``mergeable=False`` from the API can mean
+                # "definitely failing", "still computing", or "a
+                # non-required check failed". Letting auto-merge
+                # decide whether the failing thing actually blocks
+                # merge is more accurate than us treating
+                # ``False`` as terminal here.
+                #
+                # For ``blocked`` PRs we still consult
+                # ``analyze_block_reason()`` to weed out cases
+                # auto-merge cannot resolve (missing approvals,
+                # code-owner reviews, etc.). For ``behind`` and
+                # ``unstable`` we accept directly: ``behind``
+                # resolves once GitHub re-runs checks against the
+                # rebased commit, and ``unstable`` means a
+                # non-required check failed (which doesn't actually
+                # block auto-merge).
                 #
                 # Do NOT skip when:
-                #   * mergeable is False (blocked by failing
-                #     checks) — the user may want a forced
-                #     manual attempt to surface the failure.
                 #   * force_level == "all" — force semantics
-                #     intentionally proceed despite blocked
+                #     intentionally proceed despite the blocked
                 #     state and must not be overridden by
                 #     auto-merge.
-                #   * the block reason is something other than
-                #     pending required checks (for example,
-                #     missing approvals or other branch
-                #     protection requirements).
+                #   * the block reason (for ``blocked`` PRs) is
+                #     something other than pending required
+                #     checks (e.g. missing approvals).
                 pr_key = f"{repo_owner}/{repo_name}#{pr_info.number}"
                 auto_merge_pending_checks = False
                 if (
                     pr_key in self._auto_merge_enabled
-                    and pr_info.mergeable_state in ("blocked", "behind")
-                    # Same rationale as Step 5.5: treat
-                    # ``mergeable is None`` as still-computing so
-                    # we don't bypass the auto-merge skip gate on
-                    # a transient null. Only the explicit ``False``
-                    # case (blocked by failing checks) should fall
-                    # through to the manual merge attempt.
-                    and pr_info.mergeable is not False
+                    and pr_info.mergeable_state
+                    in ("blocked", "behind", "unstable")
                     and self.force_level != "all"
                 ):
-                    if pr_info.mergeable_state == "behind":
-                        # Still behind after rebase polling timed out;
-                        # auto-merge will pick the PR up once GitHub
-                        # finishes the rebase + required checks.
+                    if pr_info.mergeable_state in ("behind", "unstable"):
+                        # ``behind``: still behind after rebase polling
+                        # timed out; auto-merge will pick the PR up
+                        # once GitHub finishes rebase + required
+                        # checks.
+                        # ``unstable``: a non-required check failed but
+                        # required checks may still be pending or
+                        # passing; auto-merge will fire when branch
+                        # protection allows.
                         auto_merge_pending_checks = True
                     else:
                         block_reason: str | None = None
@@ -1670,7 +1691,7 @@ class AsyncMergeManager:
                         # only the literal substring "pending required
                         # check", but analyze_block_reason returns a
                         # range of phrasings (e.g. "required status
-                        # check\u2026 pending") depending on which
+                        # check… pending") depending on which
                         # checks are outstanding. The same predicate is
                         # used by the Step 5.5 pre-check.
                         auto_merge_pending_checks = (
@@ -1691,12 +1712,26 @@ class AsyncMergeManager:
                     # The enable was already announced earlier ("🤖 Auto-merge:
                     # <url>" or via the rebase path); use a neutral
                     # "Waiting" line here to avoid duplicating that
-                    # announcement.
+                    # announcement. Tailor the bracketed reason to
+                    # the actual ``mergeable_state`` so users see
+                    # what auto-merge is waiting on, rather than
+                    # always reporting "pending checks".
                     result.status = MergeStatus.AUTO_MERGE_PENDING
+                    if pr_info.mergeable_state == "behind":
+                        wait_reason = "behind base branch"
+                    elif pr_info.mergeable_state == "unstable":
+                        wait_reason = "non-required check failure"
+                    else:
+                        # ``blocked`` (the only other state that
+                        # reaches this branch) routed through
+                        # ``analyze_block_reason()`` and was
+                        # classified as pending required checks by
+                        # ``_block_reason_indicates_pending_checks``.
+                        wait_reason = "pending checks"
                     log_and_print(
                         self.log,
                         self._console,
-                        f"⏳ Waiting: {pr_info.html_url} [pending checks]",
+                        f"⏳ Waiting: {pr_info.html_url} [{wait_reason}]",
                         level="debug",
                     )
                 elif merged:
@@ -1862,6 +1897,20 @@ class AsyncMergeManager:
         Centralising the predicate here keeps the two call sites
         consistent so a new phrasing only has to be added once.
 
+        The predicate matches **only** wording that explicitly
+        signals a check is still in progress / waiting to start.
+        It deliberately excludes:
+
+        - ``Blocked by failing check: …`` — the check has run and
+          reported a non-pending failure; auto-merge will not
+          rescue this.
+        - ``Blocked by missing required status: …`` — the check
+          has not been registered against the commit at all;
+          auto-merge will not retry it on its own.
+        - any reason where ``failing`` or ``missing`` appears
+          before a service name (defensive: covers future GitHub
+          phrasing changes that include both keywords).
+
         Args:
             block_reason: The string returned by
                 ``analyze_block_reason()``, or ``None`` if the
@@ -1875,57 +1924,85 @@ class AsyncMergeManager:
         if block_reason is None:
             return False
         reason_lower = block_reason.lower()
+
+        # Defensive negative gate: never classify a reason as
+        # 'pending' if it explicitly says the check has failed or
+        # is missing. This guards the bare-substring matches
+        # below against future phrasings that combine both terms
+        # (e.g. "failing check (pending retry): pre-commit.ci").
+        if "failing check" in reason_lower:
+            return False
+        if "missing required status" in reason_lower:
+            return False
+        if "missing required check" in reason_lower:
+            return False
+
         return (
             "pending required check" in reason_lower
             or ("required" in reason_lower and "pending" in reason_lower)
-            or "pre-commit.ci" in reason_lower
             or "waiting for status" in reason_lower
+            or "queued" in reason_lower
         )
 
     def _is_pr_mergeable(self, pr_info: PullRequestInfo) -> bool:
+        """Check whether a PR is worth attempting to merge.
+
+        This returns ``True`` for any state where dependamerge can
+        plausibly make progress — either by approving + merging,
+        rebasing, or enabling auto-merge and waiting (Step 5.5).
+        We deliberately err on the side of letting Step 5.5 see the
+        PR: it has finer-grained logic (block-reason analysis,
+        merge-timeout-bounded waits) than this gate, so a False here
+        denies a PR the chance to be auto-merge-rescued.
+
+        Returns False only for states where no amount of waiting,
+        approving, or auto-merging can help:
+
+        - ``dirty``: real merge conflict; the branch must be
+          rebased by a human (or by ``--fix``).
+        - ``draft``: GitHub blocks merging draft PRs by design.
+
+        For all other states (``blocked``, ``behind``, ``unstable``,
+        empty/``"unknown"``) we return True regardless of the
+        ``mergeable`` boolean. ``mergeable=False`` from the API can
+        mean "definitely failing", but it can also mean "GitHub is
+        still computing" or "a non-required check failed" — the
+        downstream Step 5.5 + Step 6 gates have the context to make
+        the right call.
         """
-        Check if a PR is mergeable.
-
-        Args:
-            pr_info: Pull request information
-
-        Returns:
-            True if the PR can be merged, False otherwise
-        """
-        # Handle different types of blocks intelligently - matches original logic
-        if pr_info.mergeable_state == "blocked" and pr_info.mergeable is True:
-            # This is blocked by branch protection but tool can handle it (approval, etc.)
-            return True
-        elif pr_info.mergeable_state == "blocked" and pr_info.mergeable is False:
-            # Blocked by failing checks - we can try merging anyway
-            return True
-        elif pr_info.mergeable is False:
-            # Only skip if mergeable is explicitly False (not None/UNKNOWN)
-            # Use appropriate icon based on state - only truly unmergeable PRs get blocked
-            if pr_info.mergeable_state == "dirty" or (
-                pr_info.mergeable_state == "behind" and pr_info.mergeable is False
-            ):
-                icon = "🛑"
-                action = "Blocking"
-            else:
-                icon = "⏭️"
-                action = "Skipping"
-
-            # Just log internally, don't show verbose messages
-            skip_msg = f"{icon}  {action} unmergeable PR {pr_info.number} in {pr_info.repository_full_name} (mergeable: {pr_info.mergeable}, state: {pr_info.mergeable_state})"
-            self.log.debug(skip_msg)
-            return False
-        elif pr_info.mergeable is None:
-            # Handle UNKNOWN mergeable state - treat as potentially mergeable
-            # GitHub is still calculating mergeable state, but we can attempt merge
+        # Hard skips: states where merging is impossible regardless
+        # of mergeable value or downstream rescue logic.
+        if pr_info.mergeable_state == "dirty":
             self.log.debug(
-                f"ℹ️ PR {pr_info.number} in {pr_info.repository_full_name} has unknown mergeable state - treating as potentially mergeable"
+                "🛑 Skipping PR %s/%s#%s: merge conflict (dirty)",
+                pr_info.repository_full_name.split("/", 1)[0]
+                if "/" in pr_info.repository_full_name
+                else pr_info.repository_full_name,
+                pr_info.repository_full_name.split("/", 1)[-1],
+                pr_info.number,
             )
-            return True
+            return False
+        if pr_info.mergeable_state == "draft":
+            self.log.debug(
+                "⏭️ Skipping draft PR %s#%s",
+                pr_info.repository_full_name,
+                pr_info.number,
+            )
+            return False
 
-        # All other cases are considered mergeable
+        # Everything else — ``blocked``, ``behind``, ``unstable``,
+        # ``clean``, empty/None state, plus any ``mergeable`` value
+        # — reaches the merge flow. Step 5.5 will route
+        # not-yet-merge-ready cases to AUTO_MERGE_PENDING after
+        # consulting block-reason analysis and bounded by
+        # ``merge_timeout``, which is a much friendlier outcome than
+        # a hard skip from here.
         self.log.debug(
-            f"✅ PR {pr_info.number} in {pr_info.repository_full_name} is considered mergeable (mergeable: {pr_info.mergeable}, state: {pr_info.mergeable_state})"
+            "✅ PR %s#%s eligible for merge flow (mergeable=%s, state=%s)",
+            pr_info.repository_full_name,
+            pr_info.number,
+            pr_info.mergeable,
+            pr_info.mergeable_state,
         )
         return True
 
@@ -2317,7 +2394,20 @@ class AsyncMergeManager:
                         )
                     return True, "PR blocked but forcing merge attempt (--force=all)"
                 else:
-                    return False, "blocked by failing status checks"
+                    # Don't hard-fail here: let Step 5.5 enable
+                    # auto-merge and route to AUTO_MERGE_PENDING.
+                    # The block reason might be "failing required
+                    # check" right now but the check could still
+                    # complete successfully — GitHub returns
+                    # ``mergeable=False`` transiently for several
+                    # reasons (still computing, non-required check
+                    # failed). Step 5.5's analyze_block_reason
+                    # pre-check still weeds out genuinely-stuck
+                    # cases (missing approvals, etc.).
+                    return (
+                        True,
+                        "PR blocked — Step 5.5 will enable auto-merge",
+                    )
         elif pr_info.mergeable_state == "behind":
             if not self.fix_out_of_date:
                 if self.force_level == "all":
@@ -2326,9 +2416,27 @@ class AsyncMergeManager:
                     )
                     return True, "PR behind but forcing merge attempt (--force=all)"
                 else:
-                    return False, "PR is behind base branch and --no-fix option is set"
+                    # Don't hard-fail when behind + --no-fix: the
+                    # user opted out of *us* rebasing the branch,
+                    # but enabling auto-merge in Step 5.5 is a
+                    # separate, non-rewriting operation. If a third
+                    # party (Dependabot, pre-commit-ci) rebases the
+                    # PR while we wait, auto-merge will fire.
+                    return (
+                        True,
+                        "PR behind — Step 5.5 will enable auto-merge",
+                    )
             else:
                 return True, "PR is behind - will rebase before merge"
+        elif pr_info.mergeable_state == "unstable":
+            # ``unstable`` means a non-required check failed but
+            # the PR is otherwise mergeable. Auto-merge can still
+            # fire because non-required checks don't block branch
+            # protection. Let Step 5.5 handle it.
+            return (
+                True,
+                "PR unstable — Step 5.5 will enable auto-merge",
+            )
         elif pr_info.mergeable_state == "dirty":
             if self.force_level == "all":
                 self.log.warning(

--- a/src/dependamerge/merge_manager.py
+++ b/src/dependamerge/merge_manager.py
@@ -177,6 +177,13 @@ class AsyncMergeManager:
         # post-timeout merge attempts can be skipped gracefully.
         self._auto_merge_enabled: set[str] = set()
 
+        # Track PRs that have already gone through Step 5's
+        # rebase + poll path so Step 5.5 can skip them and avoid
+        # doubling the configured ``merge_timeout``. Set after
+        # Step 5 completes its wait, regardless of whether the
+        # final state is ``clean``, ``blocked``, or ``behind``.
+        self._rebased_prs: set[str] = set()
+
         # Track PRs currently waiting for required checks to complete.
         # Maps ``pr_key`` -> deadline (monotonic seconds) so the
         # parallel merge ticker can render an aggregate countdown
@@ -283,9 +290,9 @@ class AsyncMergeManager:
         # uses the worst-case (latest) deadline across all waiting
         # PRs so the user sees the longest remaining wait.
         ticker_task = asyncio.create_task(
-                self._wait_status_ticker(),
-                name="merge-wait-ticker",
-            )
+            self._wait_status_ticker(),
+            name="merge-wait-ticker",
+        )
 
         try:
             # Wait for all tasks to complete
@@ -294,8 +301,19 @@ class AsyncMergeManager:
             ticker_task.cancel()
             try:
                 await ticker_task
-            except (asyncio.CancelledError, Exception):
+            except asyncio.CancelledError:
+                # Expected during normal shutdown.
                 pass
+            except Exception as ticker_exc:
+                # Unexpected: log so we can debug ticker crashes
+                # without swallowing them silently. The merge run
+                # itself has already completed at this point, so
+                # we still continue to results processing.
+                self.log.warning(
+                    "wait-status ticker exited unexpectedly: %s",
+                    ticker_exc,
+                    exc_info=True,
+                )
 
         # Process results and handle exceptions
         final_results: list[MergeResult] = []
@@ -356,10 +374,27 @@ class AsyncMergeManager:
         all waiting PRs so the displayed value reflects the longest
         remaining wait, not an arbitrary one. When no PRs are
         waiting, the message is cleared.
+
+        When the progress tracker is in non-Rich (fallback) mode,
+        the per-update line would print to stdout, which would spam
+        logs every second. In that case we delegate to the plain
+        ticker (15s cadence) instead.
         """
         if not self.progress_tracker:
             # Fallback: emit a periodic plain console line so the
             # user still gets feedback even without Rich progress.
+            await self._wait_status_ticker_plain()
+            return
+
+        # If the tracker exists but Rich is unavailable (non-TTY,
+        # no Rich library, etc.), it falls back to per-update
+        # ``print()`` calls. Updating every second would spam the
+        # user's terminal/logs, so use the slower plain ticker
+        # cadence instead.
+        rich_available = bool(
+            getattr(self.progress_tracker, "rich_available", False)
+        )
+        if not rich_available:
             await self._wait_status_ticker_plain()
             return
 
@@ -370,7 +405,7 @@ class AsyncMergeManager:
                     snapshot = dict(self._waiting_prs)
 
                 if snapshot:
-                    now = asyncio.get_event_loop().time()
+                    now = asyncio.get_running_loop().time()
                     remaining = max(
                         0.0,
                         max(snapshot.values()) - now,
@@ -419,7 +454,7 @@ class AsyncMergeManager:
                     snapshot = dict(self._waiting_prs)
 
                 if snapshot:
-                    now = asyncio.get_event_loop().time()
+                    now = asyncio.get_running_loop().time()
                     if now - last_emit >= 15.0:
                         remaining = max(
                             0.0, max(snapshot.values()) - now
@@ -1113,6 +1148,17 @@ class AsyncMergeManager:
                                 updated_mergeable_state = updated_pr_data.get(
                                     "mergeable_state"
                                 )
+                                # Capture the new head SHA so later
+                                # block-reason analysis queries the
+                                # rebased commit, not the pre-rebase
+                                # one. update_branch() advances
+                                # head.sha, and analyze_block_reason()
+                                # uses head_sha to query check runs.
+                                updated_head = (
+                                    updated_pr_data.get("head") or {}
+                                ).get("sha")
+                                if updated_head:
+                                    pr_info.head_sha = updated_head
                             else:
                                 updated_mergeable = None
                                 updated_mergeable_state = None
@@ -1157,12 +1203,64 @@ class AsyncMergeManager:
                                             level="warning",
                                         )
                                     break
+                            elif updated_mergeable_state is None:
+                                # GitHub is still computing mergeability
+                                # (typically right after update_branch).
+                                # Treat as transient and keep polling
+                                # until the deadline or a concrete state
+                                # arrives — breaking here would otherwise
+                                # exit prematurely and (if auto-merge
+                                # enablement failed) fall through to a
+                                # manual merge attempt against the
+                                # still-resolving PR state.
+                                if check_attempt < self._merge_poll_max_attempts - 1:
+                                    self.log.debug(
+                                        "PR mergeable_state still computing "
+                                        "after rebase, waiting... "
+                                        "(attempt %d/%d)",
+                                        check_attempt + 1,
+                                        self._merge_poll_max_attempts,
+                                    )
+                                    await asyncio.sleep(self._merge_recheck_interval)
+                                else:
+                                    break
                             else:
                                 break
 
-                        # Update our PR info with the latest state
-                        pr_info.mergeable = updated_mergeable
-                        pr_info.mergeable_state = updated_mergeable_state
+                        # Update our PR info with the latest state.
+                        # Preserve the previous non-None mergeable
+                        # value when the refresh returns ``null``
+                        # (GitHub is still computing). The Step 6
+                        # auto-merge skip gate now accepts both
+                        # ``True`` and ``None`` (it excludes only
+                        # the explicit ``False`` case), so a
+                        # transient null no longer blocks the
+                        # auto-merge path on its own. We still
+                        # preserve the prior known ``True`` here
+                        # so downstream logging and any future
+                        # tightening of that predicate get an
+                        # accurate state to work with.
+                        if updated_mergeable is not None:
+                            pr_info.mergeable = updated_mergeable
+                        # Preserve the previous non-None mergeable_state
+                        # for the same reason as ``mergeable`` above:
+                        # GitHub returns ``null`` while still computing,
+                        # and the post-rebase reporting / Step 5.5 logic
+                        # branches on this value (e.g. "clean" vs
+                        # "blocked" vs "behind"). A transient ``None``
+                        # would otherwise be classified as the catch-all
+                        # "other state" branch.
+                        if updated_mergeable_state is not None:
+                            pr_info.mergeable_state = updated_mergeable_state
+
+                        # Mark this PR as having gone through the
+                        # Step 5 rebase + poll path. Step 5.5 will
+                        # consult ``_rebased_prs`` to avoid doubling
+                        # the merge_timeout when the rebase exits
+                        # in ``blocked`` or ``behind`` state.
+                        self._rebased_prs.add(
+                            f"{repo_owner}/{repo_name}#{pr_info.number}"
+                        )
 
                         # Report post-rebase status
                         if pr_info.mergeable_state == "clean":
@@ -1207,25 +1305,94 @@ class AsyncMergeManager:
 
             # Step 5.5: If the PR is still blocked (e.g. by a pending
             # required status check such as pre-commit.ci) or behind
-            # base branch after rebase, enable auto-merge and wait
-            # the configured merge timeout for required checks to
-            # complete. This must run for any PR that did NOT enter
-            # Step 5's rebase branch — without this, blocked PRs fall
-            # straight through to a manual merge attempt that 405's
-            # while pre-commit.ci is still pending.
-            #
-            # Skip in preview mode (no side effects) and when force=all
-            # (force semantics intentionally bypass the wait).
-            if (
+            # base branch, enable auto-merge and wait for required
+            # checks to complete. Skipped when:
+            #   * preview_mode (no side effects)
+            #   * force_level == "all" (force semantics bypass wait)
+            #   * Step 5 already ran a rebase + wait for this PR
+            #     (avoid doubling the configured merge_timeout)
+            #   * mergeable_state == "behind" but fix_out_of_date is
+            #     False — auto-merge cannot rebase, so waiting would
+            #     be futile and would mask the user's --no-fix intent
+            #   * mergeable_state == "blocked" for a reason that
+            #     cannot resolve on its own (e.g. "requires approval",
+            #     missing code-owner reviews) — waiting would just
+            #     delay the inevitable failure/merge by up to
+            #     merge_timeout. Pending required checks and behind
+            #     PRs DO benefit from waiting.
+            pr_key_for_wait = (
+                f"{repo_owner}/{repo_name}#{pr_info.number}"
+            )
+            already_rebased = pr_key_for_wait in self._rebased_prs
+            base_should_wait = (
                 not self.preview_mode
                 and self._github_client is not None
-                and pr_info.mergeable is True
+                # Treat ``mergeable is None`` as 'still computing'
+                # rather than 'not mergeable'. GitHub returns ``null``
+                # transiently while computing mergeability; we only
+                # want to exclude the explicit ``False`` case here so
+                # PRs blocked by pending checks aren't misrouted to
+                # the manual-merge fall-through.
+                and pr_info.mergeable is not False
                 and pr_info.mergeable_state in ("blocked", "behind")
                 and self.force_level != "all"
-            ):
-                pr_key_for_wait = (
-                    f"{repo_owner}/{repo_name}#{pr_info.number}"
+                and not already_rebased
+                and not (
+                    pr_info.mergeable_state == "behind"
+                    and not self.fix_out_of_date
                 )
+            )
+
+            # For ``blocked`` PRs (but not ``behind``, which only
+            # needs a rebase to clear), consult analyze_block_reason
+            # before entering the wait loop so we don't burn the
+            # full merge_timeout on PRs blocked for reasons that
+            # cannot resolve on their own.
+            should_wait = base_should_wait
+            if (
+                base_should_wait
+                and pr_info.mergeable_state == "blocked"
+                and self._github_client is not None
+            ):
+                try:
+                    pre_block_reason = (
+                        await self._github_client.analyze_block_reason(
+                            repo_owner,
+                            repo_name,
+                            pr_info.number,
+                            pr_info.head_sha,
+                        )
+                    )
+                except Exception as exc:
+                    self.log.debug(
+                        "analyze_block_reason failed for %s during "
+                        "Step 5.5 pre-check: %s",
+                        pr_key_for_wait,
+                        exc,
+                    )
+                    # Treat analysis failures as 'do not wait' so we
+                    # don't burn the full ``merge_timeout`` on a PR
+                    # whose block reason we cannot classify. The PR
+                    # will fall through to the Step 6 skip gate (which
+                    # also calls ``analyze_block_reason``) and either
+                    # defer to auto-merge or surface a manual-merge
+                    # error promptly.
+                    pre_block_reason = None
+                    should_wait = False
+
+                if should_wait and pre_block_reason is not None:
+                    if not self._block_reason_indicates_pending_checks(
+                        pre_block_reason
+                    ):
+                        self.log.debug(
+                            "Skipping Step 5.5 wait for %s: block "
+                            "reason '%s' will not resolve on its own",
+                            pr_key_for_wait,
+                            pre_block_reason,
+                        )
+                        should_wait = False
+
+            if should_wait:
                 if pr_key_for_wait not in self._auto_merge_enabled:
                     auto_ok_pre = await self._enable_auto_merge_for_pr(
                         pr_info, repo_owner, repo_name
@@ -1238,29 +1405,46 @@ class AsyncMergeManager:
                             level="debug",
                         )
 
-                # Poll for state to become "clean" before attempting
-                # the manual merge. If the timeout elapses while still
-                # blocked/behind, the auto-merge skip gate below will
-                # route this PR to AUTO_MERGE_PENDING so GitHub can
-                # complete the merge asynchronously.
-                wait_pr_key = (
-                    f"{repo_owner}/{repo_name}#{pr_info.number}"
-                )
+                # Drive the wait loop directly off a monotonic
+                # deadline so the total wait is bounded by
+                # ``merge_timeout`` even if a single iteration
+                # over-sleeps slightly.
                 wait_deadline = (
-                    asyncio.get_event_loop().time()
+                    asyncio.get_running_loop().time()
                     + self._merge_timeout
                 )
+                # Local alias so the type checker can narrow
+                # ``self._github_client`` across the await boundary.
+                wait_client = self._github_client
+                assert wait_client is not None
                 async with self._waiting_lock:
-                    self._waiting_prs[wait_pr_key] = wait_deadline
+                    self._waiting_prs[pr_key_for_wait] = wait_deadline
+                # Track whether the PR was closed during the wait
+                # and, if so, whether it was actually merged. The
+                # REST PR payload includes a ``merged`` boolean that
+                # distinguishes auto-merge success from
+                # closed-without-merge (the user closed the PR
+                # while we were waiting, dependabot superseded it,
+                # etc.).
+                closed_during_wait = False
+                merged_during_wait = False
                 try:
-                    for _wait_attempt in range(
-                        self._merge_poll_max_attempts
+                    while (
+                        asyncio.get_running_loop().time() < wait_deadline
                     ):
                         if pr_info.mergeable_state == "clean":
                             break
-                        await asyncio.sleep(self._merge_recheck_interval)
+                        # Sleep no longer than the time remaining
+                        # so we don't overshoot ``wait_deadline``.
+                        remaining = (
+                            wait_deadline
+                            - asyncio.get_running_loop().time()
+                        )
+                        await asyncio.sleep(
+                            min(self._merge_recheck_interval, remaining)
+                        )
                         try:
-                            refreshed_wait = await self._github_client.get(
+                            refreshed_wait = await wait_client.get(
                                 f"/repos/{repo_owner}/{repo_name}/pulls/"
                                 f"{pr_info.number}"
                             )
@@ -1277,24 +1461,89 @@ class AsyncMergeManager:
                         if isinstance(refreshed_wait, dict):
                             # Only overwrite when the keys are present, so a
                             # partial/empty API response does not blank out
-                            # the existing state.
+                            # the existing state. Additionally, preserve the
+                            # previous non-None ``mergeable`` value when the
+                            # refresh returns ``null`` — GitHub returns null
+                            # while still computing the value. The Step 6
+                            # skip gate accepts ``True`` and ``None`` (only
+                            # ``False`` falls through to the manual merge
+                            # attempt), but preserving the prior known
+                            # ``True`` keeps the post-wait state
+                            # informative for downstream logging and any
+                            # future tightening of that predicate.
                             if "mergeable" in refreshed_wait:
-                                pr_info.mergeable = refreshed_wait.get(
+                                refreshed_mergeable = refreshed_wait.get(
                                     "mergeable"
                                 )
+                                if refreshed_mergeable is not None:
+                                    pr_info.mergeable = refreshed_mergeable
                             if "mergeable_state" in refreshed_wait:
-                                pr_info.mergeable_state = refreshed_wait.get(
+                                # Preserve the previous non-None
+                                # ``mergeable_state`` for the same
+                                # reason as ``mergeable`` above. The
+                                # subsequent ``not in ("blocked",
+                                # "behind")`` check would otherwise
+                                # break the wait loop early on a
+                                # transient ``null`` returned while
+                                # GitHub is still computing.
+                                refreshed_state = refreshed_wait.get(
                                     "mergeable_state"
                                 )
+                                if refreshed_state is not None:
+                                    pr_info.mergeable_state = refreshed_state
+                            # Capture the current head SHA so any
+                            # subsequent analyze_block_reason()
+                            # call queries the right commit. The
+                            # head can change while we wait
+                            # (rebase, dependabot force-push, etc.).
+                            refreshed_head = (
+                                refreshed_wait.get("head") or {}
+                            ).get("sha")
+                            if refreshed_head:
+                                pr_info.head_sha = refreshed_head
                             if refreshed_wait.get("state") == "closed":
-                                # PR was merged (auto-merge fired) or closed
-                                # externally — stop waiting.
+                                # PR was closed during the wait —
+                                # capture the ``merged`` boolean so
+                                # we can distinguish auto-merge
+                                # success from closed-without-merge.
+                                closed_during_wait = True
+                                merged_during_wait = bool(
+                                    refreshed_wait.get("merged", False)
+                                )
+                                pr_info.state = "closed"
                                 break
                         if pr_info.mergeable_state not in ("blocked", "behind"):
                             break
                 finally:
                     async with self._waiting_lock:
-                        self._waiting_prs.pop(wait_pr_key, None)
+                        self._waiting_prs.pop(pr_key_for_wait, None)
+
+                # If the wait revealed the PR is already closed,
+                # short-circuit before attempting a manual merge.
+                # Distinguish auto-merge success from
+                # closed-without-merge using the ``merged`` boolean
+                # captured from the refresh payload.
+                if closed_during_wait:
+                    if merged_during_wait:
+                        result.status = MergeStatus.MERGED
+                        if self.progress_tracker:
+                            self.progress_tracker.merge_success()
+                        log_and_print(
+                            self.log,
+                            self._console,
+                            f"✅ Merged (auto-merge): {pr_info.html_url}",
+                            level="debug",
+                        )
+                    else:
+                        result.status = MergeStatus.FAILED
+                        result.error = "PR closed without merging during auto-merge wait"
+                        if self.progress_tracker:
+                            self.progress_tracker.merge_failure()
+                        self._console.print(
+                            f"🛑 Closed without merging: "
+                            f"{pr_info.html_url}"
+                        )
+                    return result
 
             # Step 6: Attempt merge
             result.status = MergeStatus.MERGING
@@ -1382,7 +1631,13 @@ class AsyncMergeManager:
                 if (
                     pr_key in self._auto_merge_enabled
                     and pr_info.mergeable_state in ("blocked", "behind")
-                    and pr_info.mergeable is True
+                    # Same rationale as Step 5.5: treat
+                    # ``mergeable is None`` as still-computing so
+                    # we don't bypass the auto-merge skip gate on
+                    # a transient null. Only the explicit ``False``
+                    # case (blocked by failing checks) should fall
+                    # through to the manual merge attempt.
+                    and pr_info.mergeable is not False
                     and self.force_level != "all"
                 ):
                     if pr_info.mergeable_state == "behind":
@@ -1414,18 +1669,13 @@ class AsyncMergeManager:
                         # check", but analyze_block_reason returns a
                         # range of phrasings (e.g. "required status
                         # check\u2026 pending") depending on which
-                        # checks are outstanding.
-                        if block_reason is not None:
-                            reason_lower = block_reason.lower()
-                            auto_merge_pending_checks = (
-                                "pending required check" in reason_lower
-                                or (
-                                    "required" in reason_lower
-                                    and "pending" in reason_lower
-                                )
-                                or "pre-commit.ci" in reason_lower
-                                or "waiting for status" in reason_lower
+                        # checks are outstanding. The same predicate is
+                        # used by the Step 5.5 pre-check.
+                        auto_merge_pending_checks = (
+                            self._block_reason_indicates_pending_checks(
+                                block_reason
                             )
+                        )
 
                 if auto_merge_pending_checks:
                     merged = None  # Sentinel: auto-merge pending
@@ -1575,7 +1825,16 @@ class AsyncMergeManager:
             if self.progress_tracker:
                 self.progress_tracker.merge_failure()
 
-            # Provide clean single-line error messages for other errors
+            # Provide clean single-line error messages for other errors.
+            # Also log at error level with the stack trace so users
+            # debugging via log files (where stdout isn't captured)
+            # have full context.
+            self.log.error(
+                "Failed to process PR %s: %s",
+                pr_info.html_url,
+                e,
+                exc_info=True,
+            )
             self._console.print(
                 f"❌ Failed: {pr_info.html_url} [processing error: {e}]"
             )
@@ -1587,6 +1846,39 @@ class AsyncMergeManager:
             self._recently_approved.discard(pr_key)
 
         return result
+
+    @staticmethod
+    def _block_reason_indicates_pending_checks(
+        block_reason: str | None,
+    ) -> bool:
+        """Return True if a block reason indicates pending required checks.
+
+        Both Step 5.5 (whether to enter the wait loop) and Step 6
+        (whether to defer to auto-merge instead of attempting a
+        manual merge) need to recognise the same set of phrasings
+        returned by ``GitHubAsync.analyze_block_reason()``.
+        Centralising the predicate here keeps the two call sites
+        consistent so a new phrasing only has to be added once.
+
+        Args:
+            block_reason: The string returned by
+                ``analyze_block_reason()``, or ``None`` if the
+                analysis failed or returned nothing.
+
+        Returns:
+            True when the reason mentions pending required checks
+            in any of the recognised phrasings; False otherwise
+            (including when ``block_reason`` is ``None``).
+        """
+        if block_reason is None:
+            return False
+        reason_lower = block_reason.lower()
+        return (
+            "pending required check" in reason_lower
+            or ("required" in reason_lower and "pending" in reason_lower)
+            or "pre-commit.ci" in reason_lower
+            or "waiting for status" in reason_lower
+        )
 
     def _is_pr_mergeable(self, pr_info: PullRequestInfo) -> bool:
         """
@@ -1663,10 +1955,14 @@ class AsyncMergeManager:
     ) -> bool:
         """Post a PR comment with one retry after a 5s pause.
 
-        Used for audit-trail comments (approval, auto-merge enable)
-        that should be visible on the PR. If both attempts fail,
-        emit a single user-visible warning to the console rather
-        than silently failing.
+        Used for the auto-merge audit-trail comment so the PR
+        conversation reflects that dependamerge enabled auto-merge.
+        Approval comments take a different path: the approval body
+        is passed directly to ``approve_pull_request()``, which
+        creates a review (not an issue comment), so this helper is
+        not used there. If both attempts fail, emit a single
+        user-visible warning to the console rather than silently
+        failing.
 
         Args:
             owner: Repository owner.
@@ -1688,13 +1984,56 @@ class AsyncMergeManager:
                     owner, repo, pr_number, body
                 )
                 return True
-            except Exception as exc:
+            except GitHubPermissionError as exc:
+                # Permission errors (typically HTTP 403) are not
+                # transient — the token lacks the required scope or
+                # the repo's branch protection forbids comments.
+                # Skip the retry to avoid a pointless 5s delay per
+                # PR and surface the failure right away.
                 self.log.debug(
-                    "Audit comment post attempt %d failed for %s: %s",
-                    attempt,
+                    "Audit comment post denied (permission) for %s: %s",
                     html_url,
                     exc,
                 )
+                break
+            except Exception as exc:
+                # Heuristic: treat 4xx (other than 408/429) as
+                # permanent and skip the retry. 5xx, 429 (rate
+                # limit), 408 (timeout), and network/transport
+                # errors get one retry after a short pause.
+                #
+                # We check several attribute paths so the
+                # heuristic works across the various exception
+                # shapes we may see:
+                #   * ``exc.status_code`` — some custom wrappers
+                #   * ``exc.status`` — ``aiohttp.ClientResponseError``
+                #   * ``exc.response.status_code`` — ``httpx`` raises
+                #     ``HTTPStatusError`` whose status lives on the
+                #     attached ``Response`` object (this is what
+                #     ``httpx.Response.raise_for_status()`` produces).
+                response = getattr(exc, "response", None)
+                status_code = (
+                    getattr(exc, "status_code", None)
+                    or getattr(exc, "status", None)
+                    or getattr(response, "status_code", None)
+                    or getattr(response, "status", None)
+                )
+                permanent = (
+                    isinstance(status_code, int)
+                    and 400 <= status_code < 500
+                    and status_code not in (408, 429)
+                )
+                self.log.debug(
+                    "Audit comment post attempt %d failed for %s: %s"
+                    " (status=%r, permanent=%s)",
+                    attempt,
+                    html_url,
+                    exc,
+                    status_code,
+                    permanent,
+                )
+                if permanent:
+                    break
                 if attempt == 1:
                     await asyncio.sleep(5.0)
 
@@ -1713,10 +2052,30 @@ class AsyncMergeManager:
     ) -> bool:
         """Enable auto-merge on a PR so it merges when checks pass.
 
-        This is a best-effort operation: if auto-merge is unavailable
-        (e.g. the repository hasn't enabled it, or the PR already has
-        auto-merge active) the failure is logged at debug level and
-        the caller falls through to manual polling/merge.
+        Idempotent and safe to call when auto-merge may already be
+        active. Outcomes:
+
+        - GraphQL ``enablePullRequestAutoMerge`` mutation succeeds:
+          add the PR to ``_auto_merge_enabled``, post the audit
+          comment, and return ``True``.
+        - GraphQL mutation reports failure (commonly because
+          auto-merge is *already* active on the PR — the response
+          omits ``autoMergeRequest`` or the request raises): fall
+          back to a REST GET on the PR and inspect ``auto_merge``.
+          If non-null, treat as already-enabled — add the PR to
+          ``_auto_merge_enabled`` (so the Step 6 skip gate still
+          routes it to ``AUTO_MERGE_PENDING`` rather than
+          attempting a 405-prone manual merge) and return ``True``,
+          but skip the audit comment so re-runs against an
+          already-configured PR don't post duplicates.
+        - GraphQL mutation reports failure AND the PR has no
+          ``auto_merge`` set: auto-merge is genuinely unavailable
+          (e.g. the repository setting is off, the PR has
+          conflicts, no required-checks are configured). Return
+          ``False`` and let the caller fall through to manual
+          polling/merge.
+        - The PR has no ``node_id`` or there is no GitHub client:
+          return ``False`` without making any API calls.
 
         Args:
             pr_info: Pull request information (must have ``node_id``).
@@ -1724,7 +2083,9 @@ class AsyncMergeManager:
             repo: Repository name.
 
         Returns:
-            True if auto-merge was successfully enabled, False otherwise.
+            True if auto-merge is active on the PR after this call
+            (whether enabled by this call or already-active before
+            it). False if auto-merge is unavailable.
         """
         if not self._github_client:
             return False
@@ -1752,24 +2113,63 @@ class AsyncMergeManager:
         enabled = await self._github_client.enable_auto_merge(
             pr_info.node_id, merge_method
         )
-        if enabled:
-            self._auto_merge_enabled.add(pr_key)
-            self.log.debug(
-                "Auto-merge enabled for %s (method=%s)",
-                pr_key,
-                merge_method,
-            )
-            # Post a visible audit-trail comment so reviewers can
-            # see at a glance that dependamerge enabled auto-merge
-            # on the PR.
-            audit_comment = (
-                "🤖 Dependamerge\n"
-                "Enabled auto-merge due to pending updates/checks ⏳"
-            )
-            await self._post_pr_comment_with_retry(
-                owner, repo, pr_info.number, pr_info.html_url, audit_comment
-            )
-        return enabled
+        if not enabled:
+            # The GraphQL mutation reports failure when auto-merge
+            # is already active on the PR (the response omits
+            # ``autoMergeRequest`` or the request raises). Check
+            # the PR's current auto-merge state via REST so the
+            # Step 6 skip gate still routes the PR to
+            # ``AUTO_MERGE_PENDING`` instead of falling through to
+            # a manual merge attempt that would 405 on pending
+            # required checks.
+            try:
+                pr_payload = await self._github_client.get(
+                    f"/repos/{owner}/{repo}/pulls/{pr_info.number}"
+                )
+            except Exception as exc:
+                self.log.debug(
+                    "Could not refresh PR %s to check existing "
+                    "auto-merge state: %s",
+                    pr_key,
+                    exc,
+                )
+                pr_payload = None
+
+            if (
+                isinstance(pr_payload, dict)
+                and pr_payload.get("auto_merge") is not None
+            ):
+                self._auto_merge_enabled.add(pr_key)
+                self.log.debug(
+                    "Auto-merge already active for %s; treating "
+                    "as enabled (no audit comment posted)",
+                    pr_key,
+                )
+                # Skip the audit comment in this branch —
+                # someone (a previous run, the author, or the
+                # repo's auto-merge bot) already enabled it; we
+                # don't want to post a duplicate comment every
+                # time dependamerge runs.
+                return True
+            return False
+
+        self._auto_merge_enabled.add(pr_key)
+        self.log.debug(
+            "Auto-merge enabled for %s (method=%s)",
+            pr_key,
+            merge_method,
+        )
+        # Post a visible audit-trail comment so reviewers can
+        # see at a glance that dependamerge enabled auto-merge
+        # on the PR.
+        audit_comment = (
+            "🤖 Dependamerge\n"
+            "Enabled auto-merge due to pending updates/checks ⏳"
+        )
+        await self._post_pr_comment_with_retry(
+            owner, repo, pr_info.number, pr_info.html_url, audit_comment
+        )
+        return True
 
     async def _check_merge_requirements(
         self, pr_info: PullRequestInfo

--- a/tests/test_auto_merge.py
+++ b/tests/test_auto_merge.py
@@ -965,3 +965,111 @@ class TestStep5_5HandlesMergeableNone:
         # fall-through (which would 405 against pending checks).
         assert result.status == MergeStatus.AUTO_MERGE_PENDING
         mock_merge_retry.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# 18. Step 5.5: behind + fix_out_of_date=False still routes to auto-merge
+# ---------------------------------------------------------------------------
+
+
+class TestStep5_5BehindWithoutFix:
+    """``behind`` PRs route through Step 5.5 regardless of ``fix_out_of_date``.
+
+    A common real-world pattern: Dependabot or pre-commit-ci has just
+    rebased the PR. GitHub briefly reports ``mergeable_state: "behind"``
+    while it recomputes mergeability, and the new commit's required
+    checks are still running. Without this routing, dependamerge would
+    immediately fail those PRs with a 405 instead of enabling
+    auto-merge and letting GitHub finish the merge once checks pass.
+
+    The user's ``--no-fix`` intent is preserved by *not rebasing the
+    branch ourselves*; enabling auto-merge is a separate, non-rewriting
+    operation that has no effect unless branch protection is satisfied.
+    """
+
+    @pytest.mark.asyncio
+    async def test_step_5_5_routes_behind_no_fix_to_auto_merge_pending(
+        self,
+    ) -> None:
+        """behind + fix_out_of_date=False → AUTO_MERGE_PENDING (not FAILED)."""
+        mgr, client = make_merge_manager(
+            preview_mode=False,
+            merge_timeout=0.1,
+            fix_out_of_date=False,
+        )
+        pr = _DEFAULT_PR.model_copy(
+            update={
+                "mergeable_state": "behind",
+                "mergeable": True,
+                "state": "open",
+            }
+        )
+
+        # Auto-merge can be enabled, but the PR stays ``behind`` for
+        # the duration of the (very short) wait loop.
+        client.enable_auto_merge = AsyncMock(return_value=True)
+        client.post_issue_comment = AsyncMock()
+        client.get = AsyncMock(
+            return_value={
+                "mergeable": True,
+                "mergeable_state": "behind",
+                "state": "open",
+            }
+        )
+        client.get_required_status_checks = AsyncMock(return_value=[])
+        # ``behind`` PRs do not consult analyze_block_reason in the
+        # Step 5.5 pre-check (only ``blocked`` does), but the Step 6
+        # skip gate treats ``behind`` as auto-merge-eligible without
+        # calling it either, so we don't need a return value.
+        client.analyze_block_reason = AsyncMock(return_value="behind base branch")
+
+        no_g2g = GitHub2GerritDetectionResult()
+        with (
+            patch.object(
+                mgr,
+                "_detect_github2gerrit",
+                new_callable=AsyncMock,
+                return_value=no_g2g,
+            ),
+            patch.object(
+                mgr,
+                "_get_merge_method_for_repo",
+                new_callable=AsyncMock,
+                return_value="merge",
+            ),
+            patch.object(
+                mgr,
+                "_trigger_stale_precommit_ci",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+            patch.object(
+                mgr,
+                "_check_merge_requirements",
+                new_callable=AsyncMock,
+                return_value=(True, ""),
+            ),
+            patch.object(
+                mgr,
+                "_approve_pr",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
+            patch.object(
+                mgr,
+                "_merge_pr_with_retry",
+                new_callable=AsyncMock,
+                return_value=True,
+            ) as mock_merge_retry,
+        ):
+            result = await mgr._merge_single_pr(pr)
+
+        # Auto-merge was enabled despite fix_out_of_date=False.
+        client.enable_auto_merge.assert_awaited_once_with("PR_kwDOTestNode42", "merge")
+        assert "owner/repo#42" in mgr._auto_merge_enabled
+        # Wait timed out while still ``behind``; the Step 6 skip gate
+        # routes to AUTO_MERGE_PENDING and the manual merge does NOT
+        # run (which would otherwise 405 against the unfinished
+        # required checks).
+        assert result.status == MergeStatus.AUTO_MERGE_PENDING
+        mock_merge_retry.assert_not_called()

--- a/tests/test_auto_merge.py
+++ b/tests/test_auto_merge.py
@@ -149,7 +149,7 @@ class TestMergeSkippedWhenAutoMergeActiveAndBlocked:
         self,
     ) -> None:
         """Auto-merge pending: _merge_pr_with_retry is NOT called."""
-        mgr, client = make_merge_manager(preview_mode=False)
+        mgr, client = make_merge_manager(preview_mode=False, merge_timeout=0.1)
         pr = _DEFAULT_PR.model_copy(
             update={
                 "mergeable_state": "blocked",
@@ -363,7 +363,7 @@ class TestAutoMergeSkipGateMergeableFalse:
         self,
     ) -> None:
         """Failing checks: auto-merge gate must not override; retry is called."""
-        mgr, client = make_merge_manager(preview_mode=False)
+        mgr, client = make_merge_manager(preview_mode=False, merge_timeout=0.1)
         pr = _DEFAULT_PR.model_copy(
             update={
                 "mergeable_state": "blocked",
@@ -433,7 +433,9 @@ class TestAutoMergeSkipGateForceAll:
     @pytest.mark.asyncio
     async def test_manual_merge_runs_with_force_all(self) -> None:
         """force_level='all': auto-merge gate must not override."""
-        mgr, client = make_merge_manager(preview_mode=False, force_level="all")
+        mgr, client = make_merge_manager(
+            preview_mode=False, force_level="all", merge_timeout=0.1
+        )
         pr = _DEFAULT_PR.model_copy(
             update={
                 "mergeable_state": "blocked",
@@ -551,7 +553,11 @@ class TestAutoMergePendingCompletesProgress:
     async def test_auto_merge_pending_calls_pr_completed(self) -> None:
         """pr_completed() is called so PR progress reaches 100%."""
         tracker = MagicMock()
-        mgr, client = make_merge_manager(preview_mode=False, progress_tracker=tracker)
+        mgr, client = make_merge_manager(
+            preview_mode=False,
+            progress_tracker=tracker,
+            merge_timeout=0.1,
+        )
         pr = _DEFAULT_PR.model_copy(
             update={
                 "mergeable_state": "blocked",
@@ -630,7 +636,7 @@ class TestAutoMergeSkipGateBlockReason:
         self,
     ) -> None:
         """Block reason = 'requires approval': manual merge must still run."""
-        mgr, client = make_merge_manager(preview_mode=False)
+        mgr, client = make_merge_manager(preview_mode=False, merge_timeout=0.1)
         pr = _DEFAULT_PR.model_copy(
             update={
                 "mergeable_state": "blocked",
@@ -699,7 +705,7 @@ class TestAutoMergeSkipGateBlockReason:
         self,
     ) -> None:
         """If analyze_block_reason raises, fall back to manual merge attempt."""
-        mgr, client = make_merge_manager(preview_mode=False)
+        mgr, client = make_merge_manager(preview_mode=False, merge_timeout=0.1)
         pr = _DEFAULT_PR.model_copy(
             update={
                 "mergeable_state": "blocked",

--- a/tests/test_auto_merge.py
+++ b/tests/test_auto_merge.py
@@ -697,8 +697,11 @@ class TestAutoMergeSkipGateBlockReason:
 
         assert result.status == MergeStatus.MERGED
         mock_merge_retry.assert_called_once()
-        # analyze_block_reason was consulted before deciding to proceed
-        client.analyze_block_reason.assert_awaited_once()
+        # analyze_block_reason was consulted before deciding to proceed.
+        # It is now called by both the Step 5.5 pre-check (to decide
+        # whether to wait) and the Step 6 skip gate, so we assert it
+        # was awaited at least once rather than exactly once.
+        assert client.analyze_block_reason.await_count >= 1
 
     @pytest.mark.asyncio
     async def test_manual_merge_runs_when_analyze_block_reason_fails(
@@ -765,3 +768,200 @@ class TestAutoMergeSkipGateBlockReason:
         # silently marking as AUTO_MERGE_PENDING.
         assert result.status == MergeStatus.MERGED
         mock_merge_retry.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# 16. Step 5.5 end-to-end: auto-merge not yet enabled, gets enabled
+# ---------------------------------------------------------------------------
+
+
+class TestStep5_5EnablesAutoMergeAndTimesOut:
+    """Step 5.5 end-to-end coverage.
+
+    Starts with ``_auto_merge_enabled`` empty so the wait phase must
+    invoke ``_enable_auto_merge_for_pr`` itself, then times out while
+    the PR is still blocked, and asserts the resulting status is
+    ``AUTO_MERGE_PENDING`` (not ``FAILED``).
+    """
+
+    @pytest.mark.asyncio
+    async def test_step_5_5_enables_auto_merge_then_times_out_pending(
+        self,
+    ) -> None:
+        """Step 5.5 enables auto-merge and yields AUTO_MERGE_PENDING."""
+        mgr, client = make_merge_manager(preview_mode=False, merge_timeout=0.1)
+        pr = _DEFAULT_PR.model_copy(
+            update={
+                "mergeable_state": "blocked",
+                "mergeable": True,
+                "state": "open",
+            }
+        )
+
+        # IMPORTANT: do NOT pre-populate ``_auto_merge_enabled`` —
+        # this is the path Copilot flagged as untested. The set
+        # stores ``"{owner}/{repo}#{number}"`` keys, not URLs.
+        assert "owner/repo#42" not in mgr._auto_merge_enabled
+
+        # GraphQL enable succeeds; subsequent .get() in the wait
+        # loop returns the PR still blocked so we time out.
+        client.enable_auto_merge = AsyncMock(return_value=True)
+        client.post_issue_comment = AsyncMock()
+        client.get = AsyncMock(
+            return_value={
+                "mergeable": True,
+                "mergeable_state": "blocked",
+                "state": "open",
+            }
+        )
+        client.get_required_status_checks = AsyncMock(return_value=[])
+        client.analyze_block_reason = AsyncMock(
+            return_value="Blocked by pending required check: pre-commit.ci"
+        )
+
+        no_g2g = GitHub2GerritDetectionResult()
+        with (
+            patch.object(
+                mgr,
+                "_detect_github2gerrit",
+                new_callable=AsyncMock,
+                return_value=no_g2g,
+            ),
+            patch.object(
+                mgr,
+                "_get_merge_method_for_repo",
+                new_callable=AsyncMock,
+                return_value="merge",
+            ),
+            patch.object(
+                mgr,
+                "_trigger_stale_precommit_ci",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+            patch.object(
+                mgr,
+                "_check_merge_requirements",
+                new_callable=AsyncMock,
+                return_value=(True, ""),
+            ),
+            patch.object(
+                mgr,
+                "_approve_pr",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
+            patch.object(
+                mgr,
+                "_merge_pr_with_retry",
+                new_callable=AsyncMock,
+                return_value=True,
+            ) as mock_merge_retry,
+        ):
+            result = await mgr._merge_single_pr(pr)
+
+        # Auto-merge was enabled by Step 5.5 itself.
+        client.enable_auto_merge.assert_awaited_once_with("PR_kwDOTestNode42", "merge")
+        assert "owner/repo#42" in mgr._auto_merge_enabled
+
+        # Wait timed out while still blocked, so the skip gate
+        # routes us to AUTO_MERGE_PENDING and the manual merge
+        # is NOT attempted.
+        assert result.status == MergeStatus.AUTO_MERGE_PENDING
+        mock_merge_retry.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# 17. Step 5.5 + skip gate: mergeable=None (still computing) is treated as
+#     still-computing rather than 'not mergeable'
+# ---------------------------------------------------------------------------
+
+
+class TestStep5_5HandlesMergeableNone:
+    """Both gates must accept mergeable=None as 'still computing'.
+
+    GitHub returns ``mergeable: null`` transiently while it is still
+    computing the value. The Step 5.5 entry condition and the Step 6
+    auto-merge skip gate must NOT bypass auto-merge handling on this
+    transient state — doing so reintroduces the original 405 failure
+    mode this PR was raised to fix.
+    """
+
+    @pytest.mark.asyncio
+    async def test_step_5_5_runs_when_mergeable_is_none(self) -> None:
+        """mergeable=None + blocked + pending checks → AUTO_MERGE_PENDING."""
+        mgr, client = make_merge_manager(preview_mode=False, merge_timeout=0.1)
+        pr = _DEFAULT_PR.model_copy(
+            update={
+                "mergeable_state": "blocked",
+                "mergeable": None,  # GitHub still computing
+                "state": "open",
+            }
+        )
+
+        client.enable_auto_merge = AsyncMock(return_value=True)
+        client.post_issue_comment = AsyncMock()
+        # Refresh keeps mergeable null + state blocked so the
+        # wait loop exhausts the timeout.
+        client.get = AsyncMock(
+            return_value={
+                "mergeable": None,
+                "mergeable_state": "blocked",
+                "state": "open",
+            }
+        )
+        client.get_required_status_checks = AsyncMock(return_value=[])
+        client.analyze_block_reason = AsyncMock(
+            return_value="Blocked by pending required check: pre-commit.ci"
+        )
+
+        no_g2g = GitHub2GerritDetectionResult()
+        with (
+            patch.object(
+                mgr,
+                "_detect_github2gerrit",
+                new_callable=AsyncMock,
+                return_value=no_g2g,
+            ),
+            patch.object(
+                mgr,
+                "_get_merge_method_for_repo",
+                new_callable=AsyncMock,
+                return_value="merge",
+            ),
+            patch.object(
+                mgr,
+                "_trigger_stale_precommit_ci",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+            patch.object(
+                mgr,
+                "_check_merge_requirements",
+                new_callable=AsyncMock,
+                return_value=(True, ""),
+            ),
+            patch.object(
+                mgr,
+                "_approve_pr",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
+            patch.object(
+                mgr,
+                "_merge_pr_with_retry",
+                new_callable=AsyncMock,
+                return_value=True,
+            ) as mock_merge_retry,
+        ):
+            result = await mgr._merge_single_pr(pr)
+
+        # Step 5.5 entry gate accepted mergeable=None and enabled
+        # auto-merge.
+        client.enable_auto_merge.assert_awaited_once_with("PR_kwDOTestNode42", "merge")
+        assert "owner/repo#42" in mgr._auto_merge_enabled
+        # Step 6 skip gate also accepted mergeable=None and routed
+        # to AUTO_MERGE_PENDING instead of the manual merge
+        # fall-through (which would 405 against pending checks).
+        assert result.status == MergeStatus.AUTO_MERGE_PENDING
+        mock_merge_retry.assert_not_called()

--- a/tests/test_auto_merge.py
+++ b/tests/test_auto_merge.py
@@ -356,13 +356,22 @@ class TestInvalidMergeTimeoutFallback:
 
 
 class TestAutoMergeSkipGateMergeableFalse:
-    """Blocked + mergeable=False (failing checks) must NOT skip manual merge."""
+    """Blocked + mergeable=False routes to AUTO_MERGE_PENDING when checks pending.
+
+    Previously this case fell through to a manual merge (which would
+    typically 405 against unfinished required checks). The current
+    behaviour treats ``mergeable=False`` the same as ``True`` / ``None``
+    when ``mergeable_state`` is auto-merge-rescuable: GitHub returns
+    ``mergeable=False`` transiently for several reasons (still
+    computing, non-required check failed) so we let Step 5.5's
+    block-reason pre-check make the routing decision.
+    """
 
     @pytest.mark.asyncio
-    async def test_manual_merge_runs_when_blocked_by_failing_checks(
+    async def test_blocked_mergeable_false_pending_checks_routes_to_pending(
         self,
     ) -> None:
-        """Failing checks: auto-merge gate must not override; retry is called."""
+        """blocked + mergeable=False + pending checks → AUTO_MERGE_PENDING."""
         mgr, client = make_merge_manager(preview_mode=False, merge_timeout=0.1)
         pr = _DEFAULT_PR.model_copy(
             update={
@@ -374,8 +383,21 @@ class TestAutoMergeSkipGateMergeableFalse:
 
         mgr._auto_merge_enabled.add("owner/repo#42")
 
-        client.get = AsyncMock(return_value={})
+        # Refresh keeps the PR in the same state for the duration
+        # of the (very short) wait loop.
+        client.get = AsyncMock(
+            return_value={
+                "mergeable": False,
+                "mergeable_state": "blocked",
+                "state": "open",
+            }
+        )
         client.get_required_status_checks = AsyncMock(return_value=[])
+        client.analyze_block_reason = AsyncMock(
+            return_value="Blocked by pending required check: pre-commit.ci"
+        )
+        client.enable_auto_merge = AsyncMock(return_value=True)
+        client.post_issue_comment = AsyncMock()
 
         no_g2g = GitHub2GerritDetectionResult()
         with (
@@ -418,8 +440,13 @@ class TestAutoMergeSkipGateMergeableFalse:
         ):
             result = await mgr._merge_single_pr(pr)
 
-        assert result.status == MergeStatus.MERGED
-        mock_merge_retry.assert_called_once()
+        # mergeable=False with pending-checks block reason now
+        # routes through Step 5.5 → AUTO_MERGE_PENDING instead of
+        # the previous manual-merge fall-through. The user gets a
+        # friendlier outcome (auto-merge will fire when checks
+        # complete) than a 405 hard fail.
+        assert result.status == MergeStatus.AUTO_MERGE_PENDING
+        mock_merge_retry.assert_not_called()
 
 
 # ---------------------------------------------------------------------------
@@ -1073,3 +1100,272 @@ class TestStep5_5BehindWithoutFix:
         # required checks).
         assert result.status == MergeStatus.AUTO_MERGE_PENDING
         mock_merge_retry.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# 19. Step 5.5: ``unstable`` (non-required check failed) routes to auto-merge
+# ---------------------------------------------------------------------------
+
+
+class TestStep5_5UnstableRoutesToAutoMerge:
+    """``unstable`` PRs route through Step 5.5 (auto-merge can rescue).
+
+    ``mergeable_state == "unstable"`` means a non-required status
+    check failed but the PR is otherwise mergeable. Branch protection
+    only blocks on *required* checks, so auto-merge can fire — we
+    should not hard-fail this case.
+    """
+
+    @pytest.mark.asyncio
+    async def test_unstable_routes_to_auto_merge_pending(self) -> None:
+        """unstable + mergeable=False → AUTO_MERGE_PENDING."""
+        mgr, client = make_merge_manager(preview_mode=False, merge_timeout=0.1)
+        pr = _DEFAULT_PR.model_copy(
+            update={
+                "mergeable_state": "unstable",
+                "mergeable": False,
+                "state": "open",
+            }
+        )
+
+        client.enable_auto_merge = AsyncMock(return_value=True)
+        client.post_issue_comment = AsyncMock()
+        client.get = AsyncMock(
+            return_value={
+                "mergeable": False,
+                "mergeable_state": "unstable",
+                "state": "open",
+            }
+        )
+        client.get_required_status_checks = AsyncMock(return_value=[])
+        # ``unstable`` doesn't trigger the analyze_block_reason
+        # pre-check (only ``blocked`` does), so this mock is just
+        # defensive.
+        client.analyze_block_reason = AsyncMock(
+            return_value="a non-required check failed"
+        )
+
+        no_g2g = GitHub2GerritDetectionResult()
+        with (
+            patch.object(
+                mgr,
+                "_detect_github2gerrit",
+                new_callable=AsyncMock,
+                return_value=no_g2g,
+            ),
+            patch.object(
+                mgr,
+                "_get_merge_method_for_repo",
+                new_callable=AsyncMock,
+                return_value="merge",
+            ),
+            patch.object(
+                mgr,
+                "_trigger_stale_precommit_ci",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+            patch.object(
+                mgr,
+                "_check_merge_requirements",
+                new_callable=AsyncMock,
+                return_value=(True, ""),
+            ),
+            patch.object(
+                mgr,
+                "_approve_pr",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
+            patch.object(
+                mgr,
+                "_merge_pr_with_retry",
+                new_callable=AsyncMock,
+                return_value=True,
+            ) as mock_merge_retry,
+        ):
+            result = await mgr._merge_single_pr(pr)
+
+        # Auto-merge enabled; Step 6 skip gate routes ``unstable``
+        # straight to AUTO_MERGE_PENDING (no analyze_block_reason
+        # needed for this state).
+        client.enable_auto_merge.assert_awaited_once_with("PR_kwDOTestNode42", "merge")
+        assert "owner/repo#42" in mgr._auto_merge_enabled
+        assert result.status == MergeStatus.AUTO_MERGE_PENDING
+        mock_merge_retry.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# 20. ``dirty`` PRs are still blocked (genuine merge conflict invariant)
+# ---------------------------------------------------------------------------
+
+
+class TestDirtyStillBlocksAtIsPrMergeable:
+    """``dirty`` PRs (real merge conflict) must NOT reach Step 5.5.
+
+    The widening of ``_is_pr_mergeable`` should not lose its hard-skip
+    for genuine merge conflicts: those need a human (or ``--fix``) to
+    rebase, and auto-merge cannot resolve them.
+    """
+
+    def test_dirty_returns_false(self) -> None:
+        """_is_pr_mergeable returns False for dirty (merge conflict)."""
+        mgr, _client = make_merge_manager()
+        pr = _DEFAULT_PR.model_copy(
+            update={
+                "mergeable_state": "dirty",
+                "mergeable": False,
+            }
+        )
+        assert mgr._is_pr_mergeable(pr) is False
+
+    def test_draft_returns_false(self) -> None:
+        """_is_pr_mergeable returns False for draft PRs."""
+        mgr, _client = make_merge_manager()
+        pr = _DEFAULT_PR.model_copy(
+            update={
+                "mergeable_state": "draft",
+                "mergeable": True,
+            }
+        )
+        assert mgr._is_pr_mergeable(pr) is False
+
+    def test_blocked_mergeable_false_returns_true(self) -> None:
+        """_is_pr_mergeable now returns True for blocked + mergeable=False.
+
+        This is the rescue path: previously this combination short-
+        circuited as 'unmergeable', now it reaches the merge flow so
+        Step 5.5 can route to AUTO_MERGE_PENDING.
+        """
+        mgr, _client = make_merge_manager()
+        pr = _DEFAULT_PR.model_copy(
+            update={
+                "mergeable_state": "blocked",
+                "mergeable": False,
+            }
+        )
+        assert mgr._is_pr_mergeable(pr) is True
+
+    def test_behind_mergeable_false_returns_true(self) -> None:
+        """_is_pr_mergeable now returns True for behind + mergeable=False."""
+        mgr, _client = make_merge_manager()
+        pr = _DEFAULT_PR.model_copy(
+            update={
+                "mergeable_state": "behind",
+                "mergeable": False,
+            }
+        )
+        assert mgr._is_pr_mergeable(pr) is True
+
+    def test_unstable_mergeable_false_returns_true(self) -> None:
+        """_is_pr_mergeable now returns True for unstable + mergeable=False."""
+        mgr, _client = make_merge_manager()
+        pr = _DEFAULT_PR.model_copy(
+            update={
+                "mergeable_state": "unstable",
+                "mergeable": False,
+            }
+        )
+        assert mgr._is_pr_mergeable(pr) is True
+
+
+# ---------------------------------------------------------------------------
+# 21. Pending-checks predicate distinguishes pending from failing/missing
+# ---------------------------------------------------------------------------
+
+
+class TestBlockReasonIndicatesPendingChecks:
+    """Predicate must classify pending vs. failing/missing accurately.
+
+    ``GitHubAsync.analyze_block_reason()`` produces several phrasings:
+
+    - ``Blocked by pending required check: …``  → pending
+    - ``Blocked by failing check: …``           → NOT pending
+    - ``Blocked by missing required status: …`` → NOT pending
+
+    A predicate that misclassifies failing or missing reasons as
+    pending would route doomed PRs to AUTO_MERGE_PENDING and mask
+    real failures, so this test pins the boundary explicitly.
+    """
+
+    def test_none_returns_false(self) -> None:
+        """None block reason is never pending."""
+        from dependamerge.merge_manager import AsyncMergeManager
+
+        assert AsyncMergeManager._block_reason_indicates_pending_checks(None) is False
+
+    def test_pending_required_check_returns_true(self) -> None:
+        """Canonical pending phrasings are recognised."""
+        from dependamerge.merge_manager import AsyncMergeManager
+
+        for reason in (
+            "Blocked by pending required check: pre-commit.ci",
+            "Blocked by 2 pending required checks: ci/build, ci/lint",
+            "required status check is still pending",
+            "waiting for status checks",
+            "check queued",
+        ):
+            assert (
+                AsyncMergeManager._block_reason_indicates_pending_checks(reason) is True
+            ), reason
+
+    def test_failing_check_returns_false(self) -> None:
+        """Failing check is NOT classified as pending."""
+        from dependamerge.merge_manager import AsyncMergeManager
+
+        for reason in (
+            "Blocked by failing check: pre-commit.ci",
+            "Blocked by failing check: ci/build",
+            "Blocked by 3 failing checks",
+        ):
+            assert (
+                AsyncMergeManager._block_reason_indicates_pending_checks(reason)
+                is False
+            ), reason
+
+    def test_missing_required_status_returns_false(self) -> None:
+        """Missing required status is NOT classified as pending."""
+        from dependamerge.merge_manager import AsyncMergeManager
+
+        for reason in (
+            "Blocked by missing required status: pre-commit.ci",
+            "Blocked by 2 missing required statuses: pre-commit.ci, ci/lint",
+            "Blocked by missing required check: pre-commit.ci",
+        ):
+            assert (
+                AsyncMergeManager._block_reason_indicates_pending_checks(reason)
+                is False
+            ), reason
+
+    def test_other_block_reasons_return_false(self) -> None:
+        """Non-check block reasons (approvals, conflicts, etc.) return False."""
+        from dependamerge.merge_manager import AsyncMergeManager
+
+        for reason in (
+            "Blocked by branch protection (requires approval)",
+            "Blocked by branch protection",
+            "Human reviewer requested changes",
+            "Blocked by 2 unresolved Copilot comments",
+            "",
+        ):
+            assert (
+                AsyncMergeManager._block_reason_indicates_pending_checks(reason)
+                is False
+            ), reason
+
+    def test_failing_with_pending_keyword_returns_false(self) -> None:
+        """Defensive: 'failing' wins even when 'pending' also appears.
+
+        Guards against future GitHub phrasings that combine both
+        keywords (e.g. "failing check (pending retry): pre-commit.ci").
+        We never want a failing check to be treated as auto-merge
+        rescuable.
+        """
+        from dependamerge.merge_manager import AsyncMergeManager
+
+        assert (
+            AsyncMergeManager._block_reason_indicates_pending_checks(
+                "Blocked by failing check (pending retry): pre-commit.ci"
+            )
+            is False
+        )

--- a/tests/test_behind_pr_handling.py
+++ b/tests/test_behind_pr_handling.py
@@ -326,8 +326,13 @@ class TestBehindPRHandling:
 
             can_merge, reason = await merge_manager._check_merge_requirements(pr_info)
 
-            assert can_merge is False
-            assert "no-fix" in reason.lower() or "behind" in reason.lower()
+            # behind + --no-fix no longer hard-fails. _check_merge_requirements
+            # now returns can_merge=True so the PR reaches Step 5.5, where
+            # auto-merge gets enabled and the wait loop runs (auto-merge
+            # is a non-rewriting operation, so it doesn't violate the
+            # user's --no-fix intent).
+            assert can_merge is True
+            assert "behind" in reason.lower() or "auto-merge" in reason.lower()
 
     @pytest.mark.asyncio
     async def test_proactive_rebase_success(self):


### PR DESCRIPTION
## Summary

Fixes a bug where dependamerge would immediately fail PRs that
GitHub reported as `blocked`, `behind`, or `unstable` — even when
auto-merge could rescue them once required checks finish — instead
of enabling GitHub auto-merge and waiting for the configured merge
timeout.

Two failures observed in the run that prompted this fix:

- `lfreleng-actions/gerrit-review-action#95` — reported as
  `behind base branch` immediately after rebase, despite checks
  still pending.
- `lfreleng-actions/checkout-gerrit-change-action#87` — reported
  as `branch protection rules prevent merge` after only a few
  seconds, with no auto-merge enabled.

## Root cause

Auto-merge enablement was wired only into the `mergeable_state ==
"behind"` rebase code path. PRs `blocked` by a pending required
check skipped auto-merge entirely and fell straight through to
`_merge_pr_with_retry`, which 405'd against the unfinished check.

The skip gate that would have routed those PRs to
`AUTO_MERGE_PENDING` required `mergeable_state == "blocked"` plus
the literal block-reason string `"pending required check"`,
missing both the `behind` post-timeout case and the other
phrasings `analyze_block_reason()` returns.

## Changes

- **New Step 5.5** in `_merge_single_pr`: for PRs in
  `mergeable_state in ("blocked", "behind", "unstable")`, enable
  auto-merge and poll until the PR becomes `clean`, is closed, or
  `merge_timeout` elapses. Pre-checks `analyze_block_reason()` so
  non-resolvable blocks (missing approvals, etc.) skip the wait.
  Skipped under `preview_mode`, `force_level == "all"`, or after
  Step 5 already ran a rebase + wait (tracked via `_rebased_prs`
  to avoid doubling the timeout). Step 5.5 accepts any
  `mergeable` value (including `False`) on the rescuable states
  because GitHub returns `mergeable=False` transiently while
  computing or when a non-required check failed.
- **Wait-status ticker**: a single-line Rich countdown
  (`⏳ Waiting for N PRs to complete checks [Ns]`) driven by a
  background task in `merge_prs_parallel`, with a 15s
  plain-console fallback when Rich isn't available.
- **Auto-merge skip gate** widened to cover `blocked`, `behind`,
  and `unstable`; it accepts `mergeable=None` and
  `mergeable=False` and recognises a tightened set of
  pending-checks phrasings via the shared
  `_block_reason_indicates_pending_checks()` helper. The
  predicate explicitly excludes `failing check` and `missing
  required status` so doomed PRs still surface to the user
  rather than being routed to `AUTO_MERGE_PENDING`.
- **State-aware wait line**: `⏳ Waiting:` now appends a reason
  matching the actual `mergeable_state` (`pending checks` /
  `behind base branch` / `non-required check failure`) instead
  of always reporting `pending checks`.
- **`_is_pr_mergeable` simplified** to return `False` only for
  `dirty` (real merge conflict) and `draft`. All other states
  reach the merge flow so Step 5.5 can decide.
- **`_check_merge_requirements`** no longer hard-fails
  `behind + --no-fix` or `blocked + mergeable=False`: both
  return `True` so the PR reaches Step 5.5. The `--no-fix`
  intent is preserved (we still don't *rebase* the branch
  ourselves; auto-merge enablement is a separate, non-rewriting
  operation).
- **Robustness**: preserve previous non-`None` values for
  `mergeable` / `mergeable_state` / `head_sha` across refreshes;
  detect "auto-merge already active" via REST when the GraphQL
  mutation reports failure (idempotent re-runs); classify HTTP
  errors as transient/permanent in the audit-comment retry
  helper.
- **Console output** unified and decluttered: concise
  `⏳ Waiting:`, `🤖 Auto-merge:`, `✅ Rebased:` lines using full
  PR URLs, with the duplicate `WARNING -` / `ERROR -` lines
  removed.
- **PR audit comments** for approval and auto-merge enablement,
  with one-retry posting and a single `⚠️ Unable to add pull
  request comment:` warning if both attempts fail.

## Tests

- New `TestStep5_5EnablesAutoMergeAndTimesOut`,
  `TestStep5_5HandlesMergeableNone`,
  `TestStep5_5BehindWithoutFix`, and
  `TestStep5_5UnstableRoutesToAutoMerge` cover the Step 5.5
  end-to-end path for the four broadened entry conditions
  (auto-merge gets enabled mid-flow, wait times out, status is
  `AUTO_MERGE_PENDING`, manual merge is NOT attempted).
- New `TestDirtyStillBlocksAtIsPrMergeable` (5 unit tests) pins
  the `_is_pr_mergeable` invariants: `dirty` and `draft` still
  block; `blocked`/`behind`/`unstable` + `mergeable=False` now
  flow through.
- New `TestBlockReasonIndicatesPendingChecks` (6 unit tests)
  pins the pending-checks predicate boundary: pending → True;
  failing / missing required status / approval / Copilot /
  empty → False; defensive failing+pending combo → False.
- All 35 tests in `tests/test_auto_merge.py` pass; full suite
  (`tests/`) is 877/877 green.

## Manual verification harness

`scripts/demo_wait_ticker.py` exercises the ticker end-to-end
without hitting GitHub:

```bash
uv run python scripts/demo_wait_ticker.py            # Rich, ~40s
uv run python scripts/demo_wait_ticker.py --plain    # Plain, ~50s
```

`docs/TESTING_WAIT_STATUS_TICKER.md` documents the verification
options and explains why the script is the recommended approach.