### PR TITLE
CI: Queue concurrent release runs instead of cancelling

### DIFF
--- a/.github/workflows/build-test-release.yaml
+++ b/.github/workflows/build-test-release.yaml
@@ -15,8 +15,8 @@ on:
 permissions: {}
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
 
 jobs:
   repository-metadata:


### PR DESCRIPTION
Switch the release workflow concurrency policy from cancelling
in-flight runs to queueing them.

## Why

The `build-test-release` workflow publishes to TestPyPI and PyPI and
creates GitHub Releases, all of which are non-idempotent operations.
Cancelling a run mid-flight can leave a partially completed release
state (e.g. TestPyPI uploaded but PyPI not yet published, or a Release
object without attached artefacts).

With `cancel-in-progress: false`, a second run for the same ref waits
for the first to finish. The duplicate-upload check on PyPI then
provides a clean fail-fast signal rather than risking corrupted state.

The concurrency group is also narrowed to `release-${{ github.ref }}`
to make intent explicit.

## Context

This change originated from Copilot review feedback on
lfreleng-actions/gha-workflow-linter#185 and is being propagated here
since `dependamerge` is the canonical repository for our Python
workflow conventions.