### PR TITLE
Feat(merge): Signed rebase, stuck DCO recovery, dispatch lock, and repo-scoped output fixes

### DIFF
--- a/src/dependamerge/cli.py
+++ b/src/dependamerge/cli.py
@@ -334,6 +334,7 @@ class _MergeContext:
     netrc_optional: bool
     github2gerrit_mode: str
     include_human_prs: bool = False
+    rebase_local: bool = True
 
     # Derived / mutable state
     github_client: GitHubClient | None = None
@@ -747,6 +748,7 @@ def _run_parallel_merge(
             github2gerrit_mode=ctx.github2gerrit_mode,
             no_netrc=ctx.no_netrc,
             netrc_file=ctx.netrc_file,
+            rebase_local=ctx.rebase_local,
         ) as merge_manager:
             if not preview:
                 console.print(
@@ -1482,6 +1484,19 @@ def merge(
         "--no-fix",
         help="Do not attempt to automatically fix out-of-date branches",
     ),
+    rebase_local: bool = typer.Option(
+        True,
+        "--rebase-local/--no-rebase-local",
+        help=(
+            "When rebasing a behind PR, prefer a local ``git`` clone + "
+            "rebase + force-push-with-lease over the GitHub REST "
+            "``update-branch`` endpoint when the base branch requires "
+            "verified signatures or the PR is from pre-commit-ci[bot]. "
+            "The local path inherits ``~/.gitconfig`` so commits stay "
+            "signed; the REST path is faster but produces unsigned "
+            "commits that break verification. Default: enabled."
+        ),
+    ),
     merge_timeout: float = typer.Option(
         DEFAULT_MERGE_TIMEOUT,
         "--merge-timeout",
@@ -1699,6 +1714,7 @@ def merge(
             netrc_optional=netrc_optional,
             github2gerrit_mode=github2gerrit_mode,
             include_human_prs=include_human_prs,
+            rebase_local=rebase_local,
         )
         try:
             _handle_repo_merge(parsed_repo, repo_ctx)
@@ -1765,6 +1781,7 @@ def merge(
         netrc_optional=netrc_optional,
         github2gerrit_mode=github2gerrit_mode,
         include_human_prs=include_human_prs,
+        rebase_local=rebase_local,
     )
 
     try:

--- a/src/dependamerge/cli.py
+++ b/src/dependamerge/cli.py
@@ -344,9 +344,9 @@ class _MergeContext:
     comparator: PRComparator | None = None
     source_pr: PullRequestInfo | None = None
     progress_tracker: MergeProgressTracker | None = None
-    all_similar_prs: list[
-        tuple[PullRequestInfo, ComparisonResult]
-    ] = field(default_factory=list)
+    all_similar_prs: list[tuple[PullRequestInfo, ComparisonResult]] = field(
+        default_factory=list
+    )
 
 
 def _validate_merge_inputs(
@@ -407,12 +407,8 @@ def _validate_merge_inputs(
         raise typer.Exit(1)
 
     if force == "all":
-        console.print(
-            "⚠️  Warning: Using --force=all will bypass most safety checks."
-        )
-        console.print(
-            "   This may attempt merges that will fail at GitHub API level."
-        )
+        console.print("⚠️  Warning: Using --force=all will bypass most safety checks.")
+        console.print("   This may attempt merges that will fail at GitHub API level.")
 
     return github2gerrit_mode
 
@@ -425,9 +421,7 @@ def _init_github_merge(ctx: _MergeContext) -> None:
     ctx.github_client = GitHubClient(ctx.token)
     assert ctx.github_client.token is not None
     ctx.token = ctx.github_client.token
-    ctx.owner, ctx.repo_name, ctx.pr_number = (
-        ctx.github_client.parse_pr_url(ctx.pr_url)
-    )
+    ctx.owner, ctx.repo_name, ctx.pr_number = ctx.github_client.parse_pr_url(ctx.pr_url)
 
     if ctx.show_progress:
         # Create the tracker but do NOT start it yet — it will be
@@ -436,9 +430,7 @@ def _init_github_merge(ctx: _MergeContext) -> None:
         # check) are fast and use plain console output instead.
         ctx.progress_tracker = MergeProgressTracker(ctx.owner)
 
-    console.print(
-        f"🔍 Examining source pull request in {ctx.owner}..."
-    )
+    console.print(f"🔍 Examining source pull request in {ctx.owner}...")
 
     ctx.comparator = PRComparator(ctx.similarity_threshold)
 
@@ -476,9 +468,7 @@ def _fetch_and_validate_source_pr(ctx: _MergeContext) -> None:
                 exception=e,
             )
         elif is_github_api_permission_error(e):
-            exit_for_github_api_error(
-                details="Failed to fetch PR details", exception=e
-            )
+            exit_for_github_api_error(details="Failed to fetch PR details", exception=e)
         else:
             exit_with_error(
                 ExitCode.GENERAL_ERROR,
@@ -532,9 +522,7 @@ def _check_merge_permissions(ctx: _MergeContext) -> None:
         if advisory_perms:
             for op in advisory_perms:
                 result = perm_results[op]
-                console.print(
-                    f"⚠️  {op}: {result['error']} (non-blocking)"
-                )
+                console.print(f"⚠️  {op}: {result['error']} (non-blocking)")
         if missing_perms:
             console.print("\n❌ Token Permission Check Failed:\n")
             for op in missing_perms:
@@ -542,16 +530,13 @@ def _check_merge_permissions(ctx: _MergeContext) -> None:
                 console.print(f"   • {op}: {result['error']}")
                 if result.get("guidance"):
                     console.print(
-                        f"     Classic: "
-                        f"{result['guidance'].get('classic', 'N/A')}"
+                        f"     Classic: {result['guidance'].get('classic', 'N/A')}"
                     )
                     console.print(
                         f"     Fine-grained: "
                         f"{result['guidance'].get('fine_grained', 'N/A')}"
                     )
-            console.print(
-                "\n💡 Update your token permissions and try again."
-            )
+            console.print("\n💡 Update your token permissions and try again.")
             raise typer.Exit(code=3)
         console.print("✅ Token has required permissions")
     except GitHubPermissionError as e:
@@ -580,20 +565,13 @@ def _validate_automation_author(ctx: _MergeContext) -> None:
     commit_messages = ctx.github_client.get_pull_request_commits(
         ctx.owner, ctx.repo_name, ctx.pr_number
     )
-    first_commit_line = (
-        commit_messages[0].split("\n")[0] if commit_messages else ""
-    )
-    expected_sha = _generate_override_sha(
-        ctx.source_pr, first_commit_line
-    )
+    first_commit_line = commit_messages[0].split("\n")[0] if commit_messages else ""
+    expected_sha = _generate_override_sha(ctx.source_pr, first_commit_line)
 
     if not ctx.override:
+        console.print("Source PR is not from a recognized automation tool.")
         console.print(
-            "Source PR is not from a recognized automation tool."
-        )
-        console.print(
-            f"To merge this and similar PRs, run again with: "
-            f"--override {expected_sha}"
+            f"To merge this and similar PRs, run again with: --override {expected_sha}"
         )
         console.print(
             f"This SHA is based on the author "
@@ -603,22 +581,14 @@ def _validate_automation_author(ctx: _MergeContext) -> None:
         )
         raise typer.Exit(0)
 
-    if not _validate_override_sha(
-        ctx.override, ctx.source_pr, first_commit_line
-    ):
+    if not _validate_override_sha(ctx.override, ctx.source_pr, first_commit_line):
         exit_with_error(
             ExitCode.VALIDATION_ERROR,
             message="❌ Invalid override SHA provided",
-            details=(
-                "Expected SHA for this PR and author: "
-                f"--override {expected_sha}"
-            ),
+            details=(f"Expected SHA for this PR and author: --override {expected_sha}"),
         )
 
-    console.print(
-        "Override SHA validated. "
-        "Proceeding with non-automation PR merge."
-    )
+    console.print("Override SHA validated. Proceeding with non-automation PR merge.")
 
 
 def _scan_and_find_similar(ctx: _MergeContext) -> None:
@@ -670,53 +640,32 @@ def _scan_and_find_similar(ctx: _MergeContext) -> None:
         summary = ctx.progress_tracker.get_summary()
         elapsed_time = summary.get("elapsed_time")
         total_prs_analyzed = summary.get("total_prs_analyzed")
-        completed_repositories = summary.get(
-            "completed_repositories"
-        )
+        completed_repositories = summary.get("completed_repositories")
         similar_prs_found = summary.get("similar_prs_found")
         errors_count = summary.get("errors_count", 0)
-        console.print(
-            f"\n✅ Analysis completed in {elapsed_time}"
-        )
+        console.print(f"\n✅ Analysis completed in {elapsed_time}")
         console.print(
             f"📊 Analyzed {total_prs_analyzed} PRs across "
             f"{completed_repositories} repositories"
         )
-        console.print(
-            f"🔍 Found {similar_prs_found} similar PRs"
-        )
+        console.print(f"🔍 Found {similar_prs_found} similar PRs")
         if errors_count > 0:
-            console.print(
-                f"⚠️  {errors_count} errors encountered "
-                "during analysis"
-            )
+            console.print(f"⚠️  {errors_count} errors encountered during analysis")
         console.print()
     else:
-        console.print(
-            f"\n🔍 Found {len(ctx.all_similar_prs)} "
-            "similar PRs"
-        )
+        console.print(f"\n🔍 Found {len(ctx.all_similar_prs)} similar PRs")
 
     if not ctx.all_similar_prs:
-        console.print(
-            "❌ No similar PRs found in the organization"
-        )
+        console.print("❌ No similar PRs found in the organization")
 
     for target_pr, comparison in ctx.all_similar_prs:
-        console.print(
-            f"  • {target_pr.repository_full_name} "
-            f"#{target_pr.number}"
-        )
-        console.print(
-            f"    {_format_condensed_similarity(comparison)}"
-        )
+        console.print(f"  • {target_pr.repository_full_name} #{target_pr.number}")
+        console.print(f"    {_format_condensed_similarity(comparison)}")
 
 
 def _run_parallel_merge(
     ctx: _MergeContext,
-    prs_to_merge: list[
-        tuple[PullRequestInfo, ComparisonResult | None]
-    ],
+    prs_to_merge: list[tuple[PullRequestInfo, ComparisonResult | None]],
     preview: bool,
     concurrency: int = 10,
 ) -> list[MergeResult]:
@@ -754,13 +703,8 @@ def _run_parallel_merge(
             rebase_local=ctx.rebase_local,
         ) as merge_manager:
             if not preview:
-                console.print(
-                    f"\n🚀 Merging {len(prs_to_merge)} "
-                    "pull requests..."
-                )
-            return await merge_manager.merge_prs_parallel(
-                prs_to_merge
-            )
+                console.print(f"\n🚀 Merging {len(prs_to_merge)} pull requests...")
+            return await merge_manager.merge_prs_parallel(prs_to_merge)
 
     return asyncio.run(_do_merge())
 
@@ -768,9 +712,7 @@ def _run_parallel_merge(
 def _handle_preview_confirmation(
     ctx: _MergeContext,
     merge_results: list[MergeResult],
-    all_prs_to_merge: list[
-        tuple[PullRequestInfo, ComparisonResult | None]
-    ],
+    all_prs_to_merge: list[tuple[PullRequestInfo, ComparisonResult | None]],
     merged_count: int,
     total_to_merge: int,
 ) -> None:
@@ -791,34 +733,22 @@ def _handle_preview_confirmation(
     commit_messages = ctx.github_client.get_pull_request_commits(
         ctx.owner, ctx.repo_name, ctx.pr_number
     )
-    first_commit_line = (
-        commit_messages[0].split("\n")[0] if commit_messages else ""
-    )
-    continue_sha_hash = _generate_continue_sha(
-        ctx.source_pr, first_commit_line
-    )
+    first_commit_line = commit_messages[0].split("\n")[0] if commit_messages else ""
+    continue_sha_hash = _generate_continue_sha(ctx.source_pr, first_commit_line)
     console.print()
-    console.print(
-        f"To proceed with merging enter: {continue_sha_hash}"
-    )
+    console.print(f"To proceed with merging enter: {continue_sha_hash}")
 
     try:
         if "pytest" in sys.modules or os.getenv("TESTING"):
-            console.print(
-                "⚠️  Test mode detected "
-                "- skipping interactive prompt"
-            )
+            console.print("⚠️  Test mode detected - skipping interactive prompt")
             return
 
         user_input = input(
-            "Enter the string above to continue "
-            "(or press Enter to cancel): "
+            "Enter the string above to continue (or press Enter to cancel): "
         ).strip()
 
         if user_input == continue_sha_hash:
-            _execute_confirmed_merge(
-                ctx, merge_results, all_prs_to_merge
-            )
+            _execute_confirmed_merge(ctx, merge_results, all_prs_to_merge)
         elif user_input == "":
             console.print("❌ Merge cancelled by user.")
         else:
@@ -832,9 +762,7 @@ def _handle_preview_confirmation(
 def _execute_confirmed_merge(
     ctx: _MergeContext,
     preview_results: list[MergeResult],
-    all_prs_to_merge: list[
-        tuple[PullRequestInfo, ComparisonResult | None]
-    ],
+    all_prs_to_merge: list[tuple[PullRequestInfo, ComparisonResult | None]],
 ) -> None:
     """Run the real merge after user confirmation."""
     mergeable_prs = [
@@ -843,26 +771,14 @@ def _execute_confirmed_merge(
         if result.status.value == "merged"
     ]
     merged_count = len(mergeable_prs)
-    console.print(
-        f"\n🔨 Merging {merged_count} mergeable pull requests..."
-    )
+    console.print(f"\n🔨 Merging {merged_count} mergeable pull requests...")
 
-    real_results = _run_parallel_merge(
-        ctx, mergeable_prs, preview=False
-    )
+    real_results = _run_parallel_merge(ctx, mergeable_prs, preview=False)
 
-    final_merged = sum(
-        1 for r in real_results if r.status.value == "merged"
-    )
-    final_failed = sum(
-        1 for r in real_results if r.status.value == "failed"
-    )
-    final_skipped = sum(
-        1 for r in real_results if r.status.value == "skipped"
-    )
-    final_blocked = sum(
-        1 for r in real_results if r.status.value == "blocked"
-    )
+    final_merged = sum(1 for r in real_results if r.status.value == "merged")
+    final_failed = sum(1 for r in real_results if r.status.value == "failed")
+    final_skipped = sum(1 for r in real_results if r.status.value == "skipped")
+    final_blocked = sum(1 for r in real_results if r.status.value == "blocked")
     final_auto_merge = sum(
         1 for r in real_results if r.status.value == "auto_merge_pending"
     )
@@ -870,6 +786,8 @@ def _execute_confirmed_merge(
     if final_auto_merge > 0:
         parts.append(f"{final_auto_merge} auto-merge pending")
     parts.append(f"{final_failed} failed")
+    if final_skipped > 0:
+        parts.append(f"{final_skipped} skipped")
     console.print(f"\n🚀 Final Results: {', '.join(parts)}")
     if final_skipped > 0:
         console.print(f"⏭️  Skipped {final_skipped} PRs")
@@ -884,27 +802,17 @@ def _display_merge_results(
     no_confirm: bool,
 ) -> None:
     """Print the final summary of merge results."""
-    merged_count = sum(
-        1 for r in merge_results if r.status.value == "merged"
-    )
-    failed_count = sum(
-        1 for r in merge_results if r.status.value == "failed"
-    )
-    skipped_count = sum(
-        1 for r in merge_results if r.status.value == "skipped"
-    )
-    blocked_count = sum(
-        1 for r in merge_results if r.status.value == "blocked"
-    )
+    merged_count = sum(1 for r in merge_results if r.status.value == "merged")
+    failed_count = sum(1 for r in merge_results if r.status.value == "failed")
+    skipped_count = sum(1 for r in merge_results if r.status.value == "skipped")
+    blocked_count = sum(1 for r in merge_results if r.status.value == "blocked")
     auto_merge_count = sum(
         1 for r in merge_results if r.status.value == "auto_merge_pending"
     )
 
     if failed_count > 0:
         if not no_confirm:
-            console.print(
-                f"❌ Would fail to merge {failed_count} PRs"
-            )
+            console.print(f"❌ Would fail to merge {failed_count} PRs")
         else:
             console.print(f"❌ Failed {failed_count} PRs")
     if skipped_count > 0:
@@ -919,6 +827,8 @@ def _display_merge_results(
         if auto_merge_count > 0:
             parts.append(f"{auto_merge_count} auto-merge pending")
         parts.append(f"{failed_count} failed")
+        if skipped_count > 0:
+            parts.append(f"{skipped_count} skipped")
         console.print(f"📈 Final Results: {', '.join(parts)}")
 
 
@@ -956,10 +866,7 @@ def _handle_repo_merge(
     ctx.owner = parsed_repo.owner
     ctx.repo_name = parsed_repo.repo
 
-    console.print(
-        f"🔍 Repository mode: fetching open PRs in "
-        f"{parsed_repo.project}..."
-    )
+    console.print(f"🔍 Repository mode: fetching open PRs in {parsed_repo.project}...")
 
     # --- Token permission check (reuse existing helper) ---
     _check_merge_permissions(ctx)
@@ -1003,10 +910,7 @@ def _handle_repo_merge(
 
     if not repo_prs:
         label = "automation " if only_automation else ""
-        console.print(
-            f"❌ No open {label}PRs found in "
-            f"{parsed_repo.project}"
-        )
+        console.print(f"❌ No open {label}PRs found in {parsed_repo.project}")
         return
 
     # --- Classify PRs as automation vs human ---
@@ -1027,67 +931,50 @@ def _handle_repo_merge(
         else:
             human_prs.append(pr)
 
-    console.print(
-        f"\n📊 Found {len(repo_prs)} open PR(s) in "
-        f"{parsed_repo.project}"
-    )
+    console.print(f"\n📊 Found {len(repo_prs)} open PR(s) in {parsed_repo.project}")
     if automation_prs:
-        console.print(
-            f"   🤖 Automation PRs: {len(automation_prs)}"
-        )
+        console.print(f"   🤖 Automation PRs: {len(automation_prs)}")
     if human_prs:
-        console.print(
-            f"   👤 Human PRs: {len(human_prs)}"
-        )
+        console.print(f"   👤 Human PRs: {len(human_prs)}")
 
     # List PRs that will be processed
     for pr in repo_prs:
         icon = "🤖" if _is_auto(pr.author) else "👤"
-        console.print(
-            f"  {icon} #{pr.number} {pr.title} "
-            f"(by {pr.author})"
-        )
+        console.print(f"  {icon} #{pr.number} {pr.title} (by {pr.author})")
 
     # --- Human PR confirmation gate ---
     # Only prompt when human PRs are actually in scope, not merely
     # because --include-human-prs was supplied.
     needs_human_confirm = bool(human_prs) and not ctx.no_confirm
     if needs_human_confirm:
-        console.print(
-            "\n⚠️  Human-authored PRs are included in this "
-            "merge operation."
-        )
-        console.print(
-            "   Review the list above carefully before "
-            "proceeding."
-        )
+        console.print("\n⚠️  Human-authored PRs are included in this merge operation.")
+        console.print("   Review the list above carefully before proceeding.")
         try:
-            user_input = typer.prompt(
-                "Type 'yes' to include human PRs, "
-                "or press Enter to skip them",
-                default="",
-                show_default=False,
-            ).strip().lower()
-            if user_input != "yes":
-                console.print(
-                    "ℹ️  Excluding human PRs from merge."
+            user_input = (
+                typer.prompt(
+                    "Type 'yes' to include human PRs, or press Enter to skip them",
+                    default="",
+                    show_default=False,
                 )
+                .strip()
+                .lower()
+            )
+            if user_input != "yes":
+                console.print("ℹ️  Excluding human PRs from merge.")
                 # Remove human PRs from the working set
                 repo_prs = automation_prs
                 human_prs = []
                 if not repo_prs:
-                    console.print(
-                        "❌ No automation PRs remain to merge."
-                    )
+                    console.print("❌ No automation PRs remain to merge.")
                     return
         except (KeyboardInterrupt, EOFError, typer.Abort):
             console.print("\n❌ Merge cancelled by user.")
             return
 
     # --- Build the merge list (ComparisonResult is None for repo mode) ---
-    all_prs_to_merge: list[
-        tuple[PullRequestInfo, ComparisonResult | None]
-    ] = [(pr, None) for pr in repo_prs]
+    all_prs_to_merge: list[tuple[PullRequestInfo, ComparisonResult | None]] = [
+        (pr, None) for pr in repo_prs
+    ]
 
     # --- Preview / merge using existing infrastructure ---
     if ctx.show_progress:
@@ -1126,10 +1013,7 @@ def _handle_repo_merge(
         console.print("❌ No PRs were processed")
         return
 
-    merged_count = sum(
-        1 for r in merge_results
-        if r.status.value == "merged"
-    )
+    merged_count = sum(1 for r in merge_results if r.status.value == "merged")
 
     if not ctx.no_confirm:
         # In preview mode, show what would happen, then prompt
@@ -1149,9 +1033,7 @@ def _handle_repo_merge(
 def _handle_repo_preview_confirmation(
     ctx: _MergeContext,
     merge_results: list[MergeResult],
-    all_prs_to_merge: list[
-        tuple[PullRequestInfo, ComparisonResult | None]
-    ],
+    all_prs_to_merge: list[tuple[PullRequestInfo, ComparisonResult | None]],
     merged_count: int,
     total_to_merge: int,
 ) -> None:
@@ -1167,31 +1049,21 @@ def _handle_repo_preview_confirmation(
         return
 
     # Generate a confirmation token from the repo context
-    combined = (
-        f"repo-merge:{ctx.owner}/{ctx.repo_name}:"
-        f"{merged_count}"
-    )
-    confirm_hash = hashlib.sha256(
-        combined.encode("utf-8")
-    ).hexdigest()[:16]
+    combined = f"repo-merge:{ctx.owner}/{ctx.repo_name}:{merged_count}"
+    confirm_hash = hashlib.sha256(combined.encode("utf-8")).hexdigest()[:16]
 
     console.print()
-    console.print(
-        f"To proceed with merging enter: {confirm_hash}"
-    )
+    console.print(f"To proceed with merging enter: {confirm_hash}")
 
     try:
         user_input = typer.prompt(
-            "Enter the string above to continue "
-            "(or press Enter to cancel)",
+            "Enter the string above to continue (or press Enter to cancel)",
             default="",
             show_default=False,
         ).strip()
 
         if user_input == confirm_hash:
-            _execute_repo_confirmed_merge(
-                ctx, merge_results, all_prs_to_merge
-            )
+            _execute_repo_confirmed_merge(ctx, merge_results, all_prs_to_merge)
         elif user_input == "":
             console.print("❌ Merge cancelled by user.")
         else:
@@ -1203,9 +1075,7 @@ def _handle_repo_preview_confirmation(
 def _execute_repo_confirmed_merge(
     ctx: _MergeContext,
     preview_results: list[MergeResult],
-    all_prs_to_merge: list[
-        tuple[PullRequestInfo, ComparisonResult | None]
-    ],
+    all_prs_to_merge: list[tuple[PullRequestInfo, ComparisonResult | None]],
 ) -> None:
     """Run the real merge after user confirmation (repo mode)."""
     mergeable_prs = [
@@ -1214,9 +1084,7 @@ def _execute_repo_confirmed_merge(
         if result.status.value == "merged"
     ]
     merged_count = len(mergeable_prs)
-    console.print(
-        f"\n🔨 Merging {merged_count} mergeable pull requests..."
-    )
+    console.print(f"\n🔨 Merging {merged_count} mergeable pull requests...")
 
     if ctx.show_progress:
         ctx.progress_tracker = MergeProgressTracker(
@@ -1240,18 +1108,10 @@ def _execute_repo_confirmed_merge(
         if ctx.show_progress and ctx.progress_tracker:
             ctx.progress_tracker.stop()
 
-    final_merged = sum(
-        1 for r in real_results if r.status.value == "merged"
-    )
-    final_failed = sum(
-        1 for r in real_results if r.status.value == "failed"
-    )
-    final_skipped = sum(
-        1 for r in real_results if r.status.value == "skipped"
-    )
-    final_blocked = sum(
-        1 for r in real_results if r.status.value == "blocked"
-    )
+    final_merged = sum(1 for r in real_results if r.status.value == "merged")
+    final_failed = sum(1 for r in real_results if r.status.value == "failed")
+    final_skipped = sum(1 for r in real_results if r.status.value == "skipped")
+    final_blocked = sum(1 for r in real_results if r.status.value == "blocked")
     final_auto_merge = sum(
         1 for r in real_results if r.status.value == "auto_merge_pending"
     )
@@ -1259,6 +1119,8 @@ def _execute_repo_confirmed_merge(
     if final_auto_merge > 0:
         parts.append(f"{final_auto_merge} auto-merge pending")
     parts.append(f"{final_failed} failed")
+    if final_skipped > 0:
+        parts.append(f"{final_skipped} skipped")
     console.print(f"\n🚀 Final Results: {', '.join(parts)}")
     if final_skipped > 0:
         console.print(f"⏭️  Skipped {final_skipped} PRs")
@@ -1306,8 +1168,12 @@ def _handle_gerrit_merge(
         console.print("❌ Gerrit credentials not found.")
         console.print("   Options:")
         console.print("   1. Create a ~/.netrc file with Gerrit credentials")
-        console.print("   2. Set GERRIT_USERNAME and GERRIT_PASSWORD environment variables")
-        console.print("   Tip: Source your .secrets.gerrit file and run use_lf or use_onap")
+        console.print(
+            "   2. Set GERRIT_USERNAME and GERRIT_PASSWORD environment variables"
+        )
+        console.print(
+            "   Tip: Source your .secrets.gerrit file and run use_lf or use_onap"
+        )
         raise typer.Exit(1)
 
     if verbose:
@@ -1370,7 +1236,9 @@ def _handle_gerrit_merge(
                     console.print("\n   Conflicting files:")
                     for file_path in rebase_result["conflicting_files"]:
                         console.print(f"   • {file_path}")
-                console.print("\n💡 To resolve: manually rebase the change locally and push a new patchset.")
+                console.print(
+                    "\n💡 To resolve: manually rebase the change locally and push a new patchset."
+                )
                 console.print(f"   git review -d {source_change.number}")
                 console.print(f"   git rebase origin/{source_change.branch}")
                 console.print("   # resolve conflicts, then:")
@@ -1393,15 +1261,19 @@ def _handle_gerrit_merge(
 
         if similar_changes:
             for change, comparison in similar_changes:
-                console.print(f"  • {change.project} #{change.number}: {change.subject}")
+                console.print(
+                    f"  • {change.project} #{change.number}: {change.subject}"
+                )
                 console.print(f"    {_format_gerrit_similarity(comparison)}")
 
         # Prepare list of changes to submit (similar + source)
         source_entry: tuple[GerritChangeInfo, GerritComparisonResult | None] = (
-            source_change, None
+            source_change,
+            None,
         )
         all_changes: list[tuple[GerritChangeInfo, GerritComparisonResult | None]] = [
-            *similar_changes, source_entry
+            *similar_changes,
+            source_entry,
         ]
 
         # Check permissions on the source change before proceeding
@@ -1419,11 +1291,17 @@ def _handle_gerrit_merge(
 
         if not no_confirm:
             # Preview mode - show permission status
-            console.print(f"\n📊 Preview: {len(all_changes)} changes would be reviewed and submitted")
+            console.print(
+                f"\n📊 Preview: {len(all_changes)} changes would be reviewed and submitted"
+            )
             if source_change.has_required_permissions():
-                console.print("   ✅ You appear to have required permissions (+2 Code-Review, submit)")
+                console.print(
+                    "   ✅ You appear to have required permissions (+2 Code-Review, submit)"
+                )
             else:
-                console.print("   ⚠️  You may not have all required permissions (see warnings above)")
+                console.print(
+                    "   ⚠️  You may not have all required permissions (see warnings above)"
+                )
             console.print("\nTo proceed, run with --no-confirm flag")
             return
 
@@ -1455,7 +1333,9 @@ def _handle_gerrit_merge(
         # Show details for failed submissions
         for result in results:
             if not result.success:
-                console.print(f"\n   ❌ {result.project} #{result.change_number}: {result.error}")
+                console.print(
+                    f"\n   ❌ {result.project} #{result.change_number}: {result.error}"
+                )
 
     except typer.Exit:
         # Re-raise typer.Exit without treating it as an error
@@ -1471,6 +1351,7 @@ def _handle_gerrit_merge(
         console.print(f"❌ Error during Gerrit merge operation: {e}")
         if verbose:
             import traceback
+
             traceback.print_exc()
         raise typer.Exit(1) from None
 
@@ -1824,11 +1705,13 @@ def merge(
         # Build full list and run parallel merge
         assert ctx.source_pr is not None
         source_entry: tuple[PullRequestInfo, ComparisonResult | None] = (
-            ctx.source_pr, None
+            ctx.source_pr,
+            None,
         )
-        all_prs_to_merge: list[
-            tuple[PullRequestInfo, ComparisonResult | None]
-        ] = [*ctx.all_similar_prs, source_entry]
+        all_prs_to_merge: list[tuple[PullRequestInfo, ComparisonResult | None]] = [
+            *ctx.all_similar_prs,
+            source_entry,
+        ]
         merge_results = _run_parallel_merge(
             ctx, all_prs_to_merge, preview=not ctx.no_confirm
         )
@@ -1838,10 +1721,7 @@ def merge(
             console.print("❌ No PRs were processed")
             return
 
-        merged_count = sum(
-            1 for r in merge_results
-            if r.status.value == "merged"
-        )
+        merged_count = sum(1 for r in merge_results if r.status.value == "merged")
 
         if not ctx.no_confirm:
             _handle_preview_confirmation(
@@ -1912,13 +1792,9 @@ def _print_debug_matching(ctx: _MergeContext) -> None:
         "   Extracted package: "
         f"'{ctx.comparator._extract_package_name(ctx.source_pr.title)}'"
     )
-    console.print(
-        f"   Similarity threshold: {ctx.similarity_threshold}"
-    )
+    console.print(f"   Similarity threshold: {ctx.similarity_threshold}")
     if ctx.source_pr.body:
-        console.print(
-            f"   Body preview: {ctx.source_pr.body[:100]}..."
-        )
+        console.print(f"   Body preview: {ctx.source_pr.body[:100]}...")
         console.print(
             "   Is dependabot body: "
             f"{ctx.comparator._is_dependabot_body(ctx.source_pr.body)}"
@@ -1926,7 +1802,6 @@ def _print_debug_matching(ctx: _MergeContext) -> None:
     else:
         console.print("   ⚠️  Source PR has no body")
     console.print()
-
 
 
 def _display_pr_info(

--- a/src/dependamerge/cli.py
+++ b/src/dependamerge/cli.py
@@ -729,8 +729,11 @@ def _run_parallel_merge(
         concurrency: Maximum number of concurrent merge workers.
             For org-wide merges (PRs spread across repos) the default
             of 10 is fine.  For repo-scoped merges (all PRs in the
-            same repo) use 1 to serialise operations and give GitHub
-            time to propagate approvals between merges.
+            same repo) ``AsyncMergeManager`` serialises the actual
+            ``merge_pull_request`` API call via a per-repo dispatch
+            lock, so a value > 1 is safe and lets the worker pool
+            keep processing other PRs while one PR sits in Step 5.5's
+            auto-merge wait loop — see ``_get_merge_dispatch_lock``.
     """
 
     async def _do_merge():
@@ -1097,12 +1100,23 @@ def _handle_repo_merge(
         ctx.progress_tracker.start()
 
     try:
-        # Serialise merges for repo-scoped operations: all PRs target
-        # the same repository, so parallel approve+merge would race
-        # against GitHub's branch-protection propagation and cause
-        # spurious "branch protection" failures.
+        # Per-repo merge dispatch is serialised inside
+        # ``AsyncMergeManager`` (see ``_get_merge_dispatch_lock``),
+        # so it is now safe to run multiple workers against PRs
+        # that target the same repository — only the actual
+        # ``merge_pull_request`` call queues, while approve,
+        # rebase, and the Step 5.5 auto-merge wait run in
+        # parallel.
         merge_results = _run_parallel_merge(
-            ctx, all_prs_to_merge, preview=not ctx.no_confirm, concurrency=1
+            ctx,
+            all_prs_to_merge,
+            preview=not ctx.no_confirm,
+            # Allow parallel workers; the merge dispatch itself is
+            # serialised per repo by ``AsyncMergeManager`` so PRs
+            # parked in Step 5.5's wait loop no longer block other
+            # PRs in the batch.  Cap by PR count so we don't spawn
+            # more workers than there is work.
+            concurrency=min(5, len(all_prs_to_merge)) or 1,
         )
     finally:
         if ctx.show_progress and ctx.progress_tracker:
@@ -1215,7 +1229,12 @@ def _execute_repo_confirmed_merge(
 
     try:
         real_results = _run_parallel_merge(
-            ctx, mergeable_prs, preview=False, concurrency=1
+            ctx,
+            mergeable_prs,
+            preview=False,
+            # Per-repo merge dispatch lock makes parallel workers
+            # safe; cap by PR count.
+            concurrency=min(5, len(mergeable_prs)) or 1,
         )
     finally:
         if ctx.show_progress and ctx.progress_tracker:

--- a/src/dependamerge/cli.py
+++ b/src/dependamerge/cli.py
@@ -6,6 +6,7 @@ import hashlib
 import logging
 import os
 import sys
+from collections import OrderedDict
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
@@ -528,18 +529,61 @@ def _check_merge_permissions(ctx: _MergeContext) -> None:
         ]
         if missing_perms:
             console.print("\n❌ Token Permission Check Failed:\n")
+            # Group failing operations by their guidance tuple so we
+            # don't repeat the same URL block once per failed
+            # operation.  In the common 401 / expired-token case
+            # every operation lands on the same guidance, which
+            # used to produce four near-identical six-line blocks;
+            # under the grouped renderer it collapses to a single
+            # list of operations followed by one guidance block.
+            # The 403 case (per-operation scope guidance) naturally
+            # falls out as one group per distinct guidance tuple,
+            # so each operation still gets its own scope hint.
+            groups: OrderedDict[
+                tuple[str | None, str | None, str | None],
+                list[tuple[str, str]],
+            ] = OrderedDict()
             for op in missing_perms:
                 result = perm_results[op]
-                console.print(f"   • {op}: {result['error']}")
-                if result.get("guidance"):
-                    console.print(
-                        f"     Classic: {result['guidance'].get('classic', 'N/A')}"
-                    )
-                    console.print(
-                        f"     Fine-grained: "
-                        f"{result['guidance'].get('fine_grained', 'N/A')}"
-                    )
-            console.print("\n💡 Update your token permissions and try again.")
+                guidance = result.get("guidance") or {}
+                key = (
+                    guidance.get("classic"),
+                    guidance.get("fine_grained"),
+                    guidance.get("fix"),
+                )
+                groups.setdefault(key, []).append(
+                    (op, result.get("error", ""))
+                )
+
+            for key, items in groups.items():
+                classic, fine_grained, fix = key
+                # List the failing operations in this group.
+                for op, _err in items:
+                    console.print(f"   • {op}")
+                # Show the shared error message once if every op
+                # in the group reports the same one (the 401 case);
+                # otherwise show each operation's message inline
+                # so distinct failures stay distinguishable.
+                distinct_errors = {err for _, err in items if err}
+                if len(distinct_errors) == 1:
+                    console.print(f"\n   {next(iter(distinct_errors))}")
+                elif distinct_errors:
+                    console.print()
+                    for op, err in items:
+                        if err:
+                            console.print(f"   {op}: {err}")
+                # Single guidance block for the whole group.
+                if classic or fine_grained or fix:
+                    console.print()
+                    if classic:
+                        console.print(f"   Classic:       {classic}")
+                    if fine_grained:
+                        console.print(f"   Fine-grained:  {fine_grained}")
+                    if fix:
+                        console.print(f"   Fix:           {fix}")
+                console.print()  # blank line between groups
+
+            console.print("💡 Update your token permissions and try again.")
             raise typer.Exit(code=3)
         console.print("✅ Token has required permissions")
     except GitHubPermissionError as e:

--- a/src/dependamerge/cli.py
+++ b/src/dependamerge/cli.py
@@ -504,25 +504,28 @@ def _check_merge_permissions(ctx: _MergeContext) -> None:
 
     try:
         perm_results = asyncio.run(_check())
-        # Separate blocking failures from advisory warnings.
-        # branch_protection (Administration: Read) is advisory — the
-        # merge flow tolerates missing visibility and the token can
-        # still approve/merge successfully without it.
-        _ADVISORY_OPS = {"branch_protection"}
+        # Every permission probed by the pre-flight check is now
+        # required by some part of the merge flow:
+        #
+        # * ``approve``, ``merge``, ``update_branch`` — obviously
+        #   needed for the core merge actions.
+        # * ``branch_protection`` — used by the signature-preserving
+        #   local-rebase gate (``requires_commit_signatures``) and
+        #   by Step 5.5's block-reason analysis.  A token without
+        #   it degrades the merge flow in ways that are confusing
+        #   to diagnose at runtime, so treat it as blocking up-front.
+        #
+        # There is consequently no advisory class — a missing
+        # permission is always a hard failure.  If a future
+        # operation is genuinely optional, partition
+        # ``missing_perms`` into blocking and advisory subsets
+        # (and re-introduce the ``⚠️ … (non-blocking)`` display
+        # for the advisory subset) at that point.
         missing_perms = [
             op
             for op, result in perm_results.items()
-            if not result["has_permission"] and op not in _ADVISORY_OPS
+            if not result["has_permission"]
         ]
-        advisory_perms = [
-            op
-            for op, result in perm_results.items()
-            if not result["has_permission"] and op in _ADVISORY_OPS
-        ]
-        if advisory_perms:
-            for op in advisory_perms:
-                result = perm_results[op]
-                console.print(f"⚠️  {op}: {result['error']} (non-blocking)")
         if missing_perms:
             console.print("\n❌ Token Permission Check Failed:\n")
             for op in missing_perms:

--- a/src/dependamerge/cli.py
+++ b/src/dependamerge/cli.py
@@ -523,9 +523,7 @@ def _check_merge_permissions(ctx: _MergeContext) -> None:
         # (and re-introduce the ``⚠️ … (non-blocking)`` display
         # for the advisory subset) at that point.
         missing_perms = [
-            op
-            for op, result in perm_results.items()
-            if not result["has_permission"]
+            op for op, result in perm_results.items() if not result["has_permission"]
         ]
         if missing_perms:
             console.print("\n❌ Token Permission Check Failed:\n")
@@ -551,9 +549,7 @@ def _check_merge_permissions(ctx: _MergeContext) -> None:
                     guidance.get("fine_grained"),
                     guidance.get("fix"),
                 )
-                groups.setdefault(key, []).append(
-                    (op, result.get("error", ""))
-                )
+                groups.setdefault(key, []).append((op, result.get("error", "")))
 
             for key, items in groups.items():
                 classic, fine_grained, fix = key
@@ -706,12 +702,19 @@ def _scan_and_find_similar(ctx: _MergeContext) -> None:
         console.print(f"🔍 Found {similar_prs_found} similar PRs")
         if errors_count > 0:
             console.print(f"⚠️  {errors_count} errors encountered during analysis")
-        console.print()
+        # The trailing blank line delineates the similar-PR list that
+        # follows.  When no similar PRs were found there is no list to
+        # separate, so the blank line is suppressed (see below).
+        if ctx.all_similar_prs:
+            console.print()
     else:
         console.print(f"\n🔍 Found {len(ctx.all_similar_prs)} similar PRs")
 
     if not ctx.all_similar_prs:
-        console.print("❌ No similar PRs found in the organization")
+        # Not a failure: the supplied PR is simply the only one to
+        # merge.  Use a neutral "skip ahead" glyph rather than ❌ so
+        # the output does not read like an error.
+        console.print("⏩ No similar PRs found in the organization")
 
     for target_pr, comparison in ctx.all_similar_prs:
         console.print(f"  • {target_pr.repository_full_name} #{target_pr.number}")
@@ -723,6 +726,7 @@ def _run_parallel_merge(
     prs_to_merge: list[tuple[PullRequestInfo, ComparisonResult | None]],
     preview: bool,
     concurrency: int = 10,
+    leading_blank: bool = True,
 ) -> list[MergeResult]:
     """Execute a parallel merge (preview or real) and return results.
 
@@ -738,6 +742,11 @@ def _run_parallel_merge(
             lock, so a value > 1 is safe and lets the worker pool
             keep processing other PRs while one PR sits in Step 5.5's
             auto-merge wait loop — see ``_get_merge_dispatch_lock``.
+        leading_blank: When True (default), the ``🚀 Merging ...``
+            banner is preceded by a blank line to separate it from a
+            preceding similar-PR list.  Callers pass False when no
+            list was printed (e.g. no similar PRs were found) so the
+            output stays compact.
     """
 
     async def _do_merge():
@@ -758,7 +767,10 @@ def _run_parallel_merge(
             rebase_local=ctx.rebase_local,
         ) as merge_manager:
             if not preview:
-                console.print(f"\n🚀 Merging {len(prs_to_merge)} pull requests...")
+                prefix = "\n" if leading_blank else ""
+                console.print(
+                    f"{prefix}🚀 Merging {len(prs_to_merge)} pull requests..."
+                )
             return await merge_manager.merge_prs_parallel(prs_to_merge)
 
     return asyncio.run(_do_merge())
@@ -1016,14 +1028,15 @@ def _handle_repo_merge(
 
     console.print(f"\n📊 Found {len(repo_prs)} open PR(s) in {parsed_repo.project}")
     if automation_prs:
-        console.print(f"   🤖 Automation PRs: {len(automation_prs)}")
+        console.print(f"🤖 Automation PRs: {len(automation_prs)}")
     if human_prs:
-        console.print(f"   👤 Human PRs: {len(human_prs)}")
+        console.print(f"👤 Human PRs: {len(human_prs)}")
 
-    # List PRs that will be processed
+    # List PRs that will be processed. The trailing ``(by {author})``
+    # already reveals whether each PR is automation or human, so a
+    # per-row icon would only duplicate the summary counts above.
     for pr in repo_prs:
-        icon = "🤖" if _is_auto(pr.author) else "👤"
-        console.print(f"  {icon} #{pr.number} {pr.title} (by {pr.author})")
+        console.print(f"  #{pr.number} {pr.title} (by {pr.author})")
 
     # --- Human PR confirmation gate ---
     # Only prompt when human PRs are actually in scope, not merely
@@ -1798,7 +1811,12 @@ def merge(
             source_entry,
         ]
         merge_results = _run_parallel_merge(
-            ctx, all_prs_to_merge, preview=not ctx.no_confirm
+            ctx,
+            all_prs_to_merge,
+            preview=not ctx.no_confirm,
+            # No similar-PR list was printed when none were found, so
+            # skip the blank line before the merge banner.
+            leading_blank=bool(ctx.all_similar_prs),
         )
 
         # Process and display results
@@ -2112,7 +2130,10 @@ def close(
             console.print(f"\n🔍 Found {len(all_similar_prs)} similar PRs")
 
         if not all_similar_prs:
-            console.print("❌ No similar PRs found in the organization")
+            # Not a failure: the supplied PR is simply the only one to
+            # close.  Use a neutral glyph rather than ❌ so the output
+            # does not read like an error.
+            console.print("⏩ No similar PRs found in the organization")
 
         for target_pr, comparison in all_similar_prs:
             console.print(f"  • {target_pr.repository_full_name} #{target_pr.number}")

--- a/src/dependamerge/cli.py
+++ b/src/dependamerge/cli.py
@@ -542,6 +542,14 @@ def _check_merge_permissions(ctx: _MergeContext) -> None:
     except GitHubPermissionError as e:
         console.print(f"\n❌ Permission check failed: {e}")
         raise typer.Exit(code=3) from e
+    except typer.Exit:
+        # The hard-failure branch above raises typer.Exit(code=3)
+        # to abort the run.  Without re-raising it here it would
+        # be caught by the broad ``except Exception`` below and
+        # silently downgraded to "Continuing anyway...", letting
+        # the merge proceed against a token we already know lacks
+        # the required permissions.
+        raise
     except Exception as e:
         console.print(f"⚠️  Could not verify permissions: {e}")
         console.print("   Continuing anyway...")

--- a/src/dependamerge/cli.py
+++ b/src/dependamerge/cli.py
@@ -804,6 +804,28 @@ def _execute_confirmed_merge(
     if final_auto_merge > 0:
         console.print(f"⏳ Auto-merge pending for {final_auto_merge} PRs")
 
+    _print_failed_pr_details(real_results)
+
+
+def _print_failed_pr_details(
+    merge_results: list[MergeResult],
+) -> None:
+    """Print URL and reason for each failed PR in the result list.
+
+    A bare ``Failed: 1`` line in the summary forces the user to
+    scroll back through the merge output to find which PR failed
+    and why.  Surface that information directly so the failure is
+    actionable from the final summary alone.
+    """
+    failed = [r for r in merge_results if r.status.value == "failed"]
+    if not failed:
+        return
+    console.print("\n❌ Failed PRs:")
+    for r in failed:
+        url = getattr(r.pr_info, "html_url", "<unknown>")
+        reason = r.error or "no reason reported"
+        console.print(f"   • {url}\n     {reason}")
+
 
 def _display_merge_results(
     merge_results: list[MergeResult],
@@ -838,6 +860,8 @@ def _display_merge_results(
         if skipped_count > 0:
             parts.append(f"{skipped_count} skipped")
         console.print(f"📈 Final Results: {', '.join(parts)}")
+
+    _print_failed_pr_details(merge_results)
 
 
 def _handle_repo_merge(
@@ -882,11 +906,15 @@ def _handle_repo_merge(
     # --- Progress tracker ---
     if ctx.show_progress:
         ctx.progress_tracker = MergeProgressTracker(
-            ctx.owner,
+            f"{ctx.owner}/{ctx.repo_name}",
             operation_label="Fetching open PRs",
             operation_icon="🔍",
         )
-        ctx.progress_tracker.update_total_repositories(1)
+        # Repo-scoped runs operate on a single repository, so the
+        # ``X/Y repos`` progress fraction is meaningless.  Skip
+        # ``update_total_repositories`` so the tracker falls through
+        # to the no-progress display branch and renders cleanly as
+        # ``🔍 Fetching open PRs in <owner>/<repo>``.
         ctx.progress_tracker.start()
 
     # --- Fetch open PRs for the repository ---
@@ -987,7 +1015,7 @@ def _handle_repo_merge(
     # --- Preview / merge using existing infrastructure ---
     if ctx.show_progress:
         ctx.progress_tracker = MergeProgressTracker(
-            ctx.owner,
+            f"{ctx.owner}/{ctx.repo_name}",
             operation_label="Merging PRs",
             operation_icon="🔀",
         )
@@ -1096,7 +1124,7 @@ def _execute_repo_confirmed_merge(
 
     if ctx.show_progress:
         ctx.progress_tracker = MergeProgressTracker(
-            ctx.owner,
+            f"{ctx.owner}/{ctx.repo_name}",
             operation_label="Merging PRs",
             operation_icon="🔀",
         )
@@ -1136,6 +1164,8 @@ def _execute_repo_confirmed_merge(
         console.print(f"🛑 Blocked {final_blocked} PRs")
     if final_auto_merge > 0:
         console.print(f"⏳ Auto-merge pending for {final_auto_merge} PRs")
+
+    _print_failed_pr_details(real_results)
 
 
 def _handle_gerrit_merge(

--- a/src/dependamerge/git_ops.py
+++ b/src/dependamerge/git_ops.py
@@ -322,7 +322,28 @@ def fetch(
     prune: bool = False,
     logger: Callable[[str], None] | None = None,
 ) -> None:
-    """Fetch refs with optional shallow/unshallow behavior."""
+    """Fetch refs with optional shallow/unshallow behavior.
+
+    .. warning::
+
+       Passing a *bare* branch name (e.g. ``fetch("origin", "main")``)
+       only populates ``FETCH_HEAD``; it does **not** update
+       ``refs/remotes/<remote>/<branch>`` unless the remote's
+       configured fetch refspec already covers that branch.  After a
+       ``--single-branch`` clone (which is :func:`clone`'s default)
+       the configured refspec covers only the branch the clone
+       targeted, so a subsequent ``fetch("origin", "main")`` leaves
+       ``origin/main`` *undefined* locally and any downstream
+       ``rebase`` / ``merge`` / ``rev-list`` against ``origin/main``
+       fails with ``fatal: invalid upstream 'origin/main'``.
+
+       When the caller wants the fetched branch to be usable as a
+       remote-tracking ref (the usual case), use :func:`fetch_branch`
+       instead, which always writes through an explicit refspec
+       mapping.  Callers that genuinely want
+       ``FETCH_HEAD``-only semantics (e.g. preparing a one-shot
+       ``git merge FETCH_HEAD``) can keep using the bare form here.
+    """
     args = ["git", "fetch", remote]
     if prune:
         args.append("--prune")
@@ -336,6 +357,49 @@ def fetch(
     else:
         args.extend(list(refspecs))
     run_git(args, cwd=cwd, logger=logger)
+
+
+def fetch_branch(
+    remote: str,
+    branch: str,
+    *,
+    cwd: PathLike,
+    depth: int | None = None,
+    force: bool = True,
+    logger: Callable[[str], None] | None = None,
+) -> None:
+    """Fetch ``branch`` from ``remote`` into ``refs/remotes/<remote>/<branch>``.
+
+    Wraps :func:`fetch` with an explicit refspec mapping so the
+    remote-tracking ref always lands locally, regardless of the
+    remote's configured fetch refspec.  This is the safe form to
+    use after a ``--single-branch`` clone (which is :func:`clone`'s
+    default) when subsequent code needs to refer to
+    ``<remote>/<branch>`` — e.g. as the target of
+    :func:`rebase` / :func:`rev_list_count` / a ``log <r>/<b>..HEAD``
+    invocation.
+
+    A bare ``git fetch <remote> <branch>`` would only populate
+    ``FETCH_HEAD`` in that scenario and the downstream rebase would
+    fail with ``fatal: invalid upstream '<remote>/<branch>'``
+    — see :func:`fetch` for the full background.
+
+    Args:
+        remote: Remote name (e.g. ``"origin"`` or ``"upstream"``).
+        branch: Branch name on the remote (no ``refs/heads/`` prefix).
+        cwd: Working directory in which to run ``git``.
+        depth: Optional shallow-fetch depth.  ``None`` means
+            "inherit the existing depth" (no ``--depth`` flag).
+        force: When True (the default), prepend ``+`` to the
+            refspec so the remote-tracking ref is updated even when
+            the remote has been force-pushed (the common case for
+            dependency-update bot branches that get re-pushed).
+        logger: Optional logger callback.
+    """
+    prefix = "+" if force else ""
+    refspec = f"{prefix}refs/heads/{branch}:refs/remotes/{remote}/{branch}"
+    fetch(remote, refspec, cwd=cwd, depth=depth, logger=logger)
+
 
 
 def checkout(

--- a/src/dependamerge/github_async.py
+++ b/src/dependamerge/github_async.py
@@ -930,57 +930,60 @@ class GitHubAsync:
     async def check_pr_commit_signatures(
         self, owner: str, repo: str, number: int
     ) -> tuple[bool, list[str]]:
-        """
-        Check whether all commits on a pull request have verified signatures.
+        """Check whether all commits on a pull request have verified signatures.
 
         REST: GET /repos/{owner}/{repo}/pulls/{pull_number}/commits
 
         Returns:
-            Tuple of (all_verified: bool, unverified_shas: list[str]).
-            ``all_verified`` is True when every commit carries a valid
-            signature according to GitHub.  ``unverified_shas`` contains
-            the abbreviated SHAs of any commits whose verification failed.
+            Tuple of ``(all_verified, unverified_shas)``.
+            ``all_verified`` is True when every commit carries a
+            valid signature according to GitHub.
+            ``unverified_shas`` contains the abbreviated SHAs of
+            any commits whose verification failed.
+
+        Raises:
+            Exception: surfaces the underlying API/network error
+            on failure rather than silently returning a default.
+            Callers that want fail-open or fail-closed semantics
+            should wrap the call in ``try``/``except`` and decide
+            for themselves — the previous fail-open default
+            (returning ``(True, [])``) collided with the
+            signature-preservation gate in ``rebase.py``, which
+            documents "verified" as a positive confirmation.
         """
         unverified: list[str] = []
-        try:
-            # Iterate over all pages of commits to ensure we don't miss
-            # unverified commits on pull requests with >100 commits.
-            async for commits in self.get_paginated(
-                f"/repos/{owner}/{repo}/pulls/{number}/commits",
-                per_page=100,
-            ):
-                if not isinstance(commits, list):
-                    # Unexpected response shape – assume OK to avoid false positives
-                    return True, []
+        # Iterate over all pages of commits to ensure we don't miss
+        # unverified commits on pull requests with >100 commits.
+        async for commits in self.get_paginated(
+            f"/repos/{owner}/{repo}/pulls/{number}/commits",
+            per_page=100,
+        ):
+            if not isinstance(commits, list):
+                # Unexpected response shape — assume OK to avoid
+                # false positives. The API returned 200 OK but in
+                # an unexpected shape, which is distinct from a
+                # network/HTTP error and arguably means the page
+                # is empty.
+                return True, []
 
-                for commit_data in commits:
-                    if not isinstance(commit_data, dict):
-                        continue
-                    raw_sha = commit_data.get("sha")
-                    sha = str(raw_sha)[:8] if isinstance(raw_sha, str) else "unknown"
-                    commit_obj = commit_data.get("commit")
-                    if not isinstance(commit_obj, dict):
-                        unverified.append(sha)
-                        continue
-                    verification = commit_obj.get("verification")
-                    if not isinstance(verification, dict):
-                        unverified.append(sha)
-                        continue
-                    if not verification.get("verified", False):
-                        unverified.append(sha)
+            for commit_data in commits:
+                if not isinstance(commit_data, dict):
+                    continue
+                raw_sha = commit_data.get("sha")
+                sha = str(raw_sha)[:8] if isinstance(raw_sha, str) else "unknown"
+                commit_obj = commit_data.get("commit")
+                if not isinstance(commit_obj, dict):
+                    unverified.append(sha)
+                    continue
+                verification = commit_obj.get("verification")
+                if not isinstance(verification, dict):
+                    unverified.append(sha)
+                    continue
+                if not verification.get("verified", False):
+                    unverified.append(sha)
 
-            all_verified = len(unverified) == 0
-            return all_verified, unverified
-        except Exception as e:
-            self.log.debug(
-                "Failed to check commit signatures for PR %s/%s#%s: %s",
-                owner,
-                repo,
-                number,
-                e,
-            )
-            # On error, assume verified to avoid blocking merges unnecessarily
-            return True, []
+        all_verified = len(unverified) == 0
+        return all_verified, unverified
 
     async def requires_commit_signatures(
         self, owner: str, repo: str, branch: str = "main"

--- a/src/dependamerge/github_async.py
+++ b/src/dependamerge/github_async.py
@@ -298,7 +298,7 @@ class GitHubAsync:
                 message="Token authentication failed - token may be expired or invalid",
                 token_type_guidance={
                     "classic": "Regenerate your token at: https://github.com/settings/tokens",
-                    "fine_grained": "Check token expiration at: https://github.com/settings/tokens?type=beta",
+                    "fine_grained": "Check token expiration at: https://github.com/settings/personal-access-tokens",
                     "fix": "Run: gh auth refresh -h github.com",
                 },
             )

--- a/src/dependamerge/github_client.py
+++ b/src/dependamerge/github_client.py
@@ -151,6 +151,27 @@ class GitHubClient:
                     repository_full_name=f"{owner}/{repo}",
                     html_url=pr.get("html_url") or "",
                     reviews=reviews,
+                    # Populate head/base repo identity so the
+                    # signature-preserving local-rebase path can
+                    # tell whether the PR is from a fork (and
+                    # which remote to push to).  Without these,
+                    # ``rebase.local_rebase_pr()`` fails closed
+                    # to avoid pushing to the wrong repository.
+                    head_repo_full_name=(
+                        ((pr.get("head") or {}).get("repo") or {}).get("full_name")
+                    ),
+                    head_repo_clone_url=(
+                        ((pr.get("head") or {}).get("repo") or {}).get("clone_url")
+                    ),
+                    base_repo_full_name=(
+                        ((pr.get("base") or {}).get("repo") or {}).get("full_name")
+                    ),
+                    base_repo_clone_url=(
+                        ((pr.get("base") or {}).get("repo") or {}).get("clone_url")
+                    ),
+                    is_fork=(
+                        ((pr.get("head") or {}).get("repo") or {}).get("fork")
+                    ),
                 )
 
         return asyncio.run(_run())  # type: ignore[no-any-return]

--- a/src/dependamerge/github_graphql.py
+++ b/src/dependamerge/github_graphql.py
@@ -81,6 +81,8 @@ query($org: String!, $reposCursor: String) {
             baseRefName
             headRefName
             headRefOid
+            headRepository { nameWithOwner url isFork }
+            baseRepository { nameWithOwner url }
             createdAt
             updatedAt
             files(first: 50) {
@@ -169,6 +171,8 @@ query($owner: String!, $name: String!, $prsCursor: String, $prsPageSize: Int!, $
         baseRefName
         headRefName
         headRefOid
+        headRepository { nameWithOwner url isFork }
+        baseRepository { nameWithOwner url }
         createdAt
         updatedAt
         files(first: $filesPageSize) {

--- a/src/dependamerge/github_service.py
+++ b/src/dependamerge/github_service.py
@@ -40,6 +40,47 @@ AUTOMATION_TOOLS = [
 ]
 
 
+def _str_or_none(value: Any) -> str | None:
+    """Return ``value`` as a string when truthy, else None.
+
+    Used when populating optional ``PullRequestInfo`` fields from
+    GraphQL responses where the field may be missing entirely or
+    explicitly null.
+    """
+    if isinstance(value, str) and value:
+        return value
+    return None
+
+
+def _bool_or_none(value: Any) -> bool | None:
+    """Coerce ``value`` to bool when present, else None.
+
+    Mirrors :func:`_str_or_none` for boolean GraphQL fields
+    (``isFork``).
+    """
+    if isinstance(value, bool):
+        return value
+    return None
+
+
+def _clone_url_with_git_suffix(url: Any) -> str | None:
+    """Synthesise a canonical ``.git`` clone URL from a GraphQL ``url``.
+
+    GraphQL's ``Repository.url`` returns the HTTPS URL without the
+    ``.git`` suffix that REST's ``clone_url`` includes.  This
+    helper appends ``.git`` so both code paths produce the same
+    string and downstream consumers (notably
+    :func:`rebase.local_rebase_pr`) can treat them uniformly.
+
+    Returns None when the input is missing or empty so the
+    PullRequestInfo field stays unset rather than holding a
+    bogus ``".git"`` string.
+    """
+    if isinstance(url, str) and url:
+        return f"{url}.git"
+    return None
+
+
 class GitHubService:
     """
     Asynchronous service orchestrating GraphQL paging and mapping results
@@ -524,29 +565,21 @@ class GitHubService:
             # GraphQL returns the HTTPS URL via ``url`` (without the
             # ``.git`` suffix), so we synthesise the canonical
             # ``clone_url`` form for parity with REST.
-            head_repo_full_name=(
+            head_repo_full_name=_str_or_none(
                 (pr.get("headRepository") or {}).get("nameWithOwner")
             ),
-            head_repo_clone_url=(
-                (
-                    (pr.get("headRepository") or {}).get("url")
-                    + ".git"
-                )
-                if (pr.get("headRepository") or {}).get("url")
-                else None
+            head_repo_clone_url=_clone_url_with_git_suffix(
+                (pr.get("headRepository") or {}).get("url")
             ),
-            base_repo_full_name=(
+            base_repo_full_name=_str_or_none(
                 (pr.get("baseRepository") or {}).get("nameWithOwner")
             ),
-            base_repo_clone_url=(
-                (
-                    (pr.get("baseRepository") or {}).get("url")
-                    + ".git"
-                )
-                if (pr.get("baseRepository") or {}).get("url")
-                else None
+            base_repo_clone_url=_clone_url_with_git_suffix(
+                (pr.get("baseRepository") or {}).get("url")
             ),
-            is_fork=(pr.get("headRepository") or {}).get("isFork"),
+            is_fork=_bool_or_none(
+                (pr.get("headRepository") or {}).get("isFork")
+            ),
         )
 
     async def find_similar_prs(

--- a/src/dependamerge/github_service.py
+++ b/src/dependamerge/github_service.py
@@ -515,6 +515,38 @@ class GitHubService:
             repository_full_name=repo_full_name,
             html_url=pr.get("url") or "",
             reviews=reviews,
+            # Populate head/base repo identity from the GraphQL
+            # ``headRepository`` / ``baseRepository`` fields so the
+            # signature-preserving local-rebase path can tell
+            # whether the PR is from a fork (and which remote to
+            # push to).  Without these, ``rebase.local_rebase_pr()``
+            # fails closed to avoid pushing to the wrong repository.
+            # GraphQL returns the HTTPS URL via ``url`` (without the
+            # ``.git`` suffix), so we synthesise the canonical
+            # ``clone_url`` form for parity with REST.
+            head_repo_full_name=(
+                (pr.get("headRepository") or {}).get("nameWithOwner")
+            ),
+            head_repo_clone_url=(
+                (
+                    (pr.get("headRepository") or {}).get("url")
+                    + ".git"
+                )
+                if (pr.get("headRepository") or {}).get("url")
+                else None
+            ),
+            base_repo_full_name=(
+                (pr.get("baseRepository") or {}).get("nameWithOwner")
+            ),
+            base_repo_clone_url=(
+                (
+                    (pr.get("baseRepository") or {}).get("url")
+                    + ".git"
+                )
+                if (pr.get("baseRepository") or {}).get("url")
+                else None
+            ),
+            is_fork=(pr.get("headRepository") or {}).get("isFork"),
         )
 
     async def find_similar_prs(

--- a/src/dependamerge/merge_manager.py
+++ b/src/dependamerge/merge_manager.py
@@ -2353,7 +2353,6 @@ class AsyncMergeManager:
             add_remote,
             checkout,
             clone,
-            create_secure_tempdir,
             ensure_git_available,
             fetch,
             push_force_with_lease,

--- a/src/dependamerge/merge_manager.py
+++ b/src/dependamerge/merge_manager.py
@@ -104,6 +104,7 @@ class AsyncMergeManager:
         github2gerrit_mode: str = "submit",
         no_netrc: bool = False,
         netrc_file: Path | None = None,
+        rebase_local: bool = True,
     ):
         self.token = token
         self.default_merge_method = merge_method
@@ -117,6 +118,16 @@ class AsyncMergeManager:
         self.github2gerrit_mode = github2gerrit_mode
         self.no_netrc = no_netrc
         self.netrc_file = netrc_file
+        # When True (the default), Step 5's rebase path uses a local
+        # ``git`` clone + rebase + force-push-with-lease workflow
+        # for PRs whose verification status would otherwise be lost
+        # by the GitHub REST ``update-branch`` endpoint. The local
+        # workflow inherits the user's ``~/.gitconfig`` and so
+        # respects ``commit.gpgsign`` / ``gpg.format`` /
+        # ``user.signingkey`` automatically. Set to False to force
+        # the legacy REST-only path (simpler but loses signature
+        # verification on signed branches).
+        self.rebase_local = rebase_local
         self.log = logging.getLogger(__name__)
 
         # Centralised merge-operation timing
@@ -1107,201 +1118,274 @@ class AsyncMergeManager:
                         level="debug",
                     )
 
-                    try:
-                        if self._github_client is None:
-                            raise RuntimeError("GitHub client not initialized")
-                        await self._github_client.update_branch(
-                            repo_owner, repo_name, pr_info.number
-                        )
+                    # Decide between the local ``git`` workflow and
+                    # the REST ``update-branch`` endpoint. The local
+                    # path preserves verified signatures (because it
+                    # respects the user's ``~/.gitconfig`` signing
+                    # config) at the cost of a per-PR clone; the
+                    # REST path is faster but its server-side merge
+                    # commit is unsigned, which can break branch
+                    # protection rules that require verification.
+                    use_local, local_reason = await self._should_use_local_rebase(
+                        pr_info,
+                        repo_owner,
+                        repo_name,
+                        pr_info.base_branch or "main",
+                    )
 
-                        # Enable auto-merge so the PR merges even if we
-                        # time out waiting for status checks.
-                        auto_merge_ok = await self._enable_auto_merge_for_pr(
-                            pr_info, repo_owner, repo_name
+                    if use_local:
+                        # Local-rebase path. Run our git-based
+                        # rebase + force-push-with-lease, then
+                        # mark the PR as rebased and let Step 5.5
+                        # take over (it will enable auto-merge and
+                        # run its own bounded wait against the new
+                        # head).
+                        log_and_print(
+                            self.log,
+                            self._console,
+                            f"🛡️  Local rebase: {pr_info.html_url} "
+                            f"[{local_reason}]",
+                            level="debug",
                         )
-                        if auto_merge_ok:
+                        try:
+                            local_rebase_ok = await self._local_git_rebase_pr(
+                                pr_info, repo_owner, repo_name
+                            )
+                        except Exception as exc:
                             self.log.debug(
-                                "Auto-merge enabled after rebase for %s/%s#%s",
-                                repo_owner,
-                                repo_name,
-                                pr_info.number,
+                                "Local rebase raised unexpectedly for %s: %s",
+                                pr_info.html_url,
+                                exc,
                             )
+                            local_rebase_ok = False
 
-                        # Wait for GitHub to process the update and run checks
-                        self._console.print(
-                            f"⏳ Waiting: {pr_info.html_url}"
-                        )
-                        await asyncio.sleep(self._merge_recheck_interval)
-
-                        # Re-check PR status after rebase with extended retry logic
-                        # Initialize variables before the loop
-                        updated_mergeable: bool | None = pr_info.mergeable
-                        updated_mergeable_state: str | None = pr_info.mergeable_state
-
-                        for check_attempt in range(self._merge_poll_max_attempts):
-                            updated_pr_data = await self._github_client.get(
-                                f"/repos/{repo_owner}/{repo_name}/pulls/{pr_info.number}"
-                            )
-
-                            if isinstance(updated_pr_data, dict):
-                                updated_mergeable = updated_pr_data.get("mergeable")
-                                updated_mergeable_state = updated_pr_data.get(
-                                    "mergeable_state"
-                                )
-                                # Capture the new head SHA so later
-                                # block-reason analysis queries the
-                                # rebased commit, not the pre-rebase
-                                # one. update_branch() advances
-                                # head.sha, and analyze_block_reason()
-                                # uses head_sha to query check runs.
-                                updated_head = (
-                                    updated_pr_data.get("head") or {}
-                                ).get("sha")
-                                if updated_head:
-                                    pr_info.head_sha = updated_head
-                            else:
-                                updated_mergeable = None
-                                updated_mergeable_state = None
-
-                            if updated_mergeable_state == "clean":
-                                break
-                            elif updated_mergeable_state == "behind":
-                                if check_attempt < self._merge_poll_max_attempts - 1:
-                                    self.log.debug(
-                                        "PR still processing rebase, waiting... "
-                                        "(attempt %d/%d)",
-                                        check_attempt + 1,
-                                        self._merge_poll_max_attempts,
-                                    )
-                                    await asyncio.sleep(self._merge_recheck_interval)
-                            elif updated_mergeable_state == "blocked":
-                                if check_attempt < self._merge_poll_max_attempts - 1:
-                                    self.log.debug(
-                                        "PR status checks running after rebase, "
-                                        "waiting... (attempt %d/%d)",
-                                        check_attempt + 1,
-                                        self._merge_poll_max_attempts,
-                                    )
-                                    await asyncio.sleep(self._merge_recheck_interval)
-                                else:
-                                    if auto_merge_ok:
-                                        log_and_print(
-                                            self.log,
-                                            self._console,
-                                            f"⏳ Auto-merge will complete: "
-                                            f"{pr_info.html_url} "
-                                            "[timeout waiting for checks]",
-                                            level="warning",
-                                        )
-                                    else:
-                                        log_and_print(
-                                            self.log,
-                                            self._console,
-                                            f"⚠️ Proceeding without checks: "
-                                            f"{pr_info.html_url} "
-                                            "[timeout waiting for checks]",
-                                            level="warning",
-                                        )
-                                    break
-                            elif updated_mergeable_state is None:
-                                # GitHub is still computing mergeability
-                                # (typically right after update_branch).
-                                # Treat as transient and keep polling
-                                # until the deadline or a concrete state
-                                # arrives — breaking here would otherwise
-                                # exit prematurely and (if auto-merge
-                                # enablement failed) fall through to a
-                                # manual merge attempt against the
-                                # still-resolving PR state.
-                                if check_attempt < self._merge_poll_max_attempts - 1:
-                                    self.log.debug(
-                                        "PR mergeable_state still computing "
-                                        "after rebase, waiting... "
-                                        "(attempt %d/%d)",
-                                        check_attempt + 1,
-                                        self._merge_poll_max_attempts,
-                                    )
-                                    await asyncio.sleep(self._merge_recheck_interval)
-                                else:
-                                    break
-                            else:
-                                break
-
-                        # Update our PR info with the latest state.
-                        # Preserve the previous non-None mergeable
-                        # value when the refresh returns ``null``
-                        # (GitHub is still computing). The Step 6
-                        # auto-merge skip gate now accepts both
-                        # ``True`` and ``None`` (it excludes only
-                        # the explicit ``False`` case), so a
-                        # transient null no longer blocks the
-                        # auto-merge path on its own. We still
-                        # preserve the prior known ``True`` here
-                        # so downstream logging and any future
-                        # tightening of that predicate get an
-                        # accurate state to work with.
-                        if updated_mergeable is not None:
-                            pr_info.mergeable = updated_mergeable
-                        # Preserve the previous non-None mergeable_state
-                        # for the same reason as ``mergeable`` above:
-                        # GitHub returns ``null`` while still computing,
-                        # and the post-rebase reporting / Step 5.5 logic
-                        # branches on this value (e.g. "clean" vs
-                        # "blocked" vs "behind"). A transient ``None``
-                        # would otherwise be classified as the catch-all
-                        # "other state" branch.
-                        if updated_mergeable_state is not None:
-                            pr_info.mergeable_state = updated_mergeable_state
-
-                        # Mark this PR as having gone through the
-                        # Step 5 rebase + poll path. Step 5.5 will
-                        # consult ``_rebased_prs`` to avoid doubling
-                        # the merge_timeout when the rebase exits
-                        # in ``blocked`` or ``behind`` state.
+                        # Whether the local rebase succeeded or
+                        # failed, mark this PR as having been
+                        # through Step 5 so Step 5.5's
+                        # ``_rebased_prs`` gate fires and we don't
+                        # double the configured merge_timeout. We
+                        # deliberately do *not* fall through to
+                        # REST update-branch on local failure —
+                        # doing so would destroy verification,
+                        # exactly the bug this code path exists
+                        # to prevent.
                         self._rebased_prs.add(
                             f"{repo_owner}/{repo_name}#{pr_info.number}"
                         )
-
-                        # Report post-rebase status
-                        if pr_info.mergeable_state == "clean":
+                        if local_rebase_ok:
                             log_and_print(
                                 self.log,
                                 self._console,
-                                f"✅ Rebased: {pr_info.html_url}",
-                                level="debug",
-                            )
-                        elif pr_info.mergeable_state == "behind":
-                            log_and_print(
-                                self.log,
-                                self._console,
-                                f"⚠️  Rebased: {pr_info.html_url} [still behind after rebase]",
-                                level="debug",
-                            )
-                        elif pr_info.mergeable_state == "blocked":
-                            log_and_print(
-                                self.log,
-                                self._console,
-                                f"⬆️ Rebased: {pr_info.html_url} [waiting for status checks]",
+                                f"✅ Rebased (local): {pr_info.html_url}",
                                 level="debug",
                             )
                         else:
                             log_and_print(
                                 self.log,
                                 self._console,
-                                f"ℹ️  Rebased: {pr_info.html_url}",
+                                f"🛡️  Local rebase failed; deferring to "
+                                f"auto-merge: {pr_info.html_url}",
                                 level="debug",
                             )
+                    else:
+                        # Legacy REST path. Use ``update-branch``
+                        # then poll the PR until checks complete or
+                        # ``merge_timeout`` elapses.
+                        try:
+                            if self._github_client is None:
+                                raise RuntimeError("GitHub client not initialized")
+                            await self._github_client.update_branch(
+                                repo_owner, repo_name, pr_info.number
+                            )
 
-                    except Exception as e:
-                        result.status = MergeStatus.FAILED
-                        result.error = f"Failed to rebase PR: {e}"
+                            # Enable auto-merge so the PR merges even if we
+                            # time out waiting for status checks.
+                            auto_merge_ok = await self._enable_auto_merge_for_pr(
+                                pr_info, repo_owner, repo_name
+                            )
+                            if auto_merge_ok:
+                                self.log.debug(
+                                    "Auto-merge enabled after rebase for %s/%s#%s",
+                                    repo_owner,
+                                    repo_name,
+                                    pr_info.number,
+                                )
 
-                        if self.progress_tracker:
-                            self.progress_tracker.merge_failure()
-                        self._console.print(
-                            f"❌ Failed: {pr_info.html_url} [rebase error: {e}]"
-                        )
-                        return result
+                            # Wait for GitHub to process the update and run checks
+                            self._console.print(
+                                f"⏳ Waiting: {pr_info.html_url}"
+                            )
+                            await asyncio.sleep(self._merge_recheck_interval)
+
+                            # Re-check PR status after rebase with extended retry logic
+                            # Initialize variables before the loop
+                            updated_mergeable: bool | None = pr_info.mergeable
+                            updated_mergeable_state: str | None = pr_info.mergeable_state
+
+                            for check_attempt in range(self._merge_poll_max_attempts):
+                                updated_pr_data = await self._github_client.get(
+                                    f"/repos/{repo_owner}/{repo_name}/pulls/{pr_info.number}"
+                                )
+
+                                if isinstance(updated_pr_data, dict):
+                                    updated_mergeable = updated_pr_data.get("mergeable")
+                                    updated_mergeable_state = updated_pr_data.get(
+                                        "mergeable_state"
+                                    )
+                                    # Capture the new head SHA so later
+                                    # block-reason analysis queries the
+                                    # rebased commit, not the pre-rebase
+                                    # one. update_branch() advances
+                                    # head.sha, and analyze_block_reason()
+                                    # uses head_sha to query check runs.
+                                    updated_head = (
+                                        updated_pr_data.get("head") or {}
+                                    ).get("sha")
+                                    if updated_head:
+                                        pr_info.head_sha = updated_head
+                                else:
+                                    updated_mergeable = None
+                                    updated_mergeable_state = None
+
+                                if updated_mergeable_state == "clean":
+                                    break
+                                elif updated_mergeable_state == "behind":
+                                    if check_attempt < self._merge_poll_max_attempts - 1:
+                                        self.log.debug(
+                                            "PR still processing rebase, waiting... "
+                                            "(attempt %d/%d)",
+                                            check_attempt + 1,
+                                            self._merge_poll_max_attempts,
+                                        )
+                                        await asyncio.sleep(self._merge_recheck_interval)
+                                elif updated_mergeable_state == "blocked":
+                                    if check_attempt < self._merge_poll_max_attempts - 1:
+                                        self.log.debug(
+                                            "PR status checks running after rebase, "
+                                            "waiting... (attempt %d/%d)",
+                                            check_attempt + 1,
+                                            self._merge_poll_max_attempts,
+                                        )
+                                        await asyncio.sleep(self._merge_recheck_interval)
+                                    else:
+                                        if auto_merge_ok:
+                                            log_and_print(
+                                                self.log,
+                                                self._console,
+                                                f"⏳ Auto-merge will complete: "
+                                                f"{pr_info.html_url} "
+                                                "[timeout waiting for checks]",
+                                                level="warning",
+                                            )
+                                        else:
+                                            log_and_print(
+                                                self.log,
+                                                self._console,
+                                                f"⚠️ Proceeding without checks: "
+                                                f"{pr_info.html_url} "
+                                                "[timeout waiting for checks]",
+                                                level="warning",
+                                            )
+                                        break
+                                elif updated_mergeable_state is None:
+                                    # GitHub is still computing mergeability
+                                    # (typically right after update_branch).
+                                    # Treat as transient and keep polling
+                                    # until the deadline or a concrete state
+                                    # arrives — breaking here would otherwise
+                                    # exit prematurely and (if auto-merge
+                                    # enablement failed) fall through to a
+                                    # manual merge attempt against the
+                                    # still-resolving PR state.
+                                    if check_attempt < self._merge_poll_max_attempts - 1:
+                                        self.log.debug(
+                                            "PR mergeable_state still computing "
+                                            "after rebase, waiting... "
+                                            "(attempt %d/%d)",
+                                            check_attempt + 1,
+                                            self._merge_poll_max_attempts,
+                                        )
+                                        await asyncio.sleep(self._merge_recheck_interval)
+                                    else:
+                                        break
+                                else:
+                                    break
+
+                            # Update our PR info with the latest state.
+                            # Preserve the previous non-None mergeable
+                            # value when the refresh returns ``null``
+                            # (GitHub is still computing). The Step 6
+                            # auto-merge skip gate now accepts both
+                            # ``True`` and ``None`` (it excludes only
+                            # the explicit ``False`` case), so a
+                            # transient null no longer blocks the
+                            # auto-merge path on its own. We still
+                            # preserve the prior known ``True`` here
+                            # so downstream logging and any future
+                            # tightening of that predicate get an
+                            # accurate state to work with.
+                            if updated_mergeable is not None:
+                                pr_info.mergeable = updated_mergeable
+                            # Preserve the previous non-None mergeable_state
+                            # for the same reason as ``mergeable`` above:
+                            # GitHub returns ``null`` while still computing,
+                            # and the post-rebase reporting / Step 5.5 logic
+                            # branches on this value (e.g. "clean" vs
+                            # "blocked" vs "behind"). A transient ``None``
+                            # would otherwise be classified as the catch-all
+                            # "other state" branch.
+                            if updated_mergeable_state is not None:
+                                pr_info.mergeable_state = updated_mergeable_state
+
+                            # Mark this PR as having gone through the
+                            # Step 5 rebase + poll path. Step 5.5 will
+                            # consult ``_rebased_prs`` to avoid doubling
+                            # the merge_timeout when the rebase exits
+                            # in ``blocked`` or ``behind`` state.
+                            self._rebased_prs.add(
+                                f"{repo_owner}/{repo_name}#{pr_info.number}"
+                            )
+
+                            # Report post-rebase status
+                            if pr_info.mergeable_state == "clean":
+                                log_and_print(
+                                    self.log,
+                                    self._console,
+                                    f"✅ Rebased: {pr_info.html_url}",
+                                    level="debug",
+                                )
+                            elif pr_info.mergeable_state == "behind":
+                                log_and_print(
+                                    self.log,
+                                    self._console,
+                                    f"⚠️  Rebased: {pr_info.html_url} [still behind after rebase]",
+                                    level="debug",
+                                )
+                            elif pr_info.mergeable_state == "blocked":
+                                log_and_print(
+                                    self.log,
+                                    self._console,
+                                    f"⬆️ Rebased: {pr_info.html_url} [waiting for status checks]",
+                                    level="debug",
+                                )
+                            else:
+                                log_and_print(
+                                    self.log,
+                                    self._console,
+                                    f"ℹ️  Rebased: {pr_info.html_url}",
+                                    level="debug",
+                                )
+
+                        except Exception as e:
+                            result.status = MergeStatus.FAILED
+                            result.error = f"Failed to rebase PR: {e}"
+
+                            if self.progress_tracker:
+                                self.progress_tracker.merge_failure()
+                            self._console.print(
+                                f"❌ Failed: {pr_info.html_url} [rebase error: {e}]"
+                            )
+                            return result
 
             # Step 5.5: If the PR is still blocked (e.g. by a pending
             # required status check such as pre-commit.ci), behind
@@ -2125,6 +2209,365 @@ class AsyncMergeManager:
         except Exception:
             pass
         return False
+
+    # ------------------------------------------------------------------
+    # Signature-preserving local rebase
+    # ------------------------------------------------------------------
+    #
+    # The GitHub REST ``PUT /repos/{owner}/{repo}/pulls/{n}/update-branch``
+    # endpoint creates a *server-side* merge commit whose committer is
+    # the calling token's GitHub user. That committer is not signed
+    # with the user's local SSH/GPG key, so the resulting commit
+    # loses its ``Verified`` badge — if the base branch's protection
+    # rules require verified signatures, the PR becomes
+    # un-mergeable until a human intervenes.
+    #
+    # Worse, automation bots that *would* normally recover from this
+    # have no comment-macro hook for it: ``@dependabot recreate``
+    # exists, but ``pre-commit-ci`` has no equivalent (see issue
+    # https://github.com/pre-commit-ci/issues/issues/41), so any
+    # pre-commit-ci PR we break this way is stuck until somebody
+    # closes it manually.
+    #
+    # The fix is to do the rebase *locally*: clone, rebase onto the
+    # base branch, force-push-with-lease. Because we shell out to
+    # ``git``, the user's ``~/.gitconfig`` (``commit.gpgsign``,
+    # ``gpg.format``, ``user.signingkey``) is honoured and the new
+    # commits remain verified.
+    #
+    # We only take this path when:
+    #   * ``self.rebase_local`` is True (it is by default; the CLI
+    #     exposes ``--no-rebase-local`` to opt out), AND
+    #   * either the PR is from ``pre-commit-ci[bot]`` (always —
+    #     it has no recovery macro), OR the base branch requires
+    #     verified signatures AND the current PR head commit is
+    #     itself verified (so REST update-branch *would* break
+    #     verification).
+    #
+    # On any failure (no ``git`` on PATH, conflict during rebase,
+    # network error, push rejected) we abort cleanly and return
+    # False; the caller then falls through to Step 5.5 so auto-merge
+    # can take over server-side. Auto-merge produces a properly
+    # verified merge commit signed by GitHub itself.
+
+    async def _should_use_local_rebase(
+        self,
+        pr_info: PullRequestInfo,
+        owner: str,
+        repo: str,
+        base_branch: str,
+    ) -> tuple[bool, str]:
+        """Decide whether Step 5 should rebase locally instead of via REST.
+
+        Returns:
+            ``(use_local, reason)``. ``reason`` is a short
+            human-readable string suitable for debug logging or a
+            user-visible note when ``use_local`` is True.
+        """
+        if not self.rebase_local:
+            return False, "--no-rebase-local set"
+
+        # Always use local rebase for pre-commit.ci PRs. The bot has
+        # no comment macro to recover from a verification break, so
+        # we treat it as opt-in regardless of branch protection.
+        if pr_info.author == "pre-commit-ci[bot]":
+            return True, "pre-commit-ci[bot] has no recreate/rebase macro"
+
+        if self._github_client is None:
+            return False, "no GitHub client"
+
+        # Branch-protection signature requirement (classic + rulesets)
+        try:
+            requires_signatures = await self._github_client.requires_commit_signatures(
+                owner, repo, base_branch
+            )
+        except Exception as exc:
+            self.log.debug(
+                "Could not determine signature requirement for %s/%s:%s: %s",
+                owner,
+                repo,
+                base_branch,
+                exc,
+            )
+            return False, "signature requirement check failed"
+
+        # Strict ``is True`` rather than truthy check: ``AsyncMock``
+        # default returns evaluate as truthy, and we explicitly do
+        # not want to enter the network-touching local-rebase path
+        # in test mocks that haven't been set up to handle it.
+        if requires_signatures is not True:
+            return False, "base branch does not require signatures"
+
+        # Base does require verified signatures. Check whether the
+        # current PR head is itself verified — if it isn't, REST
+        # update-branch can't make things worse, so we don't need
+        # the local-rebase machinery.
+        try:
+            all_verified, _unverified = (
+                await self._github_client.check_pr_commit_signatures(
+                    owner, repo, pr_info.number
+                )
+            )
+        except Exception as exc:
+            self.log.debug(
+                "Could not check PR commit signatures for %s/%s#%s: %s",
+                owner,
+                repo,
+                pr_info.number,
+                exc,
+            )
+            # Conservative: if we can't tell, prefer the local path
+            # (worst case: minor extra work; best case: preserve a
+            # signature we couldn't see).
+            return True, "signature check failed; preferring local path"
+
+        if all_verified:
+            return True, "base requires signatures and PR head is verified"
+        return False, "PR head is not currently verified"
+
+    async def _local_git_rebase_pr(
+        self,
+        pr_info: PullRequestInfo,
+        owner: str,
+        repo: str,
+    ) -> bool:
+        """Rebase a PR locally and force-push the result.
+
+        Clones the head repo into a secure temp workspace, fetches
+        the base branch (from upstream when the PR is from a fork),
+        runs ``git rebase``, and force-pushes with lease back to the
+        head repo. All git invocations inherit the user's
+        ``~/.gitconfig``, so signing config is respected.
+
+        Returns True only if every step succeeds. On any failure
+        (no ``git`` on PATH, conflict during rebase, network error,
+        push rejected) the workspace is cleaned up and False is
+        returned; the caller falls through to the auto-merge path
+        so we never leave a half-applied state.
+        """
+        # Local imports keep test collection cheap when the merge
+        # path is exercised purely through mocks.
+        from . import git_ops
+        from .git_ops import (
+            GitError,
+            add_remote,
+            checkout,
+            clone,
+            create_secure_tempdir,
+            ensure_git_available,
+            fetch,
+            push_force_with_lease,
+            rebase,
+            rebase_abort,
+            secure_rmtree,
+        )
+
+        # Ensure ``git`` is on PATH before we start. ``GitError``
+        # is also raised when git is missing entirely.
+        try:
+            ensure_git_available()
+        except Exception as exc:
+            self.log.debug(
+                "Local rebase unavailable (no git on PATH?): %s", exc
+            )
+            return False
+
+        # We need the head/base clone URLs. They are populated for
+        # PRs surfaced by recent versions of the find-similar / merge
+        # flows; if missing we cannot proceed locally.
+        head_clone_url = pr_info.head_repo_clone_url
+        base_clone_url = pr_info.base_repo_clone_url
+        head_full = pr_info.head_repo_full_name
+        base_full = pr_info.base_repo_full_name or f"{owner}/{repo}"
+        if not head_clone_url:
+            head_clone_url = f"https://github.com/{head_full or base_full}.git"
+        if not base_clone_url:
+            base_clone_url = f"https://github.com/{base_full}.git"
+        head_full = head_full or base_full
+
+        head_branch = pr_info.head_branch
+        base_branch = pr_info.base_branch or "main"
+        if not head_branch:
+            self.log.debug(
+                "Local rebase: PR %s/%s#%s missing head_branch",
+                owner,
+                repo,
+                pr_info.number,
+            )
+            return False
+
+        origin_url = self._authed_clone_url(head_clone_url, self.token)
+        upstream_url = self._authed_clone_url(base_clone_url, self.token)
+
+        # Use a per-PR workspace under a secure temp parent so
+        # concurrent rebases (--concurrency=N) don't collide.
+        workspace_parent = Path(
+            git_ops.create_secure_tempdir(
+                prefix="dependamerge-localrebase-"
+            )
+        )
+        workspace = (
+            workspace_parent
+            / f"{(head_full or base_full).replace('/', '__')}__pr_{pr_info.number}"
+        )
+        workspace.mkdir(parents=True, exist_ok=True)
+
+        try:
+            # Clone the head repo at the PR's head branch. Shallow
+            # clone keeps disk + network footprint low for what
+            # are typically tiny dependency-update PRs.
+            try:
+                clone(
+                    origin_url,
+                    workspace,
+                    branch=head_branch,
+                    depth=50,
+                    single_branch=True,
+                    no_tags=True,
+                    filter_blobs=True,
+                    logger=self.log.debug,
+                )
+            except GitError as exc:
+                self.log.debug(
+                    "Local rebase: clone failed for %s: %s",
+                    pr_info.html_url,
+                    exc,
+                )
+                return False
+
+            # Fetch the base branch — from upstream when the PR
+            # is from a fork, from origin otherwise. We need it
+            # available locally before we can rebase onto it.
+            try:
+                if (head_full or base_full) != base_full:
+                    add_remote(
+                        "upstream",
+                        upstream_url,
+                        cwd=workspace,
+                        logger=self.log.debug,
+                    )
+                    fetch(
+                        "upstream",
+                        base_branch,
+                        cwd=workspace,
+                        depth=50,
+                        logger=self.log.debug,
+                    )
+                    rebase_onto = f"upstream/{base_branch}"
+                else:
+                    fetch(
+                        "origin",
+                        base_branch,
+                        cwd=workspace,
+                        depth=50,
+                        logger=self.log.debug,
+                    )
+                    rebase_onto = f"origin/{base_branch}"
+            except GitError as exc:
+                self.log.debug(
+                    "Local rebase: fetch failed for %s: %s",
+                    pr_info.html_url,
+                    exc,
+                )
+                return False
+
+            # Make sure we are on the head branch (defensive against
+            # detached HEAD after clone --branch).
+            try:
+                checkout(
+                    head_branch,
+                    cwd=workspace,
+                    create=False,
+                    logger=self.log.debug,
+                )
+            except GitError:
+                # Already on the branch, or branch missing locally;
+                # rebase will surface the real problem if any.
+                pass
+
+            # Rebase. ``git rebase`` here is non-interactive; if
+            # there are conflicts the command exits non-zero and
+            # leaves the working tree in conflict state, which we
+            # explicitly abort and treat as failure.
+            try:
+                rebase_result = rebase(
+                    rebase_onto,
+                    cwd=workspace,
+                    autostash=False,
+                    interactive=False,
+                    logger=self.log.debug,
+                )
+            except GitError as exc:
+                self.log.debug(
+                    "Local rebase: rebase failed for %s: %s",
+                    pr_info.html_url,
+                    exc,
+                )
+                return False
+
+            if rebase_result.returncode != 0:
+                self.log.debug(
+                    "Local rebase: conflicts during rebase of %s; aborting.",
+                    pr_info.html_url,
+                )
+                try:
+                    rebase_abort(cwd=workspace, logger=self.log.debug)
+                except Exception:
+                    pass
+                return False
+
+            # Force-push with lease to the head repo. We push back
+            # to ``origin`` because the head ref always lives there
+            # (even for forks, the head repo *is* the fork).
+            try:
+                push_force_with_lease(
+                    "origin",
+                    head_branch,
+                    head_branch,
+                    cwd=workspace,
+                    logger=self.log.debug,
+                )
+            except GitError as exc:
+                self.log.debug(
+                    "Local rebase: force-push failed for %s: %s",
+                    pr_info.html_url,
+                    exc,
+                )
+                return False
+
+            self.log.debug(
+                "Local rebase succeeded for %s", pr_info.html_url
+            )
+            return True
+
+        finally:
+            # Always clean up. The workspace contains a clone of
+            # the user's repository, so we want it gone even on
+            # success.
+            try:
+                secure_rmtree(workspace_parent)
+            except Exception as exc:
+                self.log.debug(
+                    "Local rebase: failed to clean up workspace %s: %s",
+                    workspace_parent,
+                    exc,
+                )
+
+    @staticmethod
+    def _authed_clone_url(clone_url: str, token: str) -> str:
+        """Return an HTTPS clone URL with the token injected for auth.
+
+        Mirrors ``FixOrchestrator._authed_url`` so the token never
+        appears in command-line arguments (the URL goes through
+        the standard ``git clone`` machinery, which redacts it from
+        log output via ``git_ops._redact``). Non-HTTPS URLs (SSH,
+        etc.) are returned unchanged.
+        """
+        if clone_url.startswith("https://"):
+            return clone_url.replace(
+                "https://", f"https://x-access-token:{token}@"
+            )
+        return clone_url
 
     async def _enable_auto_merge_for_pr(
         self, pr_info: PullRequestInfo, owner: str, repo: str

--- a/src/dependamerge/merge_manager.py
+++ b/src/dependamerge/merge_manager.py
@@ -16,6 +16,7 @@ from typing import Any, cast
 
 from rich.console import Console
 
+from . import rebase
 from .copilot_handler import CopilotCommentHandler
 from .gerrit import (
     GerritAuthError,
@@ -358,14 +359,10 @@ class AsyncMergeManager:
             # or have auto-merge pending (where neither merge_success
             # nor merge_failure is called because the merge hasn't
             # actually happened yet — GitHub will merge it later).
-            if (
-                self.progress_tracker
-                and result.status
-                in (
-                    MergeStatus.BLOCKED,
-                    MergeStatus.SKIPPED,
-                    MergeStatus.AUTO_MERGE_PENDING,
-                )
+            if self.progress_tracker and result.status in (
+                MergeStatus.BLOCKED,
+                MergeStatus.SKIPPED,
+                MergeStatus.AUTO_MERGE_PENDING,
             ):
                 self.progress_tracker.pr_completed()
             return result
@@ -402,9 +399,7 @@ class AsyncMergeManager:
         # ``print()`` calls. Updating every second would spam the
         # user's terminal/logs, so use the slower plain ticker
         # cadence instead.
-        rich_available = bool(
-            getattr(self.progress_tracker, "rich_available", False)
-        )
+        rich_available = bool(getattr(self.progress_tracker, "rich_available", False))
         if not rich_available:
             await self._wait_status_ticker_plain()
             return
@@ -467,9 +462,7 @@ class AsyncMergeManager:
                 if snapshot:
                     now = asyncio.get_running_loop().time()
                     if now - last_emit >= 15.0:
-                        remaining = max(
-                            0.0, max(snapshot.values()) - now
-                        )
+                        remaining = max(0.0, max(snapshot.values()) - now)
                         count = len(snapshot)
                         noun = "PR" if count == 1 else "PRs"
                         try:
@@ -1104,288 +1097,38 @@ class AsyncMergeManager:
                         await asyncio.sleep(self._post_approval_delay)
             result.status = MergeStatus.APPROVED
 
-            # Step 5: Handle rebase if needed before merge
+            # Step 5: Handle rebase if needed before merge.
+            #
+            # Dispatched to the dedicated ``rebase`` module so the
+            # local-vs-REST decision tree, the local-git workflow,
+            # and the post-rebase polling loop all live in one
+            # place where they can be tested in isolation.
             if pr_info.mergeable_state == "behind" and self.fix_out_of_date:
-                if self.preview_mode:
-                    # NOTE: In preview mode, we should NOT print here as it breaks single-line reporting
-                    # The preview output should only be a single line per PR in the evaluation section
-                    pass
-                else:
-                    log_and_print(
-                        self.log,
-                        self._console,
-                        f"🔄 Rebasing: {pr_info.html_url} [behind base branch]",
-                        level="debug",
-                    )
-
-                    # Decide between the local ``git`` workflow and
-                    # the REST ``update-branch`` endpoint. The local
-                    # path preserves verified signatures (because it
-                    # respects the user's ``~/.gitconfig`` signing
-                    # config) at the cost of a per-PR clone; the
-                    # REST path is faster but its server-side merge
-                    # commit is unsigned, which can break branch
-                    # protection rules that require verification.
-                    use_local, local_reason = await self._should_use_local_rebase(
-                        pr_info,
-                        repo_owner,
-                        repo_name,
-                        pr_info.base_branch or "main",
-                    )
-
-                    if use_local:
-                        # Local-rebase path. Run our git-based
-                        # rebase + force-push-with-lease, then
-                        # mark the PR as rebased and let Step 5.5
-                        # take over (it will enable auto-merge and
-                        # run its own bounded wait against the new
-                        # head).
-                        log_and_print(
-                            self.log,
-                            self._console,
-                            f"🛡️  Local rebase: {pr_info.html_url} "
-                            f"[{local_reason}]",
-                            level="debug",
-                        )
-                        try:
-                            local_rebase_ok = await self._local_git_rebase_pr(
-                                pr_info, repo_owner, repo_name
-                            )
-                        except Exception as exc:
-                            self.log.debug(
-                                "Local rebase raised unexpectedly for %s: %s",
-                                pr_info.html_url,
-                                exc,
-                            )
-                            local_rebase_ok = False
-
-                        # Whether the local rebase succeeded or
-                        # failed, mark this PR as having been
-                        # through Step 5 so Step 5.5's
-                        # ``_rebased_prs`` gate fires and we don't
-                        # double the configured merge_timeout. We
-                        # deliberately do *not* fall through to
-                        # REST update-branch on local failure —
-                        # doing so would destroy verification,
-                        # exactly the bug this code path exists
-                        # to prevent.
-                        self._rebased_prs.add(
-                            f"{repo_owner}/{repo_name}#{pr_info.number}"
-                        )
-                        if local_rebase_ok:
-                            log_and_print(
-                                self.log,
-                                self._console,
-                                f"✅ Rebased (local): {pr_info.html_url}",
-                                level="debug",
-                            )
-                        else:
-                            log_and_print(
-                                self.log,
-                                self._console,
-                                f"🛡️  Local rebase failed; deferring to "
-                                f"auto-merge: {pr_info.html_url}",
-                                level="debug",
-                            )
-                    else:
-                        # Legacy REST path. Use ``update-branch``
-                        # then poll the PR until checks complete or
-                        # ``merge_timeout`` elapses.
-                        try:
-                            if self._github_client is None:
-                                raise RuntimeError("GitHub client not initialized")
-                            await self._github_client.update_branch(
-                                repo_owner, repo_name, pr_info.number
-                            )
-
-                            # Enable auto-merge so the PR merges even if we
-                            # time out waiting for status checks.
-                            auto_merge_ok = await self._enable_auto_merge_for_pr(
-                                pr_info, repo_owner, repo_name
-                            )
-                            if auto_merge_ok:
-                                self.log.debug(
-                                    "Auto-merge enabled after rebase for %s/%s#%s",
-                                    repo_owner,
-                                    repo_name,
-                                    pr_info.number,
-                                )
-
-                            # Wait for GitHub to process the update and run checks
-                            self._console.print(
-                                f"⏳ Waiting: {pr_info.html_url}"
-                            )
-                            await asyncio.sleep(self._merge_recheck_interval)
-
-                            # Re-check PR status after rebase with extended retry logic
-                            # Initialize variables before the loop
-                            updated_mergeable: bool | None = pr_info.mergeable
-                            updated_mergeable_state: str | None = pr_info.mergeable_state
-
-                            for check_attempt in range(self._merge_poll_max_attempts):
-                                updated_pr_data = await self._github_client.get(
-                                    f"/repos/{repo_owner}/{repo_name}/pulls/{pr_info.number}"
-                                )
-
-                                if isinstance(updated_pr_data, dict):
-                                    updated_mergeable = updated_pr_data.get("mergeable")
-                                    updated_mergeable_state = updated_pr_data.get(
-                                        "mergeable_state"
-                                    )
-                                    # Capture the new head SHA so later
-                                    # block-reason analysis queries the
-                                    # rebased commit, not the pre-rebase
-                                    # one. update_branch() advances
-                                    # head.sha, and analyze_block_reason()
-                                    # uses head_sha to query check runs.
-                                    updated_head = (
-                                        updated_pr_data.get("head") or {}
-                                    ).get("sha")
-                                    if updated_head:
-                                        pr_info.head_sha = updated_head
-                                else:
-                                    updated_mergeable = None
-                                    updated_mergeable_state = None
-
-                                if updated_mergeable_state == "clean":
-                                    break
-                                elif updated_mergeable_state == "behind":
-                                    if check_attempt < self._merge_poll_max_attempts - 1:
-                                        self.log.debug(
-                                            "PR still processing rebase, waiting... "
-                                            "(attempt %d/%d)",
-                                            check_attempt + 1,
-                                            self._merge_poll_max_attempts,
-                                        )
-                                        await asyncio.sleep(self._merge_recheck_interval)
-                                elif updated_mergeable_state == "blocked":
-                                    if check_attempt < self._merge_poll_max_attempts - 1:
-                                        self.log.debug(
-                                            "PR status checks running after rebase, "
-                                            "waiting... (attempt %d/%d)",
-                                            check_attempt + 1,
-                                            self._merge_poll_max_attempts,
-                                        )
-                                        await asyncio.sleep(self._merge_recheck_interval)
-                                    else:
-                                        if auto_merge_ok:
-                                            log_and_print(
-                                                self.log,
-                                                self._console,
-                                                f"⏳ Auto-merge will complete: "
-                                                f"{pr_info.html_url} "
-                                                "[timeout waiting for checks]",
-                                                level="warning",
-                                            )
-                                        else:
-                                            log_and_print(
-                                                self.log,
-                                                self._console,
-                                                f"⚠️ Proceeding without checks: "
-                                                f"{pr_info.html_url} "
-                                                "[timeout waiting for checks]",
-                                                level="warning",
-                                            )
-                                        break
-                                elif updated_mergeable_state is None:
-                                    # GitHub is still computing mergeability
-                                    # (typically right after update_branch).
-                                    # Treat as transient and keep polling
-                                    # until the deadline or a concrete state
-                                    # arrives — breaking here would otherwise
-                                    # exit prematurely and (if auto-merge
-                                    # enablement failed) fall through to a
-                                    # manual merge attempt against the
-                                    # still-resolving PR state.
-                                    if check_attempt < self._merge_poll_max_attempts - 1:
-                                        self.log.debug(
-                                            "PR mergeable_state still computing "
-                                            "after rebase, waiting... "
-                                            "(attempt %d/%d)",
-                                            check_attempt + 1,
-                                            self._merge_poll_max_attempts,
-                                        )
-                                        await asyncio.sleep(self._merge_recheck_interval)
-                                    else:
-                                        break
-                                else:
-                                    break
-
-                            # Update our PR info with the latest state.
-                            # Preserve the previous non-None mergeable
-                            # value when the refresh returns ``null``
-                            # (GitHub is still computing). The Step 6
-                            # auto-merge skip gate now accepts both
-                            # ``True`` and ``None`` (it excludes only
-                            # the explicit ``False`` case), so a
-                            # transient null no longer blocks the
-                            # auto-merge path on its own. We still
-                            # preserve the prior known ``True`` here
-                            # so downstream logging and any future
-                            # tightening of that predicate get an
-                            # accurate state to work with.
-                            if updated_mergeable is not None:
-                                pr_info.mergeable = updated_mergeable
-                            # Preserve the previous non-None mergeable_state
-                            # for the same reason as ``mergeable`` above:
-                            # GitHub returns ``null`` while still computing,
-                            # and the post-rebase reporting / Step 5.5 logic
-                            # branches on this value (e.g. "clean" vs
-                            # "blocked" vs "behind"). A transient ``None``
-                            # would otherwise be classified as the catch-all
-                            # "other state" branch.
-                            if updated_mergeable_state is not None:
-                                pr_info.mergeable_state = updated_mergeable_state
-
-                            # Mark this PR as having gone through the
-                            # Step 5 rebase + poll path. Step 5.5 will
-                            # consult ``_rebased_prs`` to avoid doubling
-                            # the merge_timeout when the rebase exits
-                            # in ``blocked`` or ``behind`` state.
-                            self._rebased_prs.add(
-                                f"{repo_owner}/{repo_name}#{pr_info.number}"
-                            )
-
-                            # Report post-rebase status
-                            if pr_info.mergeable_state == "clean":
-                                log_and_print(
-                                    self.log,
-                                    self._console,
-                                    f"✅ Rebased: {pr_info.html_url}",
-                                    level="debug",
-                                )
-                            elif pr_info.mergeable_state == "behind":
-                                log_and_print(
-                                    self.log,
-                                    self._console,
-                                    f"⚠️  Rebased: {pr_info.html_url} [still behind after rebase]",
-                                    level="debug",
-                                )
-                            elif pr_info.mergeable_state == "blocked":
-                                log_and_print(
-                                    self.log,
-                                    self._console,
-                                    f"⬆️ Rebased: {pr_info.html_url} [waiting for status checks]",
-                                    level="debug",
-                                )
-                            else:
-                                log_and_print(
-                                    self.log,
-                                    self._console,
-                                    f"ℹ️  Rebased: {pr_info.html_url}",
-                                    level="debug",
-                                )
-
-                        except Exception as e:
-                            result.status = MergeStatus.FAILED
-                            result.error = f"Failed to rebase PR: {e}"
-
-                            if self.progress_tracker:
-                                self.progress_tracker.merge_failure()
-                            self._console.print(
-                                f"❌ Failed: {pr_info.html_url} [rebase error: {e}]"
-                            )
-                            return result
+                rebase_ctx = rebase.RebaseContext(
+                    github_client=self._github_client,
+                    token=self.token,
+                    rebase_local=self.rebase_local,
+                    fix_out_of_date=self.fix_out_of_date,
+                    preview_mode=self.preview_mode,
+                    merge_recheck_interval=self._merge_recheck_interval,
+                    merge_poll_max_attempts=self._merge_poll_max_attempts,
+                    log=self.log,
+                    console=self._console,
+                    rebased_prs=self._rebased_prs,
+                    enable_auto_merge=self._enable_auto_merge_for_pr,
+                )
+                outcome = await rebase.perform_step5_rebase(
+                    ctx=rebase_ctx,
+                    pr_info=pr_info,
+                    owner=repo_owner,
+                    repo=repo_name,
+                )
+                if outcome.failed:
+                    result.status = MergeStatus.FAILED
+                    result.error = outcome.error_message
+                    if self.progress_tracker:
+                        self.progress_tracker.merge_failure()
+                    return result
 
             # Step 5.5: If the PR is still blocked (e.g. by a pending
             # required status check such as pre-commit.ci), behind
@@ -1420,9 +1163,7 @@ class AsyncMergeManager:
             # below still weeds out genuinely-stuck cases (missing
             # approvals, etc.) so we don't burn ``merge_timeout`` on
             # them.
-            pr_key_for_wait = (
-                f"{repo_owner}/{repo_name}#{pr_info.number}"
-            )
+            pr_key_for_wait = f"{repo_owner}/{repo_name}#{pr_info.number}"
             already_rebased = pr_key_for_wait in self._rebased_prs
             base_should_wait = (
                 not self.preview_mode
@@ -1444,13 +1185,11 @@ class AsyncMergeManager:
                 and self._github_client is not None
             ):
                 try:
-                    pre_block_reason = (
-                        await self._github_client.analyze_block_reason(
-                            repo_owner,
-                            repo_name,
-                            pr_info.number,
-                            pr_info.head_sha,
-                        )
+                    pre_block_reason = await self._github_client.analyze_block_reason(
+                        repo_owner,
+                        repo_name,
+                        pr_info.number,
+                        pr_info.head_sha,
                     )
                 except Exception as exc:
                     self.log.debug(
@@ -1498,10 +1237,7 @@ class AsyncMergeManager:
                 # deadline so the total wait is bounded by
                 # ``merge_timeout`` even if a single iteration
                 # over-sleeps slightly.
-                wait_deadline = (
-                    asyncio.get_running_loop().time()
-                    + self._merge_timeout
-                )
+                wait_deadline = asyncio.get_running_loop().time() + self._merge_timeout
                 # Local alias so the type checker can narrow
                 # ``self._github_client`` across the await boundary.
                 wait_client = self._github_client
@@ -1518,17 +1254,12 @@ class AsyncMergeManager:
                 closed_during_wait = False
                 merged_during_wait = False
                 try:
-                    while (
-                        asyncio.get_running_loop().time() < wait_deadline
-                    ):
+                    while asyncio.get_running_loop().time() < wait_deadline:
                         if pr_info.mergeable_state == "clean":
                             break
                         # Sleep no longer than the time remaining
                         # so we don't overshoot ``wait_deadline``.
-                        remaining = (
-                            wait_deadline
-                            - asyncio.get_running_loop().time()
-                        )
+                        remaining = wait_deadline - asyncio.get_running_loop().time()
                         await asyncio.sleep(
                             min(self._merge_recheck_interval, remaining)
                         )
@@ -1561,9 +1292,7 @@ class AsyncMergeManager:
                             # informative for downstream logging and any
                             # future tightening of that predicate.
                             if "mergeable" in refreshed_wait:
-                                refreshed_mergeable = refreshed_wait.get(
-                                    "mergeable"
-                                )
+                                refreshed_mergeable = refreshed_wait.get("mergeable")
                                 if refreshed_mergeable is not None:
                                     pr_info.mergeable = refreshed_mergeable
                             if "mergeable_state" in refreshed_wait:
@@ -1575,9 +1304,7 @@ class AsyncMergeManager:
                                 # otherwise break the wait loop early
                                 # on a transient ``null`` returned
                                 # while GitHub is still computing.
-                                refreshed_state = refreshed_wait.get(
-                                    "mergeable_state"
-                                )
+                                refreshed_state = refreshed_wait.get("mergeable_state")
                                 if refreshed_state is not None:
                                     pr_info.mergeable_state = refreshed_state
                             # Capture the current head SHA so any
@@ -1585,9 +1312,9 @@ class AsyncMergeManager:
                             # call queries the right commit. The
                             # head can change while we wait
                             # (rebase, dependabot force-push, etc.).
-                            refreshed_head = (
-                                refreshed_wait.get("head") or {}
-                            ).get("sha")
+                            refreshed_head = (refreshed_wait.get("head") or {}).get(
+                                "sha"
+                            )
                             if refreshed_head:
                                 pr_info.head_sha = refreshed_head
                             if refreshed_wait.get("state") == "closed":
@@ -1638,12 +1365,13 @@ class AsyncMergeManager:
                         )
                     else:
                         result.status = MergeStatus.FAILED
-                        result.error = "PR closed without merging during auto-merge wait"
+                        result.error = (
+                            "PR closed without merging during auto-merge wait"
+                        )
                         if self.progress_tracker:
                             self.progress_tracker.merge_failure()
                         self._console.print(
-                            f"🛑 Closed without merging: "
-                            f"{pr_info.html_url}"
+                            f"🛑 Closed without merging: {pr_info.html_url}"
                         )
                     return result
 
@@ -1738,8 +1466,7 @@ class AsyncMergeManager:
                 auto_merge_pending_checks = False
                 if (
                     pr_key in self._auto_merge_enabled
-                    and pr_info.mergeable_state
-                    in ("blocked", "behind", "unstable")
+                    and pr_info.mergeable_state in ("blocked", "behind", "unstable")
                     and self.force_level != "all"
                 ):
                     if pr_info.mergeable_state in ("behind", "unstable"):
@@ -1779,9 +1506,7 @@ class AsyncMergeManager:
                         # checks are outstanding. The same predicate is
                         # used by the Step 5.5 pre-check.
                         auto_merge_pending_checks = (
-                            self._block_reason_indicates_pending_checks(
-                                block_reason
-                            )
+                            self._block_reason_indicates_pending_checks(block_reason)
                         )
 
                 if auto_merge_pending_checks:
@@ -2203,370 +1928,10 @@ class AsyncMergeManager:
         # Both attempts failed — surface a single line so the
         # user knows the PR-side audit trail is incomplete.
         try:
-            self._console.print(
-                f"⚠️ Unable to add pull request comment: {html_url}"
-            )
+            self._console.print(f"⚠️ Unable to add pull request comment: {html_url}")
         except Exception:
             pass
         return False
-
-    # ------------------------------------------------------------------
-    # Signature-preserving local rebase
-    # ------------------------------------------------------------------
-    #
-    # The GitHub REST ``PUT /repos/{owner}/{repo}/pulls/{n}/update-branch``
-    # endpoint creates a *server-side* merge commit whose committer is
-    # the calling token's GitHub user. That committer is not signed
-    # with the user's local SSH/GPG key, so the resulting commit
-    # loses its ``Verified`` badge — if the base branch's protection
-    # rules require verified signatures, the PR becomes
-    # un-mergeable until a human intervenes.
-    #
-    # Worse, automation bots that *would* normally recover from this
-    # have no comment-macro hook for it: ``@dependabot recreate``
-    # exists, but ``pre-commit-ci`` has no equivalent (see issue
-    # https://github.com/pre-commit-ci/issues/issues/41), so any
-    # pre-commit-ci PR we break this way is stuck until somebody
-    # closes it manually.
-    #
-    # The fix is to do the rebase *locally*: clone, rebase onto the
-    # base branch, force-push-with-lease. Because we shell out to
-    # ``git``, the user's ``~/.gitconfig`` (``commit.gpgsign``,
-    # ``gpg.format``, ``user.signingkey``) is honoured and the new
-    # commits remain verified.
-    #
-    # We only take this path when:
-    #   * ``self.rebase_local`` is True (it is by default; the CLI
-    #     exposes ``--no-rebase-local`` to opt out), AND
-    #   * either the PR is from ``pre-commit-ci[bot]`` (always —
-    #     it has no recovery macro), OR the base branch requires
-    #     verified signatures AND the current PR head commit is
-    #     itself verified (so REST update-branch *would* break
-    #     verification).
-    #
-    # On any failure (no ``git`` on PATH, conflict during rebase,
-    # network error, push rejected) we abort cleanly and return
-    # False; the caller then falls through to Step 5.5 so auto-merge
-    # can take over server-side. Auto-merge produces a properly
-    # verified merge commit signed by GitHub itself.
-
-    async def _should_use_local_rebase(
-        self,
-        pr_info: PullRequestInfo,
-        owner: str,
-        repo: str,
-        base_branch: str,
-    ) -> tuple[bool, str]:
-        """Decide whether Step 5 should rebase locally instead of via REST.
-
-        Returns:
-            ``(use_local, reason)``. ``reason`` is a short
-            human-readable string suitable for debug logging or a
-            user-visible note when ``use_local`` is True.
-        """
-        if not self.rebase_local:
-            return False, "--no-rebase-local set"
-
-        # Always use local rebase for pre-commit.ci PRs. The bot has
-        # no comment macro to recover from a verification break, so
-        # we treat it as opt-in regardless of branch protection.
-        if pr_info.author == "pre-commit-ci[bot]":
-            return True, "pre-commit-ci[bot] has no recreate/rebase macro"
-
-        if self._github_client is None:
-            return False, "no GitHub client"
-
-        # Branch-protection signature requirement (classic + rulesets)
-        try:
-            requires_signatures = await self._github_client.requires_commit_signatures(
-                owner, repo, base_branch
-            )
-        except Exception as exc:
-            self.log.debug(
-                "Could not determine signature requirement for %s/%s:%s: %s",
-                owner,
-                repo,
-                base_branch,
-                exc,
-            )
-            return False, "signature requirement check failed"
-
-        # Strict ``is True`` rather than truthy check: ``AsyncMock``
-        # default returns evaluate as truthy, and we explicitly do
-        # not want to enter the network-touching local-rebase path
-        # in test mocks that haven't been set up to handle it.
-        if requires_signatures is not True:
-            return False, "base branch does not require signatures"
-
-        # Base does require verified signatures. Check whether the
-        # current PR head is itself verified — if it isn't, REST
-        # update-branch can't make things worse, so we don't need
-        # the local-rebase machinery.
-        try:
-            all_verified, _unverified = (
-                await self._github_client.check_pr_commit_signatures(
-                    owner, repo, pr_info.number
-                )
-            )
-        except Exception as exc:
-            self.log.debug(
-                "Could not check PR commit signatures for %s/%s#%s: %s",
-                owner,
-                repo,
-                pr_info.number,
-                exc,
-            )
-            # Conservative: if we can't tell, prefer the local path
-            # (worst case: minor extra work; best case: preserve a
-            # signature we couldn't see).
-            return True, "signature check failed; preferring local path"
-
-        if all_verified:
-            return True, "base requires signatures and PR head is verified"
-        return False, "PR head is not currently verified"
-
-    async def _local_git_rebase_pr(
-        self,
-        pr_info: PullRequestInfo,
-        owner: str,
-        repo: str,
-    ) -> bool:
-        """Rebase a PR locally and force-push the result.
-
-        Clones the head repo into a secure temp workspace, fetches
-        the base branch (from upstream when the PR is from a fork),
-        runs ``git rebase``, and force-pushes with lease back to the
-        head repo. All git invocations inherit the user's
-        ``~/.gitconfig``, so signing config is respected.
-
-        Returns True only if every step succeeds. On any failure
-        (no ``git`` on PATH, conflict during rebase, network error,
-        push rejected) the workspace is cleaned up and False is
-        returned; the caller falls through to the auto-merge path
-        so we never leave a half-applied state.
-        """
-        # Local imports keep test collection cheap when the merge
-        # path is exercised purely through mocks.
-        from . import git_ops
-        from .git_ops import (
-            GitError,
-            add_remote,
-            checkout,
-            clone,
-            ensure_git_available,
-            fetch,
-            push_force_with_lease,
-            rebase,
-            rebase_abort,
-            secure_rmtree,
-        )
-
-        # Ensure ``git`` is on PATH before we start. ``GitError``
-        # is also raised when git is missing entirely.
-        try:
-            ensure_git_available()
-        except Exception as exc:
-            self.log.debug(
-                "Local rebase unavailable (no git on PATH?): %s", exc
-            )
-            return False
-
-        # We need the head/base clone URLs. They are populated for
-        # PRs surfaced by recent versions of the find-similar / merge
-        # flows; if missing we cannot proceed locally.
-        head_clone_url = pr_info.head_repo_clone_url
-        base_clone_url = pr_info.base_repo_clone_url
-        head_full = pr_info.head_repo_full_name
-        base_full = pr_info.base_repo_full_name or f"{owner}/{repo}"
-        if not head_clone_url:
-            head_clone_url = f"https://github.com/{head_full or base_full}.git"
-        if not base_clone_url:
-            base_clone_url = f"https://github.com/{base_full}.git"
-        head_full = head_full or base_full
-
-        head_branch = pr_info.head_branch
-        base_branch = pr_info.base_branch or "main"
-        if not head_branch:
-            self.log.debug(
-                "Local rebase: PR %s/%s#%s missing head_branch",
-                owner,
-                repo,
-                pr_info.number,
-            )
-            return False
-
-        origin_url = self._authed_clone_url(head_clone_url, self.token)
-        upstream_url = self._authed_clone_url(base_clone_url, self.token)
-
-        # Use a per-PR workspace under a secure temp parent so
-        # concurrent rebases (--concurrency=N) don't collide.
-        workspace_parent = Path(
-            git_ops.create_secure_tempdir(
-                prefix="dependamerge-localrebase-"
-            )
-        )
-        workspace = (
-            workspace_parent
-            / f"{(head_full or base_full).replace('/', '__')}__pr_{pr_info.number}"
-        )
-        workspace.mkdir(parents=True, exist_ok=True)
-
-        try:
-            # Clone the head repo at the PR's head branch. Shallow
-            # clone keeps disk + network footprint low for what
-            # are typically tiny dependency-update PRs.
-            try:
-                clone(
-                    origin_url,
-                    workspace,
-                    branch=head_branch,
-                    depth=50,
-                    single_branch=True,
-                    no_tags=True,
-                    filter_blobs=True,
-                    logger=self.log.debug,
-                )
-            except GitError as exc:
-                self.log.debug(
-                    "Local rebase: clone failed for %s: %s",
-                    pr_info.html_url,
-                    exc,
-                )
-                return False
-
-            # Fetch the base branch — from upstream when the PR
-            # is from a fork, from origin otherwise. We need it
-            # available locally before we can rebase onto it.
-            try:
-                if (head_full or base_full) != base_full:
-                    add_remote(
-                        "upstream",
-                        upstream_url,
-                        cwd=workspace,
-                        logger=self.log.debug,
-                    )
-                    fetch(
-                        "upstream",
-                        base_branch,
-                        cwd=workspace,
-                        depth=50,
-                        logger=self.log.debug,
-                    )
-                    rebase_onto = f"upstream/{base_branch}"
-                else:
-                    fetch(
-                        "origin",
-                        base_branch,
-                        cwd=workspace,
-                        depth=50,
-                        logger=self.log.debug,
-                    )
-                    rebase_onto = f"origin/{base_branch}"
-            except GitError as exc:
-                self.log.debug(
-                    "Local rebase: fetch failed for %s: %s",
-                    pr_info.html_url,
-                    exc,
-                )
-                return False
-
-            # Make sure we are on the head branch (defensive against
-            # detached HEAD after clone --branch).
-            try:
-                checkout(
-                    head_branch,
-                    cwd=workspace,
-                    create=False,
-                    logger=self.log.debug,
-                )
-            except GitError:
-                # Already on the branch, or branch missing locally;
-                # rebase will surface the real problem if any.
-                pass
-
-            # Rebase. ``git rebase`` here is non-interactive; if
-            # there are conflicts the command exits non-zero and
-            # leaves the working tree in conflict state, which we
-            # explicitly abort and treat as failure.
-            try:
-                rebase_result = rebase(
-                    rebase_onto,
-                    cwd=workspace,
-                    autostash=False,
-                    interactive=False,
-                    logger=self.log.debug,
-                )
-            except GitError as exc:
-                self.log.debug(
-                    "Local rebase: rebase failed for %s: %s",
-                    pr_info.html_url,
-                    exc,
-                )
-                return False
-
-            if rebase_result.returncode != 0:
-                self.log.debug(
-                    "Local rebase: conflicts during rebase of %s; aborting.",
-                    pr_info.html_url,
-                )
-                try:
-                    rebase_abort(cwd=workspace, logger=self.log.debug)
-                except Exception:
-                    pass
-                return False
-
-            # Force-push with lease to the head repo. We push back
-            # to ``origin`` because the head ref always lives there
-            # (even for forks, the head repo *is* the fork).
-            try:
-                push_force_with_lease(
-                    "origin",
-                    head_branch,
-                    head_branch,
-                    cwd=workspace,
-                    logger=self.log.debug,
-                )
-            except GitError as exc:
-                self.log.debug(
-                    "Local rebase: force-push failed for %s: %s",
-                    pr_info.html_url,
-                    exc,
-                )
-                return False
-
-            self.log.debug(
-                "Local rebase succeeded for %s", pr_info.html_url
-            )
-            return True
-
-        finally:
-            # Always clean up. The workspace contains a clone of
-            # the user's repository, so we want it gone even on
-            # success.
-            try:
-                secure_rmtree(workspace_parent)
-            except Exception as exc:
-                self.log.debug(
-                    "Local rebase: failed to clean up workspace %s: %s",
-                    workspace_parent,
-                    exc,
-                )
-
-    @staticmethod
-    def _authed_clone_url(clone_url: str, token: str) -> str:
-        """Return an HTTPS clone URL with the token injected for auth.
-
-        Mirrors ``FixOrchestrator._authed_url`` so the token never
-        appears in command-line arguments (the URL goes through
-        the standard ``git clone`` machinery, which redacts it from
-        log output via ``git_ops._redact``). Non-HTTPS URLs (SSH,
-        etc.) are returned unchanged.
-        """
-        if clone_url.startswith("https://"):
-            return clone_url.replace(
-                "https://", f"https://x-access-token:{token}@"
-            )
-        return clone_url
 
     async def _enable_auto_merge_for_pr(
         self, pr_info: PullRequestInfo, owner: str, repo: str
@@ -2627,9 +1992,7 @@ class AsyncMergeManager:
             return True
 
         cache_key = f"{owner}/{repo}"
-        merge_method = self._pr_merge_methods.get(
-            cache_key, self.default_merge_method
-        )
+        merge_method = self._pr_merge_methods.get(cache_key, self.default_merge_method)
 
         enabled = await self._github_client.enable_auto_merge(
             pr_info.node_id, merge_method
@@ -2649,8 +2012,7 @@ class AsyncMergeManager:
                 )
             except Exception as exc:
                 self.log.debug(
-                    "Could not refresh PR %s to check existing "
-                    "auto-merge state: %s",
+                    "Could not refresh PR %s to check existing auto-merge state: %s",
                     pr_key,
                     exc,
                 )
@@ -2684,8 +2046,7 @@ class AsyncMergeManager:
         # see at a glance that dependamerge enabled auto-merge
         # on the PR.
         audit_comment = (
-            "🤖 Dependamerge\n"
-            "Enabled auto-merge due to pending updates/checks ⏳"
+            "🤖 Dependamerge\nEnabled auto-merge due to pending updates/checks ⏳"
         )
         await self._post_pr_comment_with_retry(
             owner, repo, pr_info.number, pr_info.html_url, audit_comment
@@ -3993,15 +3354,15 @@ class AsyncMergeManager:
                         "web_commit_signoff_required", False
                     )
                     if web_commit_signoff:
-                        self.log.debug(
-                            f"Organization {owner} requires commit signoff"
-                        )
+                        self.log.debug(f"Organization {owner} requires commit signoff")
                     return org_data
                 else:
                     self._org_settings_cache[owner] = None
                     return None
             except Exception as e:
-                self.log.debug(f"Could not check organization settings for {owner}: {e}")
+                self.log.debug(
+                    f"Could not check organization settings for {owner}: {e}"
+                )
                 self._org_settings_cache[owner] = None
                 return None
 

--- a/src/dependamerge/merge_manager.py
+++ b/src/dependamerge/merge_manager.py
@@ -1108,7 +1108,6 @@ class AsyncMergeManager:
                     github_client=self._github_client,
                     token=self.token,
                     rebase_local=self.rebase_local,
-                    fix_out_of_date=self.fix_out_of_date,
                     preview_mode=self.preview_mode,
                     merge_recheck_interval=self._merge_recheck_interval,
                     merge_poll_max_attempts=self._merge_poll_max_attempts,

--- a/src/dependamerge/merge_manager.py
+++ b/src/dependamerge/merge_manager.py
@@ -1258,7 +1258,16 @@ class AsyncMergeManager:
                             break
                         # Sleep no longer than the time remaining
                         # so we don't overshoot ``wait_deadline``.
-                        remaining = wait_deadline - asyncio.get_running_loop().time()
+                        # Clamp to a non-negative value: the loop's
+                        # ``while ... < wait_deadline`` check and the
+                        # ``time()`` call here are not atomic, so a
+                        # near-deadline crossing can produce a tiny
+                        # negative ``remaining`` which would raise
+                        # ``ValueError`` from ``asyncio.sleep``.
+                        remaining = max(
+                            0.0,
+                            wait_deadline - asyncio.get_running_loop().time(),
+                        )
                         await asyncio.sleep(
                             min(self._merge_recheck_interval, remaining)
                         )

--- a/src/dependamerge/merge_manager.py
+++ b/src/dependamerge/merge_manager.py
@@ -915,8 +915,28 @@ class AsyncMergeManager:
                     )
                     return result
 
-            # Check if PR is closed before processing
+            # Check if PR is closed before processing.  If it has
+            # been closed *and merged* by another process (a
+            # concurrent dependamerge run, a human admin, an
+            # auto-merge that landed mid-flight, etc.) we treat it
+            # as a skip rather than a failure: there is no
+            # remaining work or human follow-up to perform.
             if pr_info.state != "open":
+                already_merged = await self._is_pr_already_merged(
+                    pr_info, repo_owner, repo_name
+                )
+                if already_merged:
+                    result.status = MergeStatus.SKIPPED
+                    result.error = "already merged externally"
+                    if self.progress_tracker:
+                        self.progress_tracker.merge_skipped()
+                    log_and_print(
+                        self.log,
+                        self._console,
+                        (f"⏭️  Skipped: {pr_info.html_url} [already merged externally]"),
+                        level="info",
+                    )
+                    return result
                 result.status = MergeStatus.FAILED
                 result.error = "PR is already closed"
                 self._console.print(f"🛑 Failed: {pr_info.html_url} [already closed]")
@@ -1591,6 +1611,34 @@ class AsyncMergeManager:
                         level="debug",
                     )
                 else:
+                    # Before computing a failure reason, recheck
+                    # whether the PR was actually merged externally
+                    # (e.g. by a concurrent dependamerge run at org
+                    # scope, or by a human admin) while our merge
+                    # attempt was in flight.  When that has happened
+                    # there is no remaining work and no follow-up
+                    # action for the operator: classify the outcome
+                    # as SKIPPED rather than FAILED so the summary
+                    # does not request human attention.
+                    already_merged = await self._is_pr_already_merged(
+                        pr_info, repo_owner, repo_name
+                    )
+                    if already_merged:
+                        result.status = MergeStatus.SKIPPED
+                        result.error = "already merged externally"
+                        if self.progress_tracker:
+                            self.progress_tracker.merge_skipped()
+                        log_and_print(
+                            self.log,
+                            self._console,
+                            (
+                                f"⏭️  Skipped: {pr_info.html_url} "
+                                "[already merged externally]"
+                            ),
+                            level="info",
+                        )
+                        return result
+
                     # Compute failure summary once — used for both the
                     # recreate decision and the final error reporting.
                     failure_reason = self._get_failure_summary(pr_info)
@@ -1613,9 +1661,7 @@ class AsyncMergeManager:
                     #      again on a fresh head SHA.
                     recreated_pr = None
                     if pr_info.author == "dependabot[bot]" and not self.preview_mode:
-                        should_recreate = (
-                            "branch protection" in failure_reason.lower()
-                        )
+                        should_recreate = "branch protection" in failure_reason.lower()
                         if not should_recreate:
                             try:
                                 (
@@ -1667,10 +1713,8 @@ class AsyncMergeManager:
                             # Same per-repo dispatch serialisation as
                             # the main merge path — see
                             # ``_get_merge_dispatch_lock``.
-                            new_dispatch_lock = (
-                                await self._get_merge_dispatch_lock(
-                                    new_owner, new_repo
-                                )
+                            new_dispatch_lock = await self._get_merge_dispatch_lock(
+                                new_owner, new_repo
                             )
                             async with new_dispatch_lock:
                                 new_merged = (
@@ -2557,11 +2601,7 @@ class AsyncMergeManager:
                 return False
             if n in {"dco", "dco/dco", "dcobot"} or n.startswith("dco/"):
                 return True
-            return (
-                "signoff" in n
-                or "sign-off" in n
-                or "signed-off" in n
-            )
+            return "signoff" in n or "sign-off" in n or "signed-off" in n
 
         # 1. PR-level age floor — don't fire on PRs we caught right
         #    after they were opened or force-pushed; the DCO check
@@ -2601,8 +2641,7 @@ class AsyncMergeManager:
 
         try:
             runs = await self._github_client.get(
-                f"/repos/{repo_owner}/{repo_name}/commits/"
-                f"{pr_info.head_sha}/check-runs"
+                f"/repos/{repo_owner}/{repo_name}/commits/{pr_info.head_sha}/check-runs"
             )
         except Exception as exc:
             self.log.debug(
@@ -2635,8 +2674,7 @@ class AsyncMergeManager:
 
         try:
             statuses = await self._github_client.get(
-                f"/repos/{repo_owner}/{repo_name}/commits/"
-                f"{pr_info.head_sha}/status"
+                f"/repos/{repo_owner}/{repo_name}/commits/{pr_info.head_sha}/status"
             )
         except Exception as exc:
             self.log.debug(
@@ -3384,6 +3422,47 @@ class AsyncMergeManager:
         )
         return False
 
+    async def _is_pr_already_merged(
+        self, pr_info: PullRequestInfo, owner: str, repo: str
+    ) -> bool:
+        """Return ``True`` if the PR has been merged externally.
+
+        Called after our own merge attempt has failed (or before
+        attempting it, when the PR was already closed at fetch
+        time) to distinguish two outcomes:
+
+        * The PR is genuinely unmergeable and needs human
+          follow-up — classify as ``FAILED``.
+        * The PR was merged while we were processing it (a
+          concurrent ``dependamerge`` run at org scope, a human
+          admin, or auto-merge landing mid-flight) — classify as
+          ``SKIPPED`` because there is no remaining work.
+
+        Any API error during the recheck (network, rate limit,
+        permission, unexpected payload) degrades to ``False`` so
+        the caller falls back to the existing failure path.
+        The intent here is to upgrade the user experience for a
+        known benign race, not to mask genuine errors.
+        """
+        if not self._github_client:
+            return False
+        try:
+            pr_data = await self._github_client.get(
+                f"/repos/{owner}/{repo}/pulls/{pr_info.number}"
+            )
+        except Exception as e:
+            self.log.debug(
+                "Failed to recheck %s/%s#%s for external merge: %s",
+                owner,
+                repo,
+                pr_info.number,
+                e,
+            )
+            return False
+        if not isinstance(pr_data, dict):
+            return False
+        return pr_data.get("state") == "closed" and bool(pr_data.get("merged"))
+
     def _get_failure_summary(self, pr_info: PullRequestInfo) -> str:
         """
         Generate a detailed failure summary based on PR state.
@@ -3572,9 +3651,7 @@ class AsyncMergeManager:
         # For other failure types, don't retry
         return False
 
-    async def _get_merge_dispatch_lock(
-        self, owner: str, repo: str
-    ) -> asyncio.Lock:
+    async def _get_merge_dispatch_lock(self, owner: str, repo: str) -> asyncio.Lock:
         """Return the ``asyncio.Lock`` that serialises merge dispatch for ``owner/repo``.
 
         The lock is created lazily on first request and shared by

--- a/src/dependamerge/merge_manager.py
+++ b/src/dependamerge/merge_manager.py
@@ -192,6 +192,14 @@ class AsyncMergeManager:
         # Track PRs that were just approved (for post-approval merge retry)
         self._recently_approved: set[str] = set()
 
+        # Track repositories where the token has already failed a
+        # permission check during this run.  Subsequent PRs in the
+        # same repository are short-circuited with a clean skip
+        # message rather than triggering another round-trip to
+        # GitHub that will fail identically and emit another
+        # screenful of guidance.
+        self._permission_failed_repos: set[str] = set()
+
         # Track PRs where auto-merge has been enabled so that
         # post-timeout merge attempts can be skipped gracefully.
         self._auto_merge_enabled: set[str] = set()
@@ -838,6 +846,27 @@ class AsyncMergeManager:
         """
         start_time = time.time()
         repo_owner, repo_name = pr_info.repository_full_name.split("/", 1)
+
+        # Fast-fail when a previous PR in this batch has already
+        # hit a permission error against the same repository.  In
+        # that case the token genuinely lacks the rights to act on
+        # any PR in this repo, so attempting the GitHub API calls
+        # again would only produce another 403 and another copy of
+        # the token-guidance block.  Report the failure cleanly
+        # (single ❌ line, no traceback) and move on.
+        if pr_info.repository_full_name in self._permission_failed_repos:
+            result = MergeResult(pr_info=pr_info, status=MergeStatus.FAILED)
+            result.error = (
+                f"token lacks required permissions on {pr_info.repository_full_name}"
+            )
+            if self.progress_tracker:
+                self.progress_tracker.merge_failure()
+            self._console.print(
+                f"❌ Failed: {pr_info.html_url} "
+                "[token lacks permissions on this repository]"
+            )
+            result.duration = time.time() - start_time
+            return result
 
         # Early determination of merge method based on repository settings
         merge_method = await self._get_merge_method_for_repo(repo_owner, repo_name)
@@ -1772,11 +1801,23 @@ class AsyncMergeManager:
                         )
 
         except GitHubPermissionError as e:
-            # Handle permission errors with detailed guidance
+            # Handle permission errors with detailed guidance.
+            #
+            # When the token lacks rights on a repository the same
+            # error fires for every PR processed.  Record the repo
+            # so subsequent PRs in the batch short-circuit via the
+            # fast-fail check at the top of this method, and emit
+            # the verbose guidance block only the first time we
+            # see the failure for a given repository.
             result.status = MergeStatus.FAILED
             result.error = str(e)
             if self.progress_tracker:
                 self.progress_tracker.merge_failure()
+
+            first_failure_for_repo = (
+                pr_info.repository_full_name not in self._permission_failed_repos
+            )
+            self._permission_failed_repos.add(pr_info.repository_full_name)
 
             # Extract operation-specific error message
             operation_desc = e.operation.replace("_", " ")
@@ -1784,7 +1825,12 @@ class AsyncMergeManager:
                 f"❌ Failed: {pr_info.html_url} [permission denied: {operation_desc}]"
             )
 
-            # Provide token-specific guidance
+            if not first_failure_for_repo:
+                # Already printed the full guidance for this repo;
+                # do not repeat it for every remaining PR.
+                return result
+
+            # Provide token-specific guidance (printed once per repo)
             self._console.print("\n💡 Token Permission Issue:")
             self._console.print(f"   Problem: {e}")
 
@@ -1810,14 +1856,19 @@ class AsyncMergeManager:
                 self.progress_tracker.merge_failure()
 
             # Provide clean single-line error messages for other errors.
-            # Also log at error level with the stack trace so users
-            # debugging via log files (where stdout isn't captured)
-            # have full context.
+            # The stack trace is attached only when the logger is in
+            # DEBUG mode (i.e. the user passed ``--verbose``).  In the
+            # default WARNING setup the trace would otherwise be
+            # printed to stderr for every failure, swamping a
+            # repo-scoped batch run with several hundred lines of
+            # noise per PR when the underlying cause is something
+            # uniform (e.g. token without the required scope) that a
+            # single clean line already conveys.
             self.log.error(
                 "Failed to process PR %s: %s",
                 pr_info.html_url,
                 e,
-                exc_info=True,
+                exc_info=self.log.isEnabledFor(logging.DEBUG),
             )
             self._console.print(
                 f"❌ Failed: {pr_info.html_url} [processing error: {e}]"
@@ -3176,6 +3227,15 @@ class AsyncMergeManager:
                 "🤖 Dependamerge\nApproved this pull request ✅",
             )
             return True
+        except GitHubPermissionError:
+            # Let typed permission errors propagate to the caller's
+            # dedicated handler in ``_merge_single_pr``.  Wrapping
+            # them in a generic ``RuntimeError`` (as the old broad
+            # ``except Exception`` below did) hid them from that
+            # handler and routed the failure through the catch-all
+            # path, which dumps a full stack trace to stderr on
+            # every PR in the batch.
+            raise
         except Exception as e:
             # Handle specific error codes
             error_str = str(e)
@@ -3284,6 +3344,15 @@ class AsyncMergeManager:
                         )
                         break
 
+            except GitHubPermissionError:
+                # Token cannot merge on this repo — propagate to the
+                # caller so the PermissionError handler in
+                # ``_merge_single_pr`` reports it cleanly and records
+                # the repo for fast-fail of remaining PRs in the
+                # batch.  Retrying or breaking silently here would
+                # downgrade the failure into a generic
+                # "merge failed: clean" reason that misleads users.
+                raise
             except Exception as e:
                 error_msg = str(e)
 

--- a/src/dependamerge/merge_manager.py
+++ b/src/dependamerge/merge_manager.py
@@ -210,6 +210,19 @@ class AsyncMergeManager:
         self._waiting_prs: dict[str, float] = {}
         self._waiting_lock = asyncio.Lock()
 
+        # Per-repo locks that serialise the actual ``merge_pull_request``
+        # API call.  Multiple workers can run in parallel through approve,
+        # rebase polling, and Step 5.5's auto-merge wait loop — only the
+        # final dispatch is serialised, and only between PRs that target
+        # the same repository.  This avoids the head-of-line blocking we
+        # used to get from forcing ``concurrency=1`` for repo-scoped
+        # runs (where a single PR parked in the wait loop could block
+        # every other PR in the batch for the full ``merge_timeout``)
+        # while still preventing back-to-back merges on the same repo
+        # from racing GitHub's branch-protection propagation.
+        self._merge_dispatch_locks: dict[str, asyncio.Lock] = {}
+        self._merge_dispatch_locks_lock = asyncio.Lock()
+
         # Delay (seconds) after submitting a new approval before attempting merge.
         # GitHub needs time to propagate the approval to branch-protection evaluation.
         default_post_approval_delay = 3.0
@@ -1527,9 +1540,18 @@ class AsyncMergeManager:
                 if auto_merge_pending_checks:
                     merged = None  # Sentinel: auto-merge pending
                 else:
-                    merged = await self._merge_pr_with_retry(
-                        pr_info, repo_owner, repo_name
+                    # Serialise the actual merge dispatch per repo so
+                    # back-to-back merges don't race GitHub's branch
+                    # protection propagation.  Workers on the same
+                    # repo queue here; workers on different repos run
+                    # in parallel.  See ``_get_merge_dispatch_lock``.
+                    dispatch_lock = await self._get_merge_dispatch_lock(
+                        repo_owner, repo_name
                     )
+                    async with dispatch_lock:
+                        merged = await self._merge_pr_with_retry(
+                            pr_info, repo_owner, repo_name
+                        )
 
                 if merged is None:
                     # Auto-merge is active — PR will merge asynchronously.
@@ -1642,12 +1664,23 @@ class AsyncMergeManager:
                         try:
                             if self._github_client is None:
                                 raise RuntimeError("GitHub client not initialized")
-                            new_merged = await self._github_client.merge_pull_request(
-                                new_owner,
-                                new_repo,
-                                recreated_pr.number,
-                                new_merge_method,
+                            # Same per-repo dispatch serialisation as
+                            # the main merge path — see
+                            # ``_get_merge_dispatch_lock``.
+                            new_dispatch_lock = (
+                                await self._get_merge_dispatch_lock(
+                                    new_owner, new_repo
+                                )
                             )
+                            async with new_dispatch_lock:
+                                new_merged = (
+                                    await self._github_client.merge_pull_request(
+                                        new_owner,
+                                        new_repo,
+                                        recreated_pr.number,
+                                        new_merge_method,
+                                    )
+                                )
                         except Exception as merge_err:
                             self.log.error(
                                 "Failed to merge recreated PR %s#%s: %s",
@@ -3538,6 +3571,31 @@ class AsyncMergeManager:
 
         # For other failure types, don't retry
         return False
+
+    async def _get_merge_dispatch_lock(
+        self, owner: str, repo: str
+    ) -> asyncio.Lock:
+        """Return the ``asyncio.Lock`` that serialises merge dispatch for ``owner/repo``.
+
+        The lock is created lazily on first request and shared by
+        every worker targeting the same repository.  Workers
+        targeting different repositories receive distinct locks and
+        can dispatch in parallel.
+
+        Holding this lock around the actual ``merge_pull_request``
+        API call (and its retry loop) prevents back-to-back merges
+        on the same repo from racing GitHub's branch-protection
+        propagation, while leaving every other phase of the merge
+        flow — approve, rebase polling, Step 5.5's auto-merge wait —
+        free to run in parallel across workers.
+        """
+        key = f"{owner}/{repo}"
+        async with self._merge_dispatch_locks_lock:
+            lock = self._merge_dispatch_locks.get(key)
+            if lock is None:
+                lock = asyncio.Lock()
+                self._merge_dispatch_locks[key] = lock
+            return lock
 
     async def _get_org_settings(self, owner: str) -> dict[str, Any] | None:
         """

--- a/src/dependamerge/merge_manager.py
+++ b/src/dependamerge/merge_manager.py
@@ -53,12 +53,13 @@ from .progress_tracker import MergeProgressTracker
 DEFAULT_MERGE_TIMEOUT: float = 300.0  # seconds (5 minutes)
 DEFAULT_MERGE_RECHECK_INTERVAL: float = 10.0  # seconds between polls
 
-# A DCO check normally completes within a few seconds.  When it has
+# Required verification checks (DCO, lint, build, etc.) normally
+# start reporting within a few seconds.  When a *required* check has
 # been pending for longer than this on a PR that itself was created
 # / last updated more than this many seconds ago, the check is
-# treated as stuck.  Used by ``_detect_stuck_dco`` to decide whether
-# to ask dependabot to recreate the PR.
-STUCK_DCO_THRESHOLD_SECONDS: float = 60.0
+# treated as stuck.  Used by ``_detect_stuck_required_check`` to
+# decide whether to ask dependabot to recreate the PR.
+STUCK_CHECK_THRESHOLD_SECONDS: float = 60.0
 
 
 class MergeStatus(Enum):
@@ -1686,15 +1687,20 @@ class AsyncMergeManager:
                     # Two recreate triggers are considered:
                     #   1. Branch-protection failures (the original
                     #      unsigned-commit case).
-                    #   2. A DCO check that has been stuck (queued /
-                    #      in_progress / pending) for longer than
-                    #      ``STUCK_DCO_THRESHOLD_SECONDS`` on a PR
+                    #   2. A *required* verification check that has
+                    #      been stuck (queued / in_progress / pending)
+                    #      for longer than
+                    #      ``STUCK_CHECK_THRESHOLD_SECONDS`` on a PR
                     #      that itself was created and last updated
-                    #      that long ago. DCO normally completes in
-                    #      seconds; when it does not, the only
-                    #      reliable recovery for dependabot PRs is
-                    #      to recreate the PR so the check fires
-                    #      again on a fresh head SHA.
+                    #      that long ago. Required checks (DCO, lint,
+                    #      build, etc.) normally start reporting in
+                    #      seconds; when one stalls indefinitely, the
+                    #      only reliable recovery for dependabot PRs
+                    #      is to recreate the PR so the checks fire
+                    #      again on a fresh head SHA. pre-commit.ci is
+                    #      excluded here — it has its own dedicated
+                    #      recovery via ``_trigger_stale_precommit_ci``
+                    #      (which posts ``pre-commit.ci run``).
                     recreated_pr = None
                     if pr_info.author == "dependabot[bot]" and not self.preview_mode:
                         should_recreate = "branch protection" in failure_reason.lower()
@@ -1704,10 +1710,11 @@ class AsyncMergeManager:
                                     is_stuck,
                                     stuck_check,
                                     stuck_age,
-                                ) = await self._detect_stuck_dco(pr_info)
+                                ) = await self._detect_stuck_required_check(pr_info)
                             except Exception as exc:
                                 self.log.debug(
-                                    "_detect_stuck_dco failed for %s#%s: %s",
+                                    "_detect_stuck_required_check failed for "
+                                    "%s#%s: %s",
                                     pr_info.repository_full_name,
                                     pr_info.number,
                                     exc,
@@ -1722,7 +1729,8 @@ class AsyncMergeManager:
                                 # not get silently swallowed by the
                                 # console parser.
                                 self._console.print(
-                                    f"⏳ Stuck DCO detected: {pr_info.html_url} "
+                                    f"⏳ Stuck required check detected: "
+                                    f"{pr_info.html_url} "
                                     f"[{stuck_check} pending for "
                                     f"{stuck_age:.0f}s, requesting recreate]",
                                     markup=False,
@@ -2601,23 +2609,40 @@ class AsyncMergeManager:
         )
         return False
 
-    async def _detect_stuck_dco(
+    async def _detect_stuck_required_check(
         self,
         pr_info: PullRequestInfo,
     ) -> tuple[bool, str | None, float]:
-        """Detect whether a DCO check on ``pr_info`` is stuck.
+        """Detect whether a *required* verification check is stuck.
 
-        The DCO check normally finishes within a handful of seconds.
-        When it has been queued / in-progress for longer than
-        :data:`STUCK_DCO_THRESHOLD_SECONDS` on a PR that itself was
+        Required checks (DCO, lint, build, license scans, etc.)
+        normally start reporting within a handful of seconds.  When
+        one has been queued / in-progress / pending for longer than
+        :data:`STUCK_CHECK_THRESHOLD_SECONDS` on a PR that itself was
         created and last updated more than that long ago, treat it
         as stuck so the caller can decide whether to ask dependabot
-        to recreate the PR.
+        to recreate the PR (the only reliable recovery for a
+        dependabot PR with no ``recreate``/``rebase`` macro of its
+        own once a required check has stalled indefinitely).
+
+        Only checks that are *required* on the PR's base branch are
+        considered, since a non-required check cannot block the
+        merge.  DCO-shaped checks are additionally always treated as
+        eligible as a safety net: the GitHub DCO App check is the
+        canonical stuck-check case and is effectively always blocking
+        where it is enabled, even when the required-checks lookup
+        cannot enumerate it.
+
+        ``pre-commit.ci`` checks are explicitly excluded here even
+        when required — they have their own dedicated recovery via
+        :meth:`_trigger_stale_precommit_ci`, which posts the
+        ``pre-commit.ci run`` comment (dependabot's ``recreate`` macro
+        does not retrigger pre-commit.ci).
 
         The age floor on PR ``created_at`` / ``updated_at`` avoids
         false positives on PRs that were touched seconds before we
-        observed them — in those cases the DCO check is simply
-        running normally and should be allowed to finish.
+        observed them — in those cases the check is simply running
+        normally and should be allowed to finish.
 
         Args:
             pr_info: The pull request being evaluated.
@@ -2633,7 +2658,7 @@ class AsyncMergeManager:
             return False, None, 0.0
 
         repo_owner, repo_name = pr_info.repository_full_name.split("/", 1)
-        threshold = STUCK_DCO_THRESHOLD_SECONDS
+        threshold = STUCK_CHECK_THRESHOLD_SECONDS
 
         from datetime import datetime, timezone
 
@@ -2661,9 +2686,21 @@ class AsyncMergeManager:
                 return True
             return "signoff" in n or "sign-off" in n or "signed-off" in n
 
+        def _is_precommit_name(name: str) -> bool:
+            """Return True when ``name`` is a pre-commit.ci check.
+
+            pre-commit.ci reports as ``pre-commit.ci - pr`` (and the
+            ``- ci`` variant).  It is excluded from this detector
+            because dependabot's ``recreate`` macro does not
+            retrigger it; ``_trigger_stale_precommit_ci`` handles it
+            via the ``pre-commit.ci run`` comment instead.
+            """
+            n = (name or "").strip().lower()
+            return "pre-commit.ci" in n or "pre-commit-ci" in n
+
         # 1. PR-level age floor — don't fire on PRs we caught right
-        #    after they were opened or force-pushed; the DCO check
-        #    on those is simply running normally.
+        #    after they were opened or force-pushed; checks on those
+        #    are simply running normally.
         now = datetime.now(timezone.utc)
         try:
             pr_data = await self._github_client.get(
@@ -2671,7 +2708,7 @@ class AsyncMergeManager:
             )
         except Exception as exc:
             self.log.debug(
-                "_detect_stuck_dco: pr fetch failed for %s#%s: %s",
+                "_detect_stuck_required_check: pr fetch failed for %s#%s: %s",
                 pr_info.repository_full_name,
                 pr_info.number,
                 exc,
@@ -2693,7 +2730,45 @@ class AsyncMergeManager:
         if pr_age < threshold or pr_idle < threshold:
             return False, None, 0.0
 
-        # 2. Examine check-runs and status contexts on the head SHA.
+        # 2. Determine which checks are *required* on the base branch
+        #    so a non-blocking check is never treated as stuck.  On
+        #    any failure we fall back to an empty set, leaving the
+        #    DCO safety net (below) as the only eligible matcher.
+        required_contexts: set[str] = set()
+        try:
+            required = await self._github_client.get_required_status_checks(
+                repo_owner, repo_name, pr_info.base_branch or "main"
+            )
+            if isinstance(required, list):
+                required_contexts = {
+                    str(c.get("context", "")).strip().lower()
+                    for c in required
+                    if isinstance(c, dict) and c.get("context")
+                }
+        except Exception as exc:
+            self.log.debug(
+                "_detect_stuck_required_check: required-checks fetch failed "
+                "for %s#%s: %s",
+                pr_info.repository_full_name,
+                pr_info.number,
+                exc,
+            )
+            required_contexts = set()
+
+        def _is_eligible(name: str) -> bool:
+            """Return True when a stuck ``name`` should drive recreate.
+
+            Eligible when the check is required on the base branch or
+            is a DCO-shaped check (safety net), and is *not* a
+            pre-commit.ci check (handled separately).
+            """
+            if _is_precommit_name(name):
+                return False
+            return (name or "").strip().lower() in required_contexts or _is_dco_name(
+                name
+            )
+
+        # 3. Examine check-runs and status contexts on the head SHA.
         candidate_name: str | None = None
         candidate_age: float = 0.0
 
@@ -2703,7 +2778,8 @@ class AsyncMergeManager:
             )
         except Exception as exc:
             self.log.debug(
-                "_detect_stuck_dco: check-runs fetch failed for %s#%s: %s",
+                "_detect_stuck_required_check: check-runs fetch failed for "
+                "%s#%s: %s",
                 pr_info.repository_full_name,
                 pr_info.number,
                 exc,
@@ -2715,7 +2791,7 @@ class AsyncMergeManager:
                 if not isinstance(run, dict):
                     continue
                 name = run.get("name", "")
-                if not _is_dco_name(name):
+                if not _is_eligible(name):
                     continue
                 status = run.get("status")
                 if status not in ("queued", "in_progress"):
@@ -2736,7 +2812,7 @@ class AsyncMergeManager:
             )
         except Exception as exc:
             self.log.debug(
-                "_detect_stuck_dco: status fetch failed for %s#%s: %s",
+                "_detect_stuck_required_check: status fetch failed for " "%s#%s: %s",
                 pr_info.repository_full_name,
                 pr_info.number,
                 exc,
@@ -2748,7 +2824,7 @@ class AsyncMergeManager:
                 if not isinstance(s, dict):
                     continue
                 ctx = s.get("context", "")
-                if not _is_dco_name(ctx):
+                if not _is_eligible(ctx):
                     continue
                 if s.get("state") != "pending":
                     continue

--- a/src/dependamerge/merge_manager.py
+++ b/src/dependamerge/merge_manager.py
@@ -53,6 +53,13 @@ from .progress_tracker import MergeProgressTracker
 DEFAULT_MERGE_TIMEOUT: float = 300.0  # seconds (5 minutes)
 DEFAULT_MERGE_RECHECK_INTERVAL: float = 10.0  # seconds between polls
 
+# A DCO check normally completes within a few seconds.  When it has
+# been pending for longer than this on a PR that itself was created
+# / last updated more than this many seconds ago, the check is
+# treated as stuck.  Used by ``_detect_stuck_dco`` to decide whether
+# to ask dependabot to recreate the PR.
+STUCK_DCO_THRESHOLD_SECONDS: float = 60.0
+
 
 class MergeStatus(Enum):
     """Status of a PR merge operation."""
@@ -1569,9 +1576,55 @@ class AsyncMergeManager:
                     # Before giving up, check if this is a dependabot PR
                     # that failed due to unsigned commits.  If so, ask
                     # dependabot to recreate the PR and merge the new one.
+                    #
+                    # Two recreate triggers are considered:
+                    #   1. Branch-protection failures (the original
+                    #      unsigned-commit case).
+                    #   2. A DCO check that has been stuck (queued /
+                    #      in_progress / pending) for longer than
+                    #      ``STUCK_DCO_THRESHOLD_SECONDS`` on a PR
+                    #      that itself was created and last updated
+                    #      that long ago. DCO normally completes in
+                    #      seconds; when it does not, the only
+                    #      reliable recovery for dependabot PRs is
+                    #      to recreate the PR so the check fires
+                    #      again on a fresh head SHA.
                     recreated_pr = None
                     if pr_info.author == "dependabot[bot]" and not self.preview_mode:
-                        if "branch protection" in failure_reason.lower():
+                        should_recreate = (
+                            "branch protection" in failure_reason.lower()
+                        )
+                        if not should_recreate:
+                            try:
+                                (
+                                    is_stuck,
+                                    stuck_check,
+                                    stuck_age,
+                                ) = await self._detect_stuck_dco(pr_info)
+                            except Exception as exc:
+                                self.log.debug(
+                                    "_detect_stuck_dco failed for %s#%s: %s",
+                                    pr_info.repository_full_name,
+                                    pr_info.number,
+                                    exc,
+                                )
+                                is_stuck = False
+                                stuck_check = None
+                                stuck_age = 0.0
+                            if is_stuck:
+                                # Use markup=False so a check name
+                                # containing characters that look like
+                                # Rich markup (e.g. ``[required]``) does
+                                # not get silently swallowed by the
+                                # console parser.
+                                self._console.print(
+                                    f"⏳ Stuck DCO detected: {pr_info.html_url} "
+                                    f"[{stuck_check} pending for "
+                                    f"{stuck_age:.0f}s, requesting recreate]",
+                                    markup=False,
+                                )
+                                should_recreate = True
+                        if should_recreate:
                             recreated_pr = await self._trigger_dependabot_recreate(
                                 pr_info
                             )
@@ -2412,6 +2465,174 @@ class AsyncMergeManager:
             f"{pr_info.repository_full_name}#{pr_info.number}"
         )
         return False
+
+    async def _detect_stuck_dco(
+        self,
+        pr_info: PullRequestInfo,
+    ) -> tuple[bool, str | None, float]:
+        """Detect whether a DCO check on ``pr_info`` is stuck.
+
+        The DCO check normally finishes within a handful of seconds.
+        When it has been queued / in-progress for longer than
+        :data:`STUCK_DCO_THRESHOLD_SECONDS` on a PR that itself was
+        created and last updated more than that long ago, treat it
+        as stuck so the caller can decide whether to ask dependabot
+        to recreate the PR.
+
+        The age floor on PR ``created_at`` / ``updated_at`` avoids
+        false positives on PRs that were touched seconds before we
+        observed them — in those cases the DCO check is simply
+        running normally and should be allowed to finish.
+
+        Args:
+            pr_info: The pull request being evaluated.
+
+        Returns:
+            A 3-tuple ``(is_stuck, check_name, age_seconds)``.
+            ``check_name`` is the GitHub check / status name of the
+            stuck check (or ``None`` when no stuck check was found).
+            ``age_seconds`` is the time the check has been pending
+            (or ``0.0`` when no candidate check was found).
+        """
+        if not self._github_client:
+            return False, None, 0.0
+
+        repo_owner, repo_name = pr_info.repository_full_name.split("/", 1)
+        threshold = STUCK_DCO_THRESHOLD_SECONDS
+
+        from datetime import datetime, timezone
+
+        def _parse_ts(value: Any) -> datetime | None:
+            if not isinstance(value, str) or not value:
+                return None
+            try:
+                # GitHub returns RFC 3339 with a trailing ``Z``.
+                return datetime.fromisoformat(value.replace("Z", "+00:00"))
+            except ValueError:
+                return None
+
+        def _is_dco_name(name: str) -> bool:
+            """Return True when ``name`` looks like a DCO check.
+
+            Matches the common variants emitted by the GitHub DCO
+            App and similar bots: ``DCO``, ``dco/dco``, ``dcobot``,
+            and any name containing ``signoff`` / ``sign-off`` /
+            ``signed-off`` (case-insensitive).
+            """
+            n = (name or "").strip().lower()
+            if not n:
+                return False
+            if n in {"dco", "dco/dco", "dcobot"} or n.startswith("dco/"):
+                return True
+            return (
+                "signoff" in n
+                or "sign-off" in n
+                or "signed-off" in n
+            )
+
+        # 1. PR-level age floor — don't fire on PRs we caught right
+        #    after they were opened or force-pushed; the DCO check
+        #    on those is simply running normally.
+        now = datetime.now(timezone.utc)
+        try:
+            pr_data = await self._github_client.get(
+                f"/repos/{repo_owner}/{repo_name}/pulls/{pr_info.number}"
+            )
+        except Exception as exc:
+            self.log.debug(
+                "_detect_stuck_dco: pr fetch failed for %s#%s: %s",
+                pr_info.repository_full_name,
+                pr_info.number,
+                exc,
+            )
+            return False, None, 0.0
+
+        if not isinstance(pr_data, dict):
+            return False, None, 0.0
+
+        pr_created = _parse_ts(pr_data.get("created_at"))
+        pr_updated = _parse_ts(pr_data.get("updated_at"))
+        if pr_created is None or pr_updated is None:
+            # Without timing data we cannot safely judge stuckness;
+            # fail closed.
+            return False, None, 0.0
+
+        pr_age = (now - pr_created).total_seconds()
+        pr_idle = (now - pr_updated).total_seconds()
+        if pr_age < threshold or pr_idle < threshold:
+            return False, None, 0.0
+
+        # 2. Examine check-runs and status contexts on the head SHA.
+        candidate_name: str | None = None
+        candidate_age: float = 0.0
+
+        try:
+            runs = await self._github_client.get(
+                f"/repos/{repo_owner}/{repo_name}/commits/"
+                f"{pr_info.head_sha}/check-runs"
+            )
+        except Exception as exc:
+            self.log.debug(
+                "_detect_stuck_dco: check-runs fetch failed for %s#%s: %s",
+                pr_info.repository_full_name,
+                pr_info.number,
+                exc,
+            )
+            runs = None
+
+        if isinstance(runs, dict):
+            for run in runs.get("check_runs") or []:
+                if not isinstance(run, dict):
+                    continue
+                name = run.get("name", "")
+                if not _is_dco_name(name):
+                    continue
+                status = run.get("status")
+                if status not in ("queued", "in_progress"):
+                    continue
+                started = _parse_ts(run.get("started_at"))
+                # Use the *latest* of started_at and PR updated_at
+                # as the reference so a stale started_at left over
+                # from a prior head SHA does not inflate the age.
+                ref = max(started, pr_updated) if started else pr_updated
+                age = (now - ref).total_seconds()
+                if age >= threshold and age > candidate_age:
+                    candidate_name = name
+                    candidate_age = age
+
+        try:
+            statuses = await self._github_client.get(
+                f"/repos/{repo_owner}/{repo_name}/commits/"
+                f"{pr_info.head_sha}/status"
+            )
+        except Exception as exc:
+            self.log.debug(
+                "_detect_stuck_dco: status fetch failed for %s#%s: %s",
+                pr_info.repository_full_name,
+                pr_info.number,
+                exc,
+            )
+            statuses = None
+
+        if isinstance(statuses, dict):
+            for s in statuses.get("statuses") or []:
+                if not isinstance(s, dict):
+                    continue
+                ctx = s.get("context", "")
+                if not _is_dco_name(ctx):
+                    continue
+                if s.get("state") != "pending":
+                    continue
+                updated = _parse_ts(s.get("updated_at")) or pr_updated
+                ref = max(updated, pr_updated)
+                age = (now - ref).total_seconds()
+                if age >= threshold and age > candidate_age:
+                    candidate_name = ctx
+                    candidate_age = age
+
+        if candidate_name is None:
+            return False, None, 0.0
+        return True, candidate_name, candidate_age
 
     async def _trigger_dependabot_recreate(
         self, pr_info: PullRequestInfo

--- a/src/dependamerge/merge_manager.py
+++ b/src/dependamerge/merge_manager.py
@@ -175,7 +175,14 @@ class AsyncMergeManager:
         self._github_client: GitHubAsync | None = None
         self._github_service: GitHubService | None = None
         self._copilot_handler: CopilotCommentHandler | None = None
-        self._console = Console()
+        # Reuse the progress tracker's Rich Console (when one is
+        # provided) so per-PR ✅/❌ lines emitted during a merge run
+        # interleave cleanly with the Live progress display.  Using a
+        # separate Console() instance causes Rich's Live re-draw to
+        # garble or eat those messages because the two consoles share
+        # the terminal but coordinate independently.
+        tracker_console = getattr(progress_tracker, "console", None)
+        self._console = tracker_console if tracker_console is not None else Console()
 
         # Track merge methods per repository
         self._pr_merge_methods: dict[str, str] = {}

--- a/src/dependamerge/output_utils.py
+++ b/src/dependamerge/output_utils.py
@@ -47,4 +47,10 @@ def log_and_print(
     if style:
         console.print(message, style=style)
     else:
-        print(message)
+        # Route through the Rich console rather than the builtin
+        # ``print`` so output coordinates correctly with any active
+        # Rich ``Live`` display in the same console.  Using
+        # ``print`` here causes the Live re-draw to garble or eat
+        # interleaved messages (e.g. per-PR ✅/❌ lines emitted
+        # while a progress tracker is running).
+        console.print(message)

--- a/src/dependamerge/progress_tracker.py
+++ b/src/dependamerge/progress_tracker.py
@@ -275,9 +275,7 @@ class ProgressTracker:
 
         # Elapsed time
         elapsed = datetime.now() - self.start_time
-        text.append(
-            f"\n   ⏱️  Elapsed: {self._format_duration(elapsed)}", style="dim"
-        )
+        text.append(f"\n   ⏱️  Elapsed: {self._format_duration(elapsed)}", style="dim")
 
         return text
 
@@ -370,6 +368,7 @@ class MergeProgressTracker(ProgressTracker):
         self.similar_prs_found = 0
         self.prs_merged = 0
         self.prs_failed = 0
+        self.prs_skipped = 0
         self.prs_closed = 0
         self.is_close_operation = is_close_operation
         self._custom_label = operation_label
@@ -406,6 +405,19 @@ class MergeProgressTracker(ProgressTracker):
             self.completed_prs += 1
         self._refresh_display()
 
+    def merge_skipped(self) -> None:
+        """Record a PR skipped because it was merged externally.
+
+        Distinct from ``merge_failure`` because the operator does
+        not need to follow up: the PR is already merged, just not
+        by us.  Tracked separately so the final summary can show
+        a non-zero ⏭️ Skipped count alongside Merged / Failed.
+        """
+        self.prs_skipped += 1
+        if self.total_prs > 0:
+            self.completed_prs += 1
+        self._refresh_display()
+
     def increment_closed(self) -> None:
         """Record a successful close."""
         self.prs_closed += 1
@@ -436,9 +448,7 @@ class MergeProgressTracker(ProgressTracker):
         # Resolve label and icon — use custom values when provided,
         # otherwise fall back to the default close/merge text.
         default_label = (
-            "Closing PRs"
-            if self.is_close_operation
-            else "Searching for similar PRs"
+            "Closing PRs" if self.is_close_operation else "Searching for similar PRs"
         )
         label = self._custom_label or default_label
 
@@ -489,6 +499,8 @@ class MergeProgressTracker(ProgressTracker):
             stats_parts.append(f"🚪 Closed: {self.prs_closed}")
         if self.prs_failed > 0:
             stats_parts.append(f"❌ Failed: {self.prs_failed}")
+        if self.prs_skipped > 0:
+            stats_parts.append(f"⏭️  Skipped: {self.prs_skipped}")
 
         if stats_parts:
             text.append(f"\n   📊 {' | '.join(stats_parts)}", style="dim")
@@ -512,9 +524,7 @@ class MergeProgressTracker(ProgressTracker):
 
         # Elapsed time
         elapsed = datetime.now() - self.start_time
-        text.append(
-            f"\n   ⏱️  Elapsed: {self._format_duration(elapsed)}", style="dim"
-        )
+        text.append(f"\n   ⏱️  Elapsed: {self._format_duration(elapsed)}", style="dim")
 
         return text
 
@@ -526,6 +536,7 @@ class MergeProgressTracker(ProgressTracker):
                 "similar_prs_found": self.similar_prs_found,
                 "prs_merged": self.prs_merged,
                 "prs_failed": self.prs_failed,
+                "prs_skipped": self.prs_skipped,
                 "prs_closed": self.prs_closed,
                 "total_prs": self.total_prs,
                 "completed_prs": self.completed_prs,
@@ -562,6 +573,7 @@ class DummyProgressTracker(ProgressTracker):
         self.similar_prs_found = 0
         self.prs_merged = 0
         self.prs_failed = 0
+        self.prs_skipped = 0
         self.prs_closed = 0
         self.is_close_operation = False
         self._custom_label: str | None = None
@@ -612,6 +624,9 @@ class DummyProgressTracker(ProgressTracker):
         pass
 
     def merge_failure(self) -> None:
+        pass
+
+    def merge_skipped(self) -> None:
         pass
 
     def _refresh_display(self) -> None:

--- a/src/dependamerge/rebase.py
+++ b/src/dependamerge/rebase.py
@@ -300,6 +300,36 @@ async def local_rebase_pr(
         head_clone_url = f"https://github.com/{head_full}.git"
     if not base_clone_url:
         base_clone_url = f"https://github.com/{base_full}.git"
+
+    # Decide whether the PR is from a fork *before* we collapse
+    # ``head_full`` to ``base_full`` for clone-URL fallback.
+    # Treating fork PRs as non-fork would cause us to fetch the
+    # base branch from ``origin`` (the fork) instead of
+    # ``upstream`` (the canonical base repo) — either failing
+    # to fetch (the fork doesn't have the latest base commits)
+    # or, worse, fetching stale state and pushing back to the
+    # wrong remote.
+    #
+    # Preference order, all defensive:
+    #   1. The explicit ``pr_info.is_fork`` flag from the API.
+    #   2. Direct comparison of head/base full_names.
+    #   3. Direct comparison of head/base clone URLs.
+    if pr_info.is_fork is not None:
+        is_fork = bool(pr_info.is_fork)
+    elif head_full and base_full and head_full != base_full:
+        is_fork = True
+    elif (
+        head_clone_url
+        and base_clone_url
+        and head_clone_url != base_clone_url
+    ):
+        is_fork = True
+    else:
+        is_fork = False
+
+    # Now safe to collapse ``head_full`` for the clone-URL
+    # synthesis fallback. ``is_fork`` has already been computed
+    # above and won't be misled by this assignment.
     head_full = head_full or base_full
 
     head_branch = pr_info.head_branch
@@ -350,7 +380,7 @@ async def local_rebase_pr(
         # from a fork, from origin otherwise. We need it
         # available locally before we can rebase onto it.
         try:
-            if (head_full or base_full) != base_full:
+            if is_fork:
                 add_remote("upstream", upstream_url, cwd=workspace, logger=log.debug)
                 fetch(
                     "upstream",
@@ -400,9 +430,22 @@ async def local_rebase_pr(
         )
 
         if rebase_result.returncode != 0:
+            # Shallow clones (depth=50) can miss the merge base
+            # for PRs whose branch point is older than 50 commits.
+            # ``git rebase`` reports this as a generic non-zero
+            # exit; the diagnostic is visible in stderr but we
+            # can't reliably distinguish it without parsing
+            # locale-dependent text.
+            #
+            # Recovery: abort the failed rebase, unshallow both
+            # remotes, and retry the rebase. If that also fails,
+            # the cause is genuine (conflicts, corrupt index,
+            # etc.) and we return False as before so the caller
+            # falls through to the auto-merge path.
             log.debug(
                 "Local rebase: rebase exited non-zero for %s "
-                "(rc=%d, stderr=%r, stdout=%r); aborting.",
+                "(rc=%d, stderr=%r, stdout=%r); attempting "
+                "unshallow + retry.",
                 pr_info.html_url,
                 rebase_result.returncode,
                 rebase_result.stderr,
@@ -412,7 +455,53 @@ async def local_rebase_pr(
                 rebase_abort(cwd=workspace, logger=log.debug)
             except Exception:
                 pass
-            return False
+
+            try:
+                fetch(
+                    "origin",
+                    cwd=workspace,
+                    unshallow=True,
+                    logger=log.debug,
+                )
+                if is_fork:
+                    fetch(
+                        "upstream",
+                        cwd=workspace,
+                        unshallow=True,
+                        logger=log.debug,
+                    )
+            except GitError as exc:
+                log.debug(
+                    "Local rebase: unshallow failed for %s: %s",
+                    pr_info.html_url,
+                    exc,
+                )
+                return False
+
+            rebase_result = rebase(
+                rebase_onto,
+                cwd=workspace,
+                autostash=False,
+                interactive=False,
+                logger=log.debug,
+            )
+            if rebase_result.returncode != 0:
+                log.debug(
+                    "Local rebase: rebase still failing after unshallow "
+                    "for %s (rc=%d, stderr=%r); aborting.",
+                    pr_info.html_url,
+                    rebase_result.returncode,
+                    rebase_result.stderr,
+                )
+                try:
+                    rebase_abort(cwd=workspace, logger=log.debug)
+                except Exception:
+                    pass
+                return False
+            log.debug(
+                "Local rebase: succeeded after unshallow for %s",
+                pr_info.html_url,
+            )
 
         # Force-push with lease to the head repo. We push back to
         # ``origin`` because the head ref always lives there (even

--- a/src/dependamerge/rebase.py
+++ b/src/dependamerge/rebase.py
@@ -1,0 +1,788 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 The Linux Foundation
+"""Rebase strategies for behind pull requests.
+
+This module centralises every code path dependamerge uses to bring
+a PR up to date with its base branch before merging:
+
+- :func:`should_use_local_rebase` decides between the local-git
+  workflow (preserves verified commit signatures via the user's
+  ``~/.gitconfig``) and the GitHub REST ``update-branch``
+  endpoint (fast but produces unsigned commits).
+- :func:`local_rebase_pr` runs the local clone + rebase +
+  force-push-with-lease against a secure temp workspace.
+- :func:`rest_rebase_and_poll` runs the REST ``update-branch``
+  call followed by the post-rebase polling loop that waits for
+  GitHub to recompute mergeability.
+- :func:`perform_step5_rebase` is the top-level dispatcher used by
+  :class:`AsyncMergeManager._merge_single_pr` Step 5.
+- :func:`authed_clone_url` injects a token into an HTTPS clone URL
+  for non-interactive ``git clone`` auth.
+
+The dispatcher takes a :class:`RebaseContext` rather than a full
+``AsyncMergeManager`` reference, which keeps the rebase logic
+testable in isolation (no need to construct a manager + GitHub
+client + progress tracker just to exercise a decision tree).
+
+The local-rebase path is the headline reason this module exists:
+``PUT /repos/{owner}/{repo}/pulls/{n}/update-branch`` creates a
+server-side merge commit whose committer is the calling token's
+GitHub user, which is *not* signed with the user's local SSH/GPG
+key.  On repos whose branch protection requires verified
+signatures, the resulting commit loses its ``Verified`` badge and
+becomes un-mergeable.  ``pre-commit-ci[bot]`` PRs are particularly
+affected because that bot has no comment macro for recreating a PR
+with a re-signed commit (https://github.com/pre-commit-ci/issues/issues/41).
+The local path solves this by shelling out to ``git`` so the
+user's signing config is honoured.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from rich.console import Console
+
+from . import git_ops
+from .git_ops import (
+    GitError,
+    add_remote,
+    checkout,
+    clone,
+    ensure_git_available,
+    fetch,
+    push_force_with_lease,
+    rebase,
+    rebase_abort,
+    secure_rmtree,
+)
+from .models import PullRequestInfo
+from .output_utils import log_and_print
+
+if TYPE_CHECKING:
+    from .github_async import GitHubAsync
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class RebaseContext:
+    """Bundle of dependencies the rebase orchestrator needs.
+
+    Passed in lieu of a full ``AsyncMergeManager`` reference so the
+    rebase logic stays decoupled from manager internals and can be
+    tested without standing up the whole merge pipeline.
+    """
+
+    github_client: GitHubAsync | None
+    token: str
+    rebase_local: bool
+    fix_out_of_date: bool
+    preview_mode: bool
+    merge_recheck_interval: float
+    merge_poll_max_attempts: int
+    log: logging.Logger
+    console: Console
+    # Mutable set on the manager that records PR keys (``owner/repo#N``)
+    # which have already been through Step 5.  Step 5.5 consults this
+    # to avoid doubling the configured ``merge_timeout``.  We keep the
+    # raw set reference rather than a callback so the existing
+    # invariant (Step 5 always adds, Step 5.5 always reads) stays
+    # obvious at the call site.
+    rebased_prs: set[str]
+    # Async callable equivalent to ``manager._enable_auto_merge_for_pr``.
+    # Passed in to avoid a circular import.
+    enable_auto_merge: Callable[[PullRequestInfo, str, str], Awaitable[bool]]
+
+
+@dataclass
+class Step5Outcome:
+    """Result of :func:`perform_step5_rebase`.
+
+    ``failed`` indicates the caller should mark the PR as ``FAILED``
+    and bail out of the merge attempt.  ``error_message`` is the
+    user-visible reason in that case.
+    """
+
+    failed: bool = False
+    error_message: str | None = None
+
+
+def authed_clone_url(clone_url: str, token: str) -> str:
+    """Return an HTTPS clone URL with the token injected for auth.
+
+    The token never appears in command-line arguments — it goes
+    through the standard ``git clone`` machinery, which redacts it
+    from log output via :func:`git_ops._redact`.  Non-HTTPS URLs
+    (SSH, ``git://``) are returned unchanged.
+    """
+    if clone_url.startswith("https://"):
+        return clone_url.replace("https://", f"https://x-access-token:{token}@")
+    return clone_url
+
+
+async def should_use_local_rebase(
+    *,
+    github_client: GitHubAsync | None,
+    pr_info: PullRequestInfo,
+    owner: str,
+    repo: str,
+    base_branch: str,
+    rebase_local: bool,
+    log: logging.Logger,
+) -> tuple[bool, str]:
+    """Decide whether Step 5 should rebase locally instead of via REST.
+
+    Returns ``(use_local, reason)``.  ``reason`` is a short
+    human-readable string suitable for debug logging or a
+    user-visible note when ``use_local`` is True.
+
+    The gate activates when ``rebase_local`` is True AND either:
+
+    - the PR is from ``pre-commit-ci[bot]`` (always — that bot has
+      no comment macro for recreating a PR with a re-signed
+      commit), OR
+    - the base branch requires verified signatures AND the current
+      PR head commit is itself verified (so REST update-branch
+      *would* break verification).
+
+    Strict ``is True`` comparison is used on the
+    ``requires_commit_signatures`` return so ``AsyncMock`` defaults
+    don't accidentally route real PRs into the local-rebase path
+    in tests that haven't explicitly set ``return_value``.  If the
+    requirement check raises, we fail safely to the REST path.
+    """
+    if not rebase_local:
+        return False, "--no-rebase-local set"
+
+    # Always use local rebase for pre-commit.ci PRs. The bot has
+    # no comment macro to recover from a verification break, so
+    # we treat it as opt-in regardless of branch protection.
+    if pr_info.author == "pre-commit-ci[bot]":
+        return True, "pre-commit-ci[bot] has no recreate/rebase macro"
+
+    if github_client is None:
+        return False, "no GitHub client"
+
+    # Branch-protection signature requirement (classic + rulesets)
+    try:
+        requires_signatures = await github_client.requires_commit_signatures(
+            owner, repo, base_branch
+        )
+    except Exception as exc:
+        log.debug(
+            "Could not determine signature requirement for %s/%s:%s: %s",
+            owner,
+            repo,
+            base_branch,
+            exc,
+        )
+        return False, "signature requirement check failed"
+
+    # Strict ``is True`` rather than truthy check: ``AsyncMock``
+    # default returns evaluate as truthy, and we explicitly do
+    # not want to enter the network-touching local-rebase path
+    # in test mocks that haven't been set up to handle it.
+    if requires_signatures is not True:
+        return False, "base branch does not require signatures"
+
+    # Base does require verified signatures. Check whether the
+    # current PR head is itself verified — if it isn't, REST
+    # update-branch can't make things worse, so we don't need
+    # the local-rebase machinery.
+    try:
+        all_verified, _unverified = await github_client.check_pr_commit_signatures(
+            owner, repo, pr_info.number
+        )
+    except Exception as exc:
+        log.debug(
+            "Could not check PR commit signatures for %s/%s#%s: %s",
+            owner,
+            repo,
+            pr_info.number,
+            exc,
+        )
+        # Conservative: if we can't tell, prefer the local path
+        # (worst case: minor extra work; best case: preserve a
+        # signature we couldn't see).
+        return True, "signature check failed; preferring local path"
+
+    if all_verified:
+        return True, "base requires signatures and PR head is verified"
+    return False, "PR head is not currently verified"
+
+
+async def local_rebase_pr(
+    *,
+    pr_info: PullRequestInfo,
+    owner: str,
+    repo: str,
+    token: str,
+    log: logging.Logger,
+) -> bool:
+    """Rebase a PR locally and force-push the result.
+
+    Clones the head repo into a secure temp workspace, fetches the
+    base branch (from upstream when the PR is from a fork), runs
+    ``git rebase``, and force-pushes with lease back to the head
+    repo.  All git invocations inherit the user's ``~/.gitconfig``,
+    so signing config is respected.
+
+    Returns True only if every step succeeds.  On any failure (no
+    ``git`` on PATH, conflict during rebase, network error, push
+    rejected) the workspace is cleaned up and False is returned;
+    the caller should fall through to the auto-merge path so we
+    never leave a half-applied state.
+    """
+    # Ensure ``git`` is on PATH before we start. ``GitError`` is
+    # also raised when git is missing entirely.
+    try:
+        ensure_git_available()
+    except Exception as exc:
+        log.debug("Local rebase unavailable (no git on PATH?): %s", exc)
+        return False
+
+    # We need the head/base clone URLs. They are populated for PRs
+    # surfaced by recent versions of the find-similar / merge flows;
+    # if missing we synthesise them from the repository names.
+    head_clone_url = pr_info.head_repo_clone_url
+    base_clone_url = pr_info.base_repo_clone_url
+    head_full = pr_info.head_repo_full_name
+    base_full = pr_info.base_repo_full_name or f"{owner}/{repo}"
+    if not head_clone_url:
+        head_clone_url = f"https://github.com/{head_full or base_full}.git"
+    if not base_clone_url:
+        base_clone_url = f"https://github.com/{base_full}.git"
+    head_full = head_full or base_full
+
+    head_branch = pr_info.head_branch
+    base_branch = pr_info.base_branch or "main"
+    if not head_branch:
+        log.debug(
+            "Local rebase: PR %s/%s#%s missing head_branch",
+            owner,
+            repo,
+            pr_info.number,
+        )
+        return False
+
+    origin_url = authed_clone_url(head_clone_url, token)
+    upstream_url = authed_clone_url(base_clone_url, token)
+
+    # Use a per-PR workspace under a secure temp parent so
+    # concurrent rebases (--concurrency=N) don't collide.
+    workspace_parent = Path(
+        git_ops.create_secure_tempdir(prefix="dependamerge-localrebase-")
+    )
+    workspace = (
+        workspace_parent
+        / f"{(head_full or base_full).replace('/', '__')}__pr_{pr_info.number}"
+    )
+    workspace.mkdir(parents=True, exist_ok=True)
+
+    try:
+        # Clone the head repo at the PR's head branch. Shallow
+        # clone keeps disk + network footprint low for what are
+        # typically tiny dependency-update PRs.
+        try:
+            clone(
+                origin_url,
+                workspace,
+                branch=head_branch,
+                depth=50,
+                single_branch=True,
+                no_tags=True,
+                filter_blobs=True,
+                logger=log.debug,
+            )
+        except GitError as exc:
+            log.debug("Local rebase: clone failed for %s: %s", pr_info.html_url, exc)
+            return False
+
+        # Fetch the base branch — from upstream when the PR is
+        # from a fork, from origin otherwise. We need it
+        # available locally before we can rebase onto it.
+        try:
+            if (head_full or base_full) != base_full:
+                add_remote("upstream", upstream_url, cwd=workspace, logger=log.debug)
+                fetch(
+                    "upstream",
+                    base_branch,
+                    cwd=workspace,
+                    depth=50,
+                    logger=log.debug,
+                )
+                rebase_onto = f"upstream/{base_branch}"
+            else:
+                fetch(
+                    "origin",
+                    base_branch,
+                    cwd=workspace,
+                    depth=50,
+                    logger=log.debug,
+                )
+                rebase_onto = f"origin/{base_branch}"
+        except GitError as exc:
+            log.debug("Local rebase: fetch failed for %s: %s", pr_info.html_url, exc)
+            return False
+
+        # Make sure we are on the head branch (defensive against
+        # detached HEAD after clone --branch).
+        try:
+            checkout(head_branch, cwd=workspace, create=False, logger=log.debug)
+        except GitError:
+            # Already on the branch, or branch missing locally;
+            # rebase will surface the real problem if any.
+            pass
+
+        # Rebase. ``git rebase`` here is non-interactive; if there
+        # are conflicts the command exits non-zero and leaves the
+        # working tree in conflict state, which we explicitly abort
+        # and treat as failure.
+        try:
+            rebase_result = rebase(
+                rebase_onto,
+                cwd=workspace,
+                autostash=False,
+                interactive=False,
+                logger=log.debug,
+            )
+        except GitError as exc:
+            log.debug("Local rebase: rebase failed for %s: %s", pr_info.html_url, exc)
+            return False
+
+        if rebase_result.returncode != 0:
+            log.debug(
+                "Local rebase: conflicts during rebase of %s; aborting.",
+                pr_info.html_url,
+            )
+            try:
+                rebase_abort(cwd=workspace, logger=log.debug)
+            except Exception:
+                pass
+            return False
+
+        # Force-push with lease to the head repo. We push back to
+        # ``origin`` because the head ref always lives there (even
+        # for forks, the head repo *is* the fork).
+        try:
+            push_force_with_lease(
+                "origin",
+                head_branch,
+                head_branch,
+                cwd=workspace,
+                logger=log.debug,
+            )
+        except GitError as exc:
+            log.debug(
+                "Local rebase: force-push failed for %s: %s",
+                pr_info.html_url,
+                exc,
+            )
+            return False
+
+        log.debug("Local rebase succeeded for %s", pr_info.html_url)
+        return True
+
+    finally:
+        # Always clean up. The workspace contains a clone of the
+        # user's repository, so we want it gone even on success.
+        try:
+            secure_rmtree(workspace_parent)
+        except Exception as exc:
+            log.debug(
+                "Local rebase: failed to clean up workspace %s: %s",
+                workspace_parent,
+                exc,
+            )
+
+
+async def perform_step5_rebase(
+    *,
+    ctx: RebaseContext,
+    pr_info: PullRequestInfo,
+    owner: str,
+    repo: str,
+) -> Step5Outcome:
+    """Run Step 5 of the merge flow: bring the PR up to date with its base.
+
+    Dispatches between the local-git path (signature-preserving)
+    and the legacy REST ``update-branch`` path based on
+    :func:`should_use_local_rebase`.  When the local path is
+    selected, REST ``update-branch`` is **never** called — even on
+    local-rebase failure — so we never destroy a verified
+    signature.  In the failure case we mark the PR as having been
+    through Step 5 (so Step 5.5 doesn't double the configured
+    ``merge_timeout``) and let auto-merge take over server-side.
+
+    Returns a :class:`Step5Outcome`.  ``failed=True`` indicates the
+    caller should set ``MergeStatus.FAILED`` and bail; the legacy
+    REST path is the only path that can produce this outcome (a
+    raised exception during ``update_branch`` or the polling loop).
+    """
+    if ctx.preview_mode:
+        # NOTE: In preview mode, we should NOT print here as it
+        # breaks single-line reporting.  The preview output
+        # should only be a single line per PR in the evaluation
+        # section.
+        return Step5Outcome()
+
+    log_and_print(
+        ctx.log,
+        ctx.console,
+        f"🔄 Rebasing: {pr_info.html_url} [behind base branch]",
+        level="debug",
+    )
+
+    use_local, local_reason = await should_use_local_rebase(
+        github_client=ctx.github_client,
+        pr_info=pr_info,
+        owner=owner,
+        repo=repo,
+        base_branch=pr_info.base_branch or "main",
+        rebase_local=ctx.rebase_local,
+        log=ctx.log,
+    )
+
+    if use_local:
+        await _run_local_path(
+            ctx=ctx,
+            pr_info=pr_info,
+            owner=owner,
+            repo=repo,
+            local_reason=local_reason,
+        )
+        return Step5Outcome()
+
+    return await _run_rest_path(
+        ctx=ctx,
+        pr_info=pr_info,
+        owner=owner,
+        repo=repo,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+async def _run_local_path(
+    *,
+    ctx: RebaseContext,
+    pr_info: PullRequestInfo,
+    owner: str,
+    repo: str,
+    local_reason: str,
+) -> None:
+    """Local-rebase path.  Always succeeds from the caller's POV.
+
+    Whether the underlying ``git`` workflow succeeds or fails, we
+    record the PR in ``_rebased_prs`` so Step 5.5 doesn't double
+    the merge_timeout, and we never fall back to REST
+    ``update-branch`` (doing so would defeat the whole point of
+    the local path).
+    """
+    log_and_print(
+        ctx.log,
+        ctx.console,
+        f"🛡️  Local rebase: {pr_info.html_url} [{local_reason}]",
+        level="debug",
+    )
+    try:
+        local_rebase_ok = await local_rebase_pr(
+            pr_info=pr_info,
+            owner=owner,
+            repo=repo,
+            token=ctx.token,
+            log=ctx.log,
+        )
+    except Exception as exc:
+        ctx.log.debug(
+            "Local rebase raised unexpectedly for %s: %s",
+            pr_info.html_url,
+            exc,
+        )
+        local_rebase_ok = False
+
+    ctx.rebased_prs.add(f"{owner}/{repo}#{pr_info.number}")
+    if local_rebase_ok:
+        log_and_print(
+            ctx.log,
+            ctx.console,
+            f"✅ Rebased (local): {pr_info.html_url}",
+            level="debug",
+        )
+    else:
+        log_and_print(
+            ctx.log,
+            ctx.console,
+            f"🛡️  Local rebase failed; deferring to auto-merge: {pr_info.html_url}",
+            level="debug",
+        )
+
+
+async def _run_rest_path(
+    *,
+    ctx: RebaseContext,
+    pr_info: PullRequestInfo,
+    owner: str,
+    repo: str,
+) -> Step5Outcome:
+    """Legacy REST ``update-branch`` path with post-rebase polling.
+
+    Uses the GitHub REST API to bring the PR up to date, enables
+    auto-merge so the PR merges even if we time out waiting for
+    status checks, then polls until checks complete or
+    ``merge_timeout`` elapses.  Updates ``pr_info`` in place with
+    the post-rebase state.
+
+    Returns a :class:`Step5Outcome` whose ``failed`` field is True
+    when ``update_branch`` (or the polling apparatus) raises an
+    exception — the caller should mark the merge as ``FAILED`` in
+    that case.
+    """
+    if ctx.github_client is None:
+        return Step5Outcome(failed=True, error_message="GitHub client not initialized")
+    client = ctx.github_client
+
+    try:
+        await client.update_branch(owner, repo, pr_info.number)
+
+        # Enable auto-merge so the PR merges even if we time out
+        # waiting for status checks.
+        auto_merge_ok = await ctx.enable_auto_merge(pr_info, owner, repo)
+        if auto_merge_ok:
+            ctx.log.debug(
+                "Auto-merge enabled after rebase for %s/%s#%s",
+                owner,
+                repo,
+                pr_info.number,
+            )
+
+        # Wait for GitHub to process the update and run checks
+        ctx.console.print(f"⏳ Waiting: {pr_info.html_url}")
+        await asyncio.sleep(ctx.merge_recheck_interval)
+
+        updated_mergeable, updated_mergeable_state = await _poll_post_rebase(
+            ctx=ctx,
+            pr_info=pr_info,
+            owner=owner,
+            repo=repo,
+            auto_merge_ok=auto_merge_ok,
+        )
+
+        # Update our PR info with the latest state.  Preserve the
+        # previous non-None values when the refresh returns
+        # ``null`` (GitHub is still computing).  The Step 6
+        # auto-merge skip gate accepts both ``True`` and ``None``
+        # (it excludes only the explicit ``False`` case), so a
+        # transient null no longer blocks the auto-merge path on
+        # its own.  We still preserve the prior known ``True`` so
+        # downstream logging and any future tightening of that
+        # predicate get an accurate state to work with.  The same
+        # rationale applies to ``mergeable_state``: GitHub returns
+        # ``null`` while still computing, and the post-rebase
+        # reporting / Step 5.5 logic branches on this value (e.g.
+        # "clean" vs "blocked" vs "behind"); a transient ``None``
+        # would otherwise be classified as the catch-all "other
+        # state" branch.
+        if updated_mergeable is not None:
+            pr_info.mergeable = updated_mergeable
+        if updated_mergeable_state is not None:
+            pr_info.mergeable_state = updated_mergeable_state
+
+        # Mark this PR as having gone through the Step 5 rebase
+        # + poll path.  Step 5.5 will consult ``_rebased_prs`` to
+        # avoid doubling the merge_timeout when the rebase exits
+        # in ``blocked`` or ``behind`` state.
+        ctx.rebased_prs.add(f"{owner}/{repo}#{pr_info.number}")
+
+        _log_post_rebase_status(ctx=ctx, pr_info=pr_info)
+        return Step5Outcome()
+
+    except Exception as exc:
+        ctx.console.print(f"❌ Failed: {pr_info.html_url} [rebase error: {exc}]")
+        return Step5Outcome(failed=True, error_message=f"Failed to rebase PR: {exc}")
+
+
+async def _poll_post_rebase(
+    *,
+    ctx: RebaseContext,
+    pr_info: PullRequestInfo,
+    owner: str,
+    repo: str,
+    auto_merge_ok: bool,
+) -> tuple[bool | None, str | None]:
+    """Poll the PR after ``update_branch`` until it stabilises.
+
+    Returns the latest ``(mergeable, mergeable_state)`` observed.
+    Updates ``pr_info.head_sha`` in place when the refresh shows a
+    new head commit (so any subsequent ``analyze_block_reason()``
+    call queries the rebased commit, not the pre-rebase one).
+    """
+    if ctx.github_client is None:
+        return pr_info.mergeable, pr_info.mergeable_state
+    client = ctx.github_client
+
+    updated_mergeable: bool | None = pr_info.mergeable
+    updated_mergeable_state: str | None = pr_info.mergeable_state
+
+    for check_attempt in range(ctx.merge_poll_max_attempts):
+        updated_pr_data: Any = await client.get(
+            f"/repos/{owner}/{repo}/pulls/{pr_info.number}"
+        )
+
+        if isinstance(updated_pr_data, dict):
+            updated_mergeable = updated_pr_data.get("mergeable")
+            updated_mergeable_state = updated_pr_data.get("mergeable_state")
+            updated_head = (updated_pr_data.get("head") or {}).get("sha")
+            if updated_head:
+                pr_info.head_sha = updated_head
+        else:
+            updated_mergeable = None
+            updated_mergeable_state = None
+
+        if _poll_should_continue(
+            ctx=ctx,
+            pr_info=pr_info,
+            attempt=check_attempt,
+            mergeable_state=updated_mergeable_state,
+            auto_merge_ok=auto_merge_ok,
+        ):
+            await asyncio.sleep(ctx.merge_recheck_interval)
+            continue
+        break
+
+    return updated_mergeable, updated_mergeable_state
+
+
+def _poll_should_continue(
+    *,
+    ctx: RebaseContext,
+    pr_info: PullRequestInfo,
+    attempt: int,
+    mergeable_state: str | None,
+    auto_merge_ok: bool,
+) -> bool:
+    """Return True when the post-rebase poll loop should keep waiting.
+
+    Centralising the per-state decisions here keeps
+    :func:`_poll_post_rebase` short and readable.
+    """
+    if mergeable_state == "clean":
+        return False
+
+    last_attempt = attempt >= ctx.merge_poll_max_attempts - 1
+
+    if mergeable_state == "behind":
+        if last_attempt:
+            return False
+        ctx.log.debug(
+            "PR still processing rebase, waiting... (attempt %d/%d)",
+            attempt + 1,
+            ctx.merge_poll_max_attempts,
+        )
+        return True
+
+    if mergeable_state == "blocked":
+        if last_attempt:
+            _log_blocked_timeout(ctx=ctx, pr_info=pr_info, auto_merge_ok=auto_merge_ok)
+            return False
+        ctx.log.debug(
+            "PR status checks running after rebase, waiting... (attempt %d/%d)",
+            attempt + 1,
+            ctx.merge_poll_max_attempts,
+        )
+        return True
+
+    if mergeable_state is None:
+        # GitHub is still computing mergeability (typically right
+        # after update_branch).  Treat as transient and keep
+        # polling until the deadline or a concrete state arrives —
+        # breaking here would otherwise exit prematurely and (if
+        # auto-merge enablement failed) fall through to a manual
+        # merge attempt against the still-resolving PR state.
+        if last_attempt:
+            return False
+        ctx.log.debug(
+            "PR mergeable_state still computing after rebase, "
+            "waiting... (attempt %d/%d)",
+            attempt + 1,
+            ctx.merge_poll_max_attempts,
+        )
+        return True
+
+    # Any other concrete state ("dirty", "draft", "unstable",
+    # "unknown", ...) ends the poll loop immediately.
+    return False
+
+
+def _log_blocked_timeout(
+    *,
+    ctx: RebaseContext,
+    pr_info: PullRequestInfo,
+    auto_merge_ok: bool,
+) -> None:
+    """Emit the user-facing line when the post-rebase poll times out blocked."""
+    if auto_merge_ok:
+        log_and_print(
+            ctx.log,
+            ctx.console,
+            f"⏳ Auto-merge will complete: {pr_info.html_url} "
+            "[timeout waiting for checks]",
+            level="warning",
+        )
+    else:
+        log_and_print(
+            ctx.log,
+            ctx.console,
+            f"⚠️ Proceeding without checks: {pr_info.html_url} "
+            "[timeout waiting for checks]",
+            level="warning",
+        )
+
+
+def _log_post_rebase_status(
+    *,
+    ctx: RebaseContext,
+    pr_info: PullRequestInfo,
+) -> None:
+    """Emit the post-rebase status line based on the final mergeable_state."""
+    state = pr_info.mergeable_state
+    if state == "clean":
+        log_and_print(
+            ctx.log,
+            ctx.console,
+            f"✅ Rebased: {pr_info.html_url}",
+            level="debug",
+        )
+    elif state == "behind":
+        log_and_print(
+            ctx.log,
+            ctx.console,
+            f"⚠️  Rebased: {pr_info.html_url} [still behind after rebase]",
+            level="debug",
+        )
+    elif state == "blocked":
+        log_and_print(
+            ctx.log,
+            ctx.console,
+            f"⬆️ Rebased: {pr_info.html_url} [waiting for status checks]",
+            level="debug",
+        )
+    else:
+        log_and_print(
+            ctx.log,
+            ctx.console,
+            f"ℹ️  Rebased: {pr_info.html_url}",
+            level="debug",
+        )

--- a/src/dependamerge/rebase.py
+++ b/src/dependamerge/rebase.py
@@ -507,19 +507,22 @@ async def _run_local_path(
     """Local-rebase path.  Always succeeds from the caller's POV.
 
     Whether the underlying ``git`` workflow succeeds or fails, we
-    record the PR in ``_rebased_prs`` so Step 5.5 doesn't double
-    the merge_timeout, and we never fall back to REST
-    ``update-branch`` (doing so would defeat the whole point of
-    the local path).
+    never fall back to REST ``update-branch`` (doing so would
+    defeat the whole point of the local path).
 
-    We also enable auto-merge here — not in Step 5.5 — because
-    marking ``_rebased_prs`` makes Step 5.5 skip this PR, and
-    without auto-merge enablement Step 6's skip gate wouldn't
-    fire either (it only routes to ``AUTO_MERGE_PENDING`` when
-    the PR is in ``_auto_merge_enabled``).  Without that, a still-
-    pending PR would fall through to a manual merge attempt and
-    405 against unfinished checks — the failure mode this whole
-    feature exists to prevent.
+    Auto-merge enablement and ``_rebased_prs`` marking are linked:
+
+    - If auto-merge gets enabled, mark ``_rebased_prs`` so Step
+      5.5 skips this PR; auto-merge will handle the bounded wait
+      server-side and Step 6's skip gate routes to
+      ``AUTO_MERGE_PENDING``.
+    - If auto-merge cannot be enabled (repo doesn't allow it,
+      branch protection blocks it, etc.), do **not** mark
+      ``_rebased_prs`` so Step 5.5 still runs its bounded poll
+      loop. Without this, GitHub may still be recomputing
+      mergeability after the force-push when Step 6 fires and a
+      manual merge attempt would 405 transiently. Letting Step
+      5.5 wait gives GitHub time to settle before Step 6 acts.
     """
     log_and_print(
         ctx.log,
@@ -543,26 +546,29 @@ async def _run_local_path(
         )
         local_rebase_ok = False
 
-    ctx.rebased_prs.add(f"{owner}/{repo}#{pr_info.number}")
-
-    # Enable auto-merge regardless of local-rebase outcome.
-    # On success: GitHub may need a few seconds to recompute
-    # mergeability and start checks against the new head;
-    # auto-merge will fire when checks pass.
-    # On failure: the PR is unchanged on the GitHub side; auto-
-    # merge will fire when the PR is brought up to date through
-    # some other channel (a third-party rebase, a human update).
-    # In both cases, having auto-merge enabled means Step 6's
-    # skip gate routes the PR to ``AUTO_MERGE_PENDING`` rather
-    # than attempting a 405-prone manual merge.
+    # Try to enable auto-merge. We capture the return value so we
+    # can decide whether Step 5.5 should also run (see comment
+    # below).
     try:
-        await ctx.enable_auto_merge(pr_info, owner, repo)
+        auto_merge_ok = await ctx.enable_auto_merge(pr_info, owner, repo)
     except Exception as exc:
         ctx.log.debug(
             "Could not enable auto-merge after local rebase for %s: %s",
             pr_info.html_url,
             exc,
         )
+        auto_merge_ok = False
+
+    # Only mark ``_rebased_prs`` when auto-merge is active.
+    # Otherwise leave it unset so Step 5.5 still runs its bounded
+    # poll loop — GitHub may still be recomputing mergeability
+    # after the force-push, and a manual merge attempt in Step 6
+    # without that wait would 405 transiently.  When auto-merge
+    # *is* active, Step 6's skip gate routes the PR to
+    # ``AUTO_MERGE_PENDING`` directly, so the Step 5.5 wait would
+    # only double the merge_timeout.
+    if auto_merge_ok:
+        ctx.rebased_prs.add(f"{owner}/{repo}#{pr_info.number}")
 
     if local_rebase_ok:
         log_and_print(
@@ -578,6 +584,7 @@ async def _run_local_path(
             f"🛡️  Local rebase failed; deferring to auto-merge: {pr_info.html_url}",
             level="debug",
         )
+
 
 
 async def _run_rest_path(

--- a/src/dependamerge/rebase.py
+++ b/src/dependamerge/rebase.py
@@ -85,7 +85,6 @@ class RebaseContext:
     github_client: GitHubAsync | None
     token: str
     rebase_local: bool
-    fix_out_of_date: bool
     preview_mode: bool
     merge_recheck_interval: float
     merge_poll_max_attempts: int
@@ -357,26 +356,31 @@ async def local_rebase_pr(
             # rebase will surface the real problem if any.
             pass
 
-        # Rebase. ``git rebase`` here is non-interactive; if there
-        # are conflicts the command exits non-zero and leaves the
-        # working tree in conflict state, which we explicitly abort
-        # and treat as failure.
-        try:
-            rebase_result = rebase(
-                rebase_onto,
-                cwd=workspace,
-                autostash=False,
-                interactive=False,
-                logger=log.debug,
-            )
-        except GitError as exc:
-            log.debug("Local rebase: rebase failed for %s: %s", pr_info.html_url, exc)
-            return False
+        # Rebase. ``git rebase`` runs with ``check=False`` (see
+        # ``git_ops.rebase``), so a non-zero exit does *not* raise
+        # ``GitError``; we have to inspect ``returncode``
+        # ourselves. Conflicts are the most common cause of a
+        # non-zero exit here, but other failures (corrupt index,
+        # invalid base ref, etc.) hit the same path — surface
+        # stderr/stdout in debug output so the cause is visible
+        # to anyone investigating, then abort the rebase to leave
+        # the workspace in a clean state before cleanup.
+        rebase_result = rebase(
+            rebase_onto,
+            cwd=workspace,
+            autostash=False,
+            interactive=False,
+            logger=log.debug,
+        )
 
         if rebase_result.returncode != 0:
             log.debug(
-                "Local rebase: conflicts during rebase of %s; aborting.",
+                "Local rebase: rebase exited non-zero for %s "
+                "(rc=%d, stderr=%r, stdout=%r); aborting.",
                 pr_info.html_url,
+                rebase_result.returncode,
+                rebase_result.stderr,
+                rebase_result.stdout,
             )
             try:
                 rebase_abort(cwd=workspace, logger=log.debug)

--- a/src/dependamerge/rebase.py
+++ b/src/dependamerge/rebase.py
@@ -11,11 +11,14 @@ a PR up to date with its base branch before merging:
   endpoint (fast but produces unsigned commits).
 - :func:`local_rebase_pr` runs the local clone + rebase +
   force-push-with-lease against a secure temp workspace.
-- :func:`rest_rebase_and_poll` runs the REST ``update-branch``
-  call followed by the post-rebase polling loop that waits for
-  GitHub to recompute mergeability.
 - :func:`perform_step5_rebase` is the top-level dispatcher used by
-  :class:`AsyncMergeManager._merge_single_pr` Step 5.
+  :class:`AsyncMergeManager._merge_single_pr` Step 5.  It calls
+  :func:`should_use_local_rebase` to decide between paths, then
+  delegates to either ``_run_local_path`` or ``_run_rest_path``
+  (private helpers).  ``_run_rest_path`` runs the REST
+  ``update-branch`` call and the post-rebase polling loop
+  (``_poll_post_rebase``) that waits for GitHub to recompute
+  mergeability.
 - :func:`authed_clone_url` injects a token into an HTTPS clone URL
   for non-interactive ``git clone`` auth.
 

--- a/src/dependamerge/rebase.py
+++ b/src/dependamerge/rebase.py
@@ -119,10 +119,18 @@ class Step5Outcome:
 def authed_clone_url(clone_url: str, token: str) -> str:
     """Return an HTTPS clone URL with the token injected for auth.
 
-    The token never appears in command-line arguments — it goes
-    through the standard ``git clone`` machinery, which redacts it
-    from log output via :func:`git_ops._redact`.  Non-HTTPS URLs
-    (SSH, ``git://``) are returned unchanged.
+    The token *is* passed to ``git`` as part of the URL command-
+    line argument, which means it can be visible to process-
+    listing tools (``ps``, ``/proc/<pid>/cmdline``) on the local
+    machine for the duration of the git invocation. Log output is
+    separately redacted by :func:`git_ops._redact`, but no
+    equivalent protection exists for ``ps``-style introspection.
+    Callers needing stronger guarantees should use a different
+    auth mechanism (e.g. SSH keys or a credential helper) and
+    pass an unmodified ``ssh://`` / ``git@`` URL through
+    unchanged.
+
+    Non-HTTPS URLs (SSH, ``git://``) are returned unchanged.
     """
     if clone_url.startswith("https://"):
         return clone_url.replace("https://", f"https://x-access-token:{token}@")
@@ -210,10 +218,16 @@ async def should_use_local_rebase(
             pr_info.number,
             exc,
         )
-        # Conservative: if we can't tell, prefer the local path
-        # (worst case: minor extra work; best case: preserve a
-        # signature we couldn't see).
-        return True, "signature check failed; preferring local path"
+        # Fail closed: if we can't confirm the PR head is
+        # verified, route to the REST path. The opposite
+        # (assuming verification and using the local path)
+        # would mean transient API failures could trigger
+        # network-touching local clones, and would conflict
+        # with the documented gate ("base requires signatures
+        # AND PR head is verified"). When verification isn't
+        # established, REST update-branch can't make things
+        # any worse than they already are.
+        return False, "signature check failed"
 
     if all_verified:
         return True, "base requires signatures and PR head is verified"
@@ -490,6 +504,15 @@ async def _run_local_path(
     the merge_timeout, and we never fall back to REST
     ``update-branch`` (doing so would defeat the whole point of
     the local path).
+
+    We also enable auto-merge here — not in Step 5.5 — because
+    marking ``_rebased_prs`` makes Step 5.5 skip this PR, and
+    without auto-merge enablement Step 6's skip gate wouldn't
+    fire either (it only routes to ``AUTO_MERGE_PENDING`` when
+    the PR is in ``_auto_merge_enabled``).  Without that, a still-
+    pending PR would fall through to a manual merge attempt and
+    405 against unfinished checks — the failure mode this whole
+    feature exists to prevent.
     """
     log_and_print(
         ctx.log,
@@ -514,6 +537,26 @@ async def _run_local_path(
         local_rebase_ok = False
 
     ctx.rebased_prs.add(f"{owner}/{repo}#{pr_info.number}")
+
+    # Enable auto-merge regardless of local-rebase outcome.
+    # On success: GitHub may need a few seconds to recompute
+    # mergeability and start checks against the new head;
+    # auto-merge will fire when checks pass.
+    # On failure: the PR is unchanged on the GitHub side; auto-
+    # merge will fire when the PR is brought up to date through
+    # some other channel (a third-party rebase, a human update).
+    # In both cases, having auto-merge enabled means Step 6's
+    # skip gate routes the PR to ``AUTO_MERGE_PENDING`` rather
+    # than attempting a 405-prone manual merge.
+    try:
+        await ctx.enable_auto_merge(pr_info, owner, repo)
+    except Exception as exc:
+        ctx.log.debug(
+            "Could not enable auto-merge after local rebase for %s: %s",
+            pr_info.html_url,
+            exc,
+        )
+
     if local_rebase_ok:
         log_and_print(
             ctx.log,

--- a/src/dependamerge/rebase.py
+++ b/src/dependamerge/rebase.py
@@ -273,8 +273,31 @@ async def local_rebase_pr(
     base_clone_url = pr_info.base_repo_clone_url
     head_full = pr_info.head_repo_full_name
     base_full = pr_info.base_repo_full_name or f"{owner}/{repo}"
+
+    # Fail closed when head repo identity is ambiguous. Without a
+    # confirmed ``head_repo_full_name`` or ``head_repo_clone_url``
+    # we cannot tell whether the PR is from a fork. Synthesising a
+    # clone URL from the base repo would push to the wrong remote
+    # for fork PRs (creating or overwriting a branch on the base
+    # repo). The caller falls through to the auto-merge path on
+    # False, which is always safe.
+    if not head_full and not head_clone_url:
+        log.debug(
+            "Local rebase: PR %s/%s#%s missing head_repo identity "
+            "(head_repo_full_name and head_repo_clone_url are both unset); "
+            "failing closed to avoid pushing to the wrong remote.",
+            owner,
+            repo,
+            pr_info.number,
+        )
+        return False
+
+    # Both fields populated, or one of them — synthesise the
+    # missing URL from the known full_name. Safe because
+    # ``head_full`` is now confirmed to refer to the head repo,
+    # not the base.
     if not head_clone_url:
-        head_clone_url = f"https://github.com/{head_full or base_full}.git"
+        head_clone_url = f"https://github.com/{head_full}.git"
     if not base_clone_url:
         base_clone_url = f"https://github.com/{base_full}.git"
     head_full = head_full or base_full

--- a/src/dependamerge/rebase.py
+++ b/src/dependamerge/rebase.py
@@ -59,6 +59,7 @@ from .git_ops import (
     clone,
     ensure_git_available,
     fetch,
+    fetch_branch,
     push_force_with_lease,
     rebase,
     rebase_abort,
@@ -379,10 +380,17 @@ async def local_rebase_pr(
         # Fetch the base branch — from upstream when the PR is
         # from a fork, from origin otherwise. We need it
         # available locally before we can rebase onto it.
+        #
+        # Use :func:`fetch_branch` rather than the bare ``fetch``
+        # form: the ``--single-branch`` clone above restricts the
+        # remote's configured refspec to the PR head branch, so a
+        # bare ``git fetch origin <base>`` would only populate
+        # ``FETCH_HEAD`` and a subsequent ``git rebase origin/<base>``
+        # would fail with ``fatal: invalid upstream 'origin/<base>'``.
         try:
             if is_fork:
                 add_remote("upstream", upstream_url, cwd=workspace, logger=log.debug)
-                fetch(
+                fetch_branch(
                     "upstream",
                     base_branch,
                     cwd=workspace,
@@ -391,7 +399,7 @@ async def local_rebase_pr(
                 )
                 rebase_onto = f"upstream/{base_branch}"
             else:
-                fetch(
+                fetch_branch(
                     "origin",
                     base_branch,
                     cwd=workspace,

--- a/src/dependamerge/resolve_conflicts.py
+++ b/src/dependamerge/resolve_conflicts.py
@@ -41,6 +41,7 @@ from .git_ops import (
     commit_amend_no_edit,
     create_secure_tempdir,
     fetch,
+    fetch_branch,
     list_conflicted_files,
     push_force_with_lease,
     rebase,
@@ -426,12 +427,26 @@ class FixOrchestrator:
         # Ensure we have base branch available for rebase
         if ctx.head_repo_full_name != ctx.base_repo_full_name:
             add_remote("upstream", upstream_url, cwd=workspace, logger=self._log)
-            fetch(
+            # Use ``fetch_branch`` so ``upstream/<base_branch>``
+            # lands as a remote-tracking ref — the ``--single-branch``
+            # clone above restricts the origin's configured refspec
+            # to the PR head branch, so a bare
+            # ``git fetch upstream <base>`` would only populate
+            # ``FETCH_HEAD`` and the downstream
+            # ``git rebase upstream/<base>`` in
+            # :meth:`InteractiveResolver.resolve` would fail with
+            # ``fatal: invalid upstream 'upstream/<base>'``.
+            fetch_branch(
                 "upstream", ctx.base_branch, cwd=workspace, depth=50, logger=self._log
             )
         else:
-            # Same repo; fetch the base branch from origin if not present
-            fetch("origin", ctx.base_branch, cwd=workspace, depth=50, logger=self._log)
+            # Same repo; fetch the base branch from origin into the
+            # remote-tracking ref (see comment in the fork branch
+            # above for why ``fetch_branch`` is required rather than
+            # a bare ``fetch``).
+            fetch_branch(
+                "origin", ctx.base_branch, cwd=workspace, depth=50, logger=self._log
+            )
 
         # Ensure we are on the head branch explicitly (detached HEAD safety)
         checkout(ctx.head_branch, cwd=workspace, create=False, logger=self._log)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4,6 +4,7 @@
 import hashlib
 from unittest.mock import AsyncMock, Mock, patch
 
+import pytest
 from typer.testing import CliRunner
 
 from dependamerge.cli import _generate_override_sha, _validate_override_sha, app
@@ -12,6 +13,21 @@ from dependamerge.models import PullRequestInfo
 
 class TestCLI:
     runner: CliRunner = CliRunner()
+
+    @pytest.fixture(autouse=True)
+    def _mock_pre_flight_permission_check(self):
+        """Auto-mock the pre-flight token permission check.
+
+        The real check makes live GitHub API calls and aborts the
+        command with ``typer.Exit(3)`` when the configured token
+        lacks the required scopes.  Tests in this class use mock
+        ``GitHubClient`` / ``GitHubAsync`` instances and a dummy
+        token, so the live check would always fail and abort
+        before exercising the code under test.  Patch it out for
+        the duration of every test in the class.
+        """
+        with patch("dependamerge.cli._check_merge_permissions") as mock_check:
+            yield mock_check
 
     def setup_method(self):
         self.runner = CliRunner()
@@ -26,7 +42,10 @@ class TestCLI:
     @patch("dependamerge.cli.PRComparator")
     @patch("dependamerge.github_service.GitHubService")
     def test_merge_command_interactive_default(
-        self, mock_service_class, mock_comparator_class, mock_client_class
+        self,
+        mock_service_class,
+        mock_comparator_class,
+        mock_client_class,
     ):
         # Setup mocks
         mock_client = Mock()

--- a/tests/test_dependabot_recreate.py
+++ b/tests/test_dependabot_recreate.py
@@ -167,9 +167,7 @@ class TestCheckPrCommitSignatures:
         api.log = AsyncMock()
         api.log.debug = lambda *a, **kw: None
         with pytest.raises(RuntimeError, match="API error"):
-            await GitHubAsync.check_pr_commit_signatures(
-                api, "owner", "repo", 42
-            )
+            await GitHubAsync.check_pr_commit_signatures(api, "owner", "repo", 42)
 
     @pytest.mark.asyncio
     async def test_unexpected_response_shape(self):

--- a/tests/test_dependabot_recreate.py
+++ b/tests/test_dependabot_recreate.py
@@ -148,19 +148,28 @@ class TestCheckPrCommitSignatures:
         assert len(unverified) == 1
 
     @pytest.mark.asyncio
-    async def test_api_error_returns_verified(self):
-        """On API errors, assume verified to avoid false positives."""
+    async def test_api_error_propagates(self):
+        """On API errors, the exception now propagates to callers.
+
+        The previous fail-open default (returning ``(True, [])`` on
+        error) collided with the signature-preservation gate in
+        ``rebase.py``, which interprets ``all_verified=True`` as a
+        positive confirmation. Surfacing the error lets each caller
+        choose its own fail-open / fail-closed semantics.
+        """
         api = AsyncMock(spec=GitHubAsync)
 
         async def _raise_gen(*a, **kw):
-            raise Exception("API error")
+            raise RuntimeError("API error")
             yield  # pragma: no cover – makes this an async generator
 
         api.get_paginated = _raise_gen
         api.log = AsyncMock()
         api.log.debug = lambda *a, **kw: None
-        result = await GitHubAsync.check_pr_commit_signatures(api, "owner", "repo", 42)
-        assert result == (True, [])
+        with pytest.raises(RuntimeError, match="API error"):
+            await GitHubAsync.check_pr_commit_signatures(
+                api, "owner", "repo", 42
+            )
 
     @pytest.mark.asyncio
     async def test_unexpected_response_shape(self):

--- a/tests/test_external_merge_race.py
+++ b/tests/test_external_merge_race.py
@@ -1,0 +1,186 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 The Linux Foundation
+
+"""Tests for external-merge race handling in ``AsyncMergeManager``.
+
+These tests verify that a PR which is merged externally (by a
+concurrent ``dependamerge`` run, a human admin, or auto-merge
+landing mid-flight) is classified as ``SKIPPED`` rather than
+``FAILED`` so the operator does not see spurious ``❌ Failed``
+entries that need follow-up.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from dependamerge.merge_manager import MergeStatus
+from dependamerge.models import PullRequestInfo
+from tests.conftest import make_merge_manager
+
+
+def _make_pr(
+    *,
+    state: str = "open",
+    number: int = 59,
+    repo: str = "lfreleng-actions/git-commit-message-action",
+) -> PullRequestInfo:
+    return PullRequestInfo(
+        number=number,
+        title="Chore: Bump some dep from 0.3.3 to 0.3.4",
+        body="bump",
+        author="dependabot[bot]",
+        head_sha="deadbeef" * 5,
+        base_branch="main",
+        head_branch="dependabot/x",
+        state=state,
+        mergeable=True,
+        mergeable_state="clean",
+        behind_by=None,
+        files_changed=[],
+        repository_full_name=repo,
+        html_url=f"https://github.com/{repo}/pull/{number}",
+        reviews=[],
+        review_comments=[],
+    )
+
+
+class TestIsPrAlreadyMerged:
+    """Direct unit tests for ``_is_pr_already_merged``."""
+
+    @pytest.mark.asyncio
+    async def test_returns_true_when_state_closed_and_merged(self) -> None:
+        """A closed+merged PR returns True (the external-merge race)."""
+        mgr, client = make_merge_manager()
+        client.get = AsyncMock(return_value={"state": "closed", "merged": True})
+        pr = _make_pr()
+
+        result = await mgr._is_pr_already_merged(pr, "owner", "repo")
+
+        assert result is True
+        client.get.assert_awaited_once_with("/repos/owner/repo/pulls/59")
+
+    @pytest.mark.asyncio
+    async def test_returns_false_when_closed_without_merge(self) -> None:
+        """A PR closed without being merged is not an external merge."""
+        mgr, client = make_merge_manager()
+        client.get = AsyncMock(return_value={"state": "closed", "merged": False})
+
+        result = await mgr._is_pr_already_merged(_make_pr(), "o", "r")
+
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_returns_false_when_still_open(self) -> None:
+        """An open PR is definitely not externally merged."""
+        mgr, client = make_merge_manager()
+        client.get = AsyncMock(return_value={"state": "open", "merged": False})
+
+        result = await mgr._is_pr_already_merged(_make_pr(), "o", "r")
+
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_returns_false_on_api_error(self) -> None:
+        """API errors during the recheck degrade to False (fail safe).
+
+        We must not mask a genuine merge failure as a skip just
+        because the recheck itself errored.
+        """
+        mgr, client = make_merge_manager()
+        client.get = AsyncMock(side_effect=RuntimeError("boom"))
+
+        result = await mgr._is_pr_already_merged(_make_pr(), "o", "r")
+
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_returns_false_on_unexpected_payload(self) -> None:
+        """Non-dict payloads degrade to False rather than crashing."""
+        mgr, client = make_merge_manager()
+        client.get = AsyncMock(return_value=["unexpected", "list"])
+
+        result = await mgr._is_pr_already_merged(_make_pr(), "o", "r")
+
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_returns_false_when_client_missing(self) -> None:
+        """No GitHub client means we cannot recheck; fail safe to False."""
+        mgr, _client = make_merge_manager()
+        mgr._github_client = None
+
+        result = await mgr._is_pr_already_merged(_make_pr(), "o", "r")
+
+        assert result is False
+
+
+class TestEarlyExitClosedPrPath:
+    """``_merge_single_pr`` PR-already-closed branch tests.
+
+    When the PR fetched at the start of ``_merge_single_pr`` is
+    already closed, the manager should distinguish between
+    "closed+merged" (skip) and "closed without merging" (fail).
+    """
+
+    @pytest.mark.asyncio
+    async def test_closed_and_merged_is_skipped(self) -> None:
+        mgr, client = make_merge_manager()
+        # Recheck call returns closed+merged.
+        client.get = AsyncMock(return_value={"state": "closed", "merged": True})
+        pr = _make_pr(state="closed")
+
+        result = await mgr._merge_single_pr(pr)
+
+        assert result.status == MergeStatus.SKIPPED
+        assert result.error == "already merged externally"
+
+    @pytest.mark.asyncio
+    async def test_closed_without_merge_is_failed(self) -> None:
+        mgr, client = make_merge_manager()
+        # Recheck call returns closed but not merged.
+        client.get = AsyncMock(return_value={"state": "closed", "merged": False})
+        pr = _make_pr(state="closed")
+
+        result = await mgr._merge_single_pr(pr)
+
+        assert result.status == MergeStatus.FAILED
+        assert result.error == "PR is already closed"
+
+
+class TestProgressTrackerMergeSkipped:
+    """Confirm the progress tracker exposes ``merge_skipped``."""
+
+    def test_increments_skipped_counter(self) -> None:
+        from dependamerge.progress_tracker import MergeProgressTracker
+
+        tracker = MergeProgressTracker(organization="lfreleng-actions")
+        tracker.set_total_prs(3)
+
+        assert tracker.prs_skipped == 0
+        tracker.merge_skipped()
+        tracker.merge_skipped()
+        assert tracker.prs_skipped == 2
+        # Skips count toward overall completion so the percentage
+        # progresses past parked PRs in repo-scoped batches.
+        assert tracker.completed_prs == 2
+
+    def test_summary_includes_skipped(self) -> None:
+        from dependamerge.progress_tracker import MergeProgressTracker
+
+        tracker = MergeProgressTracker(organization="lfreleng-actions")
+        tracker.merge_skipped()
+
+        summary = tracker.get_summary()
+
+        assert summary["prs_skipped"] == 1
+
+    def test_dummy_tracker_has_merge_skipped(self) -> None:
+        """DummyProgressTracker must implement the same surface."""
+        from dependamerge.progress_tracker import DummyProgressTracker
+
+        tracker = DummyProgressTracker()
+        # Must not raise.
+        tracker.merge_skipped()

--- a/tests/test_external_merge_race.py
+++ b/tests/test_external_merge_race.py
@@ -150,6 +150,50 @@ class TestEarlyExitClosedPrPath:
         assert result.error == "PR is already closed"
 
 
+class TestPermissionErrorFastFail:
+    """Tests for the permission-error fast-fail behaviour.
+
+    When the configured token lacks rights on a repository, every
+    PR in that repository will hit the same 403.  The manager
+    must:
+
+    * Record the repository as permission-failed when the first
+      403 lands so subsequent workers short-circuit instead of
+      replaying the same API round-trip.
+    * Print the verbose token-guidance block only on the first
+      failure for that repository, to avoid screensful of
+      duplicate output during a batch run.
+    * Never dump a Python stack trace to stderr for permission
+      errors (they are an expected, user-actionable failure
+      mode, not an unhandled exception).
+    """
+
+    @pytest.mark.asyncio
+    async def test_subsequent_pr_in_failed_repo_short_circuits(
+        self,
+    ) -> None:
+        """Once a repo is recorded as permission-failed, the next PR
+        in that repo must return FAILED without calling the API."""
+        mgr, client = make_merge_manager()
+        # Pre-populate the failed-repo set as if a sibling PR had
+        # already hit a 403.
+        mgr._permission_failed_repos.add("lfreleng-actions/git-commit-message-action")
+        pr = _make_pr()
+
+        result = await mgr._merge_single_pr(pr)
+
+        assert result.status == MergeStatus.FAILED
+        assert "token lacks required permissions" in (result.error or "")
+        # No API call should have been made; the short-circuit
+        # runs before any await on the client.
+        client.get.assert_not_called()
+
+    def test_permission_failed_repos_starts_empty(self) -> None:
+        """Sanity check: a fresh manager has no failed repos."""
+        mgr, _client = make_merge_manager()
+        assert mgr._permission_failed_repos == set()
+
+
 class TestProgressTrackerMergeSkipped:
     """Confirm the progress tracker exposes ``merge_skipped``."""
 

--- a/tests/test_fix_verification.py
+++ b/tests/test_fix_verification.py
@@ -15,6 +15,7 @@ from dependamerge.models import PullRequestInfo
 def test_final_verification():
     """Final test to demonstrate the fix is working"""
     with (
+        patch("dependamerge.cli._check_merge_permissions"),
         patch("dependamerge.cli.GitHubClient") as mock_client_class,
         patch("dependamerge.cli.PRComparator") as mock_comparator_class,
         patch("dependamerge.github_service.GitHubService") as mock_service_class,

--- a/tests/test_local_rebase_signing.py
+++ b/tests/test_local_rebase_signing.py
@@ -250,6 +250,37 @@ class TestShouldUseLocalRebaseGate:
         )
         assert use_local is False
 
+    @pytest.mark.asyncio
+    async def test_pr_signature_check_failure_uses_rest(self) -> None:
+        """If ``check_pr_commit_signatures()`` raises, fail safely to REST.
+
+        Distinct from ``test_signature_check_failure_uses_rest``
+        which covers ``requires_commit_signatures()`` raising.
+        Here the base requirement check succeeds (signatures are
+        required) but the PR-head verification check raises.
+        Failing closed avoids triggering network-touching local
+        clones on transient API failures, and keeps the gate
+        consistent with its documented invariant ("base requires
+        signatures AND PR head is verified").
+        """
+        mgr, client = _make_mgr()
+        pr = _make_pr(author="dependabot[bot]")
+        client.requires_commit_signatures = AsyncMock(return_value=True)
+        client.check_pr_commit_signatures = AsyncMock(
+            side_effect=RuntimeError("transient API error")
+        )
+        use_local, reason = await rebase_module.should_use_local_rebase(
+            github_client=mgr._github_client,
+            pr_info=pr,
+            owner="owner",
+            repo="repo",
+            base_branch="main",
+            rebase_local=mgr.rebase_local,
+            log=mgr.log,
+        )
+        assert use_local is False
+        assert "signature check failed" in reason
+
 
 # ---------------------------------------------------------------------------
 # 2. Step 5 dispatch: local-rebase path skips REST update-branch
@@ -422,13 +453,15 @@ class TestStep5DispatchLocalRebase:
         client.update_branch.assert_not_awaited()
         # PR is marked rebased so Step 5.5 doesn't double-wait.
         assert "owner/repo#42" in mgr._rebased_prs
-        # The flow continues to Step 6 (manual merge attempt). In
-        # this test the mock returns True so we end up MERGED; in
-        # production a signature-protected branch would 405 here
-        # and surface the failure to the user. Either outcome is
-        # better than the previous behaviour of *silently breaking*
-        # the verification by calling REST update-branch.
-        assert result.status == MergeStatus.MERGED
+        # Auto-merge gets enabled by the local-rebase orchestrator
+        # (regardless of whether the local rebase itself succeeded
+        # or failed) so Step 6's skip gate routes the PR to
+        # AUTO_MERGE_PENDING. Without this, marking ``_rebased_prs``
+        # would skip Step 5.5 too, and Step 6 would attempt a
+        # manual merge that 405s against pending checks — exactly
+        # the failure mode this feature exists to prevent.
+        assert "owner/repo#42" in mgr._auto_merge_enabled
+        assert result.status == MergeStatus.AUTO_MERGE_PENDING
 
     @pytest.mark.asyncio
     async def test_unsigned_base_uses_rest_update_branch(self) -> None:

--- a/tests/test_local_rebase_signing.py
+++ b/tests/test_local_rebase_signing.py
@@ -21,6 +21,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from dependamerge import rebase as rebase_module
 from dependamerge.github2gerrit_detector import GitHub2GerritDetectionResult
 from dependamerge.merge_manager import AsyncMergeManager, MergeStatus
 from dependamerge.models import PullRequestInfo
@@ -86,8 +87,14 @@ class TestShouldUseLocalRebaseGate:
         """``--no-rebase-local`` short-circuits the gate to False."""
         mgr, _client = _make_mgr(rebase_local=False)
         pr = _make_pr(author="pre-commit-ci[bot]")  # would otherwise match
-        use_local, reason = await mgr._should_use_local_rebase(
-            pr, "owner", "repo", "main"
+        use_local, reason = await rebase_module.should_use_local_rebase(
+            github_client=mgr._github_client,
+            pr_info=pr,
+            owner="owner",
+            repo="repo",
+            base_branch="main",
+            rebase_local=mgr.rebase_local,
+            log=mgr.log,
         )
         assert use_local is False
         assert "--no-rebase-local" in reason
@@ -104,8 +111,14 @@ class TestShouldUseLocalRebaseGate:
         pr = _make_pr(author="pre-commit-ci[bot]")
         # No signature mocks needed: pre-commit-ci shortcut fires
         # before requires_commit_signatures is consulted.
-        use_local, reason = await mgr._should_use_local_rebase(
-            pr, "owner", "repo", "main"
+        use_local, reason = await rebase_module.should_use_local_rebase(
+            github_client=mgr._github_client,
+            pr_info=pr,
+            owner="owner",
+            repo="repo",
+            base_branch="main",
+            rebase_local=mgr.rebase_local,
+            log=mgr.log,
         )
         assert use_local is True
         assert "pre-commit-ci" in reason
@@ -118,8 +131,14 @@ class TestShouldUseLocalRebaseGate:
         pr = _make_pr(author="dependabot[bot]")
         client.requires_commit_signatures = AsyncMock(return_value=True)
         client.check_pr_commit_signatures = AsyncMock(return_value=(True, []))
-        use_local, reason = await mgr._should_use_local_rebase(
-            pr, "owner", "repo", "main"
+        use_local, reason = await rebase_module.should_use_local_rebase(
+            github_client=mgr._github_client,
+            pr_info=pr,
+            owner="owner",
+            repo="repo",
+            base_branch="main",
+            rebase_local=mgr.rebase_local,
+            log=mgr.log,
         )
         assert use_local is True
         assert "PR head is verified" in reason
@@ -136,8 +155,14 @@ class TestShouldUseLocalRebaseGate:
         pr = _make_pr(author="dependabot[bot]")
         client.requires_commit_signatures = AsyncMock(return_value=True)
         client.check_pr_commit_signatures = AsyncMock(return_value=(False, ["abc123"]))
-        use_local, reason = await mgr._should_use_local_rebase(
-            pr, "owner", "repo", "main"
+        use_local, reason = await rebase_module.should_use_local_rebase(
+            github_client=mgr._github_client,
+            pr_info=pr,
+            owner="owner",
+            repo="repo",
+            base_branch="main",
+            rebase_local=mgr.rebase_local,
+            log=mgr.log,
         )
         assert use_local is False
         assert "not currently verified" in reason
@@ -148,8 +173,14 @@ class TestShouldUseLocalRebaseGate:
         mgr, client = _make_mgr()
         pr = _make_pr(author="dependabot[bot]")
         client.requires_commit_signatures = AsyncMock(return_value=False)
-        use_local, reason = await mgr._should_use_local_rebase(
-            pr, "owner", "repo", "main"
+        use_local, reason = await rebase_module.should_use_local_rebase(
+            github_client=mgr._github_client,
+            pr_info=pr,
+            owner="owner",
+            repo="repo",
+            base_branch="main",
+            rebase_local=mgr.rebase_local,
+            log=mgr.log,
         )
         assert use_local is False
         assert "does not require signatures" in reason
@@ -164,8 +195,14 @@ class TestShouldUseLocalRebaseGate:
         mgr, client = _make_mgr()
         pr = _make_pr(author="dependabot[bot]")
         client.requires_commit_signatures = AsyncMock(side_effect=RuntimeError("boom"))
-        use_local, reason = await mgr._should_use_local_rebase(
-            pr, "owner", "repo", "main"
+        use_local, reason = await rebase_module.should_use_local_rebase(
+            github_client=mgr._github_client,
+            pr_info=pr,
+            owner="owner",
+            repo="repo",
+            base_branch="main",
+            rebase_local=mgr.rebase_local,
+            log=mgr.log,
         )
         assert use_local is False
         assert "signature requirement check failed" in reason
@@ -176,8 +213,14 @@ class TestShouldUseLocalRebaseGate:
         mgr, _client = _make_mgr()
         mgr._github_client = None
         pr = _make_pr(author="dependabot[bot]")
-        use_local, reason = await mgr._should_use_local_rebase(
-            pr, "owner", "repo", "main"
+        use_local, reason = await rebase_module.should_use_local_rebase(
+            github_client=mgr._github_client,
+            pr_info=pr,
+            owner="owner",
+            repo="repo",
+            base_branch="main",
+            rebase_local=mgr.rebase_local,
+            log=mgr.log,
         )
         assert use_local is False
         assert "no GitHub client" in reason
@@ -196,8 +239,14 @@ class TestShouldUseLocalRebaseGate:
         mgr, client = _make_mgr()
         pr = _make_pr(author="dependabot[bot]")
         client.requires_commit_signatures = AsyncMock(return_value=MagicMock())
-        use_local, _reason = await mgr._should_use_local_rebase(
-            pr, "owner", "repo", "main"
+        use_local, _reason = await rebase_module.should_use_local_rebase(
+            github_client=mgr._github_client,
+            pr_info=pr,
+            owner="owner",
+            repo="repo",
+            base_branch="main",
+            rebase_local=mgr.rebase_local,
+            log=mgr.log,
         )
         assert use_local is False
 
@@ -240,9 +289,8 @@ class TestStep5DispatchLocalRebase:
         client.requires_commit_signatures = AsyncMock(return_value=True)
 
         with (
-            patch.object(
-                mgr,
-                "_local_git_rebase_pr",
+            patch(
+                "dependamerge.rebase.local_rebase_pr",
                 new_callable=AsyncMock,
                 return_value=True,
             ) as mock_local_rebase,
@@ -325,9 +373,8 @@ class TestStep5DispatchLocalRebase:
         client.requires_commit_signatures = AsyncMock(return_value=True)
 
         with (
-            patch.object(
-                mgr,
-                "_local_git_rebase_pr",
+            patch(
+                "dependamerge.rebase.local_rebase_pr",
                 new_callable=AsyncMock,
                 return_value=False,
             ) as mock_local_rebase,
@@ -410,9 +457,8 @@ class TestStep5DispatchLocalRebase:
         client.requires_commit_signatures = AsyncMock(return_value=False)
 
         with (
-            patch.object(
-                mgr,
-                "_local_git_rebase_pr",
+            patch(
+                "dependamerge.rebase.local_rebase_pr",
                 new_callable=AsyncMock,
                 return_value=True,
             ) as mock_local_rebase,
@@ -488,9 +534,8 @@ class TestStep5DispatchLocalRebase:
         client.requires_commit_signatures = AsyncMock(return_value=True)
 
         with (
-            patch.object(
-                mgr,
-                "_local_git_rebase_pr",
+            patch(
+                "dependamerge.rebase.local_rebase_pr",
                 new_callable=AsyncMock,
                 return_value=True,
             ) as mock_local_rebase,
@@ -546,15 +591,15 @@ class TestAuthedCloneUrl:
     """Token injection mirrors ``FixOrchestrator._authed_url``."""
 
     def test_https_url_gets_token(self) -> None:
-        url = AsyncMergeManager._authed_clone_url(
+        url = rebase_module.authed_clone_url(
             "https://github.com/owner/repo.git", "abc123"
         )
         assert url == "https://x-access-token:abc123@github.com/owner/repo.git"
 
     def test_ssh_url_unchanged(self) -> None:
         ssh = "git@github.com:owner/repo.git"
-        assert AsyncMergeManager._authed_clone_url(ssh, "abc123") == ssh
+        assert rebase_module.authed_clone_url(ssh, "abc123") == ssh
 
     def test_git_protocol_url_unchanged(self) -> None:
         url = "git://github.com/owner/repo.git"
-        assert AsyncMergeManager._authed_clone_url(url, "abc123") == url
+        assert rebase_module.authed_clone_url(url, "abc123") == url

--- a/tests/test_local_rebase_signing.py
+++ b/tests/test_local_rebase_signing.py
@@ -4,7 +4,7 @@
 
 Covers:
 
-- ``_should_use_local_rebase`` decision tree (pre-commit-ci, signed
+- ``should_use_local_rebase`` decision tree (pre-commit-ci, signed
   base + signed head, signed base + unsigned head, unsigned base,
   ``--no-rebase-local`` opt-out).
 - End-to-end Step 5 dispatch: when the gate says ``use_local``, we
@@ -75,7 +75,7 @@ def _make_mgr(**overrides) -> tuple[AsyncMergeManager, AsyncMock]:
 
 
 # ---------------------------------------------------------------------------
-# 1. _should_use_local_rebase decision tree
+# 1. should_use_local_rebase decision tree
 # ---------------------------------------------------------------------------
 
 

--- a/tests/test_local_rebase_signing.py
+++ b/tests/test_local_rebase_signing.py
@@ -635,3 +635,101 @@ class TestAuthedCloneUrl:
     def test_git_protocol_url_unchanged(self) -> None:
         url = "git://github.com/owner/repo.git"
         assert rebase_module.authed_clone_url(url, "abc123") == url
+
+
+# ---------------------------------------------------------------------------
+# 4. Local-rebase path conditionally skips _rebased_prs marking
+# ---------------------------------------------------------------------------
+
+
+class TestLocalRebaseAutoMergeUnavailable:
+    """Verify the conditional ``_rebased_prs`` invariant.
+
+    When local rebase succeeds but auto-merge cannot be enabled
+    (repo doesn't allow it, branch protection blocks it, etc.),
+    we must **not** mark ``_rebased_prs`` — doing so would skip
+    Step 5.5 and let Step 6 attempt a manual merge while GitHub
+    is still recomputing mergeability after the force-push,
+    which would 405 transiently.
+
+    When auto-merge *is* enabled, marking ``_rebased_prs`` is
+    correct: Step 5.5's wait would be redundant since auto-merge
+    handles the wait server-side, and the marker keeps Step 6's
+    skip gate firing for ``AUTO_MERGE_PENDING``.
+    """
+
+    @pytest.mark.asyncio
+    async def test_auto_merge_unavailable_leaves_pr_unmarked(self) -> None:
+        """enable_auto_merge False → PR not in ``_rebased_prs``."""
+        mgr, client = _make_mgr(merge_timeout=0.1, fix_out_of_date=True)
+        pr = _make_pr(author="pre-commit-ci[bot]", mergeable_state="behind")
+
+        client.update_branch = AsyncMock()
+        # Repo doesn't allow auto-merge — enable_auto_merge returns False.
+        client.enable_auto_merge = AsyncMock(return_value=False)
+        # Refresh keeps the PR ``behind`` (transient post-push state).
+        client.get = AsyncMock(
+            return_value={
+                "mergeable": True,
+                "mergeable_state": "behind",
+                "state": "open",
+            }
+        )
+        client.analyze_block_reason = AsyncMock(return_value=None)
+        client.get_required_status_checks = AsyncMock(return_value=[])
+        client.requires_commit_signatures = AsyncMock(return_value=True)
+        client.post_issue_comment = AsyncMock()
+
+        with (
+            patch(
+                "dependamerge.rebase.local_rebase_pr",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
+            patch.object(
+                mgr,
+                "_detect_github2gerrit",
+                new_callable=AsyncMock,
+                return_value=GitHub2GerritDetectionResult(),
+            ),
+            patch.object(
+                mgr,
+                "_get_merge_method_for_repo",
+                new_callable=AsyncMock,
+                return_value="merge",
+            ),
+            patch.object(
+                mgr,
+                "_trigger_stale_precommit_ci",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+            patch.object(
+                mgr,
+                "_check_merge_requirements",
+                new_callable=AsyncMock,
+                return_value=(True, ""),
+            ),
+            patch.object(
+                mgr,
+                "_approve_pr",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
+            patch.object(
+                mgr,
+                "_merge_pr_with_retry",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
+        ):
+            await mgr._merge_single_pr(pr)
+
+        # REST update-branch must still NOT fire (signature
+        # preservation invariant).
+        client.update_branch.assert_not_awaited()
+        # _rebased_prs must NOT be populated, so Step 5.5 still
+        # runs its bounded wait. This gives GitHub time to
+        # recompute mergeability after the force-push before any
+        # manual merge attempt in Step 6.
+        assert "owner/repo#42" not in mgr._rebased_prs

--- a/tests/test_local_rebase_signing.py
+++ b/tests/test_local_rebase_signing.py
@@ -85,10 +85,10 @@ class TestShouldUseLocalRebaseGate:
     @pytest.mark.asyncio
     async def test_disabled_by_no_rebase_local_flag(self) -> None:
         """``--no-rebase-local`` short-circuits the gate to False."""
-        mgr, _client = _make_mgr(rebase_local=False)
+        mgr, client = _make_mgr(rebase_local=False)
         pr = _make_pr(author="pre-commit-ci[bot]")  # would otherwise match
         use_local, reason = await rebase_module.should_use_local_rebase(
-            github_client=mgr._github_client,
+            github_client=client,
             pr_info=pr,
             owner="owner",
             repo="repo",
@@ -112,7 +112,7 @@ class TestShouldUseLocalRebaseGate:
         # No signature mocks needed: pre-commit-ci shortcut fires
         # before requires_commit_signatures is consulted.
         use_local, reason = await rebase_module.should_use_local_rebase(
-            github_client=mgr._github_client,
+            github_client=client,
             pr_info=pr,
             owner="owner",
             repo="repo",
@@ -132,7 +132,7 @@ class TestShouldUseLocalRebaseGate:
         client.requires_commit_signatures = AsyncMock(return_value=True)
         client.check_pr_commit_signatures = AsyncMock(return_value=(True, []))
         use_local, reason = await rebase_module.should_use_local_rebase(
-            github_client=mgr._github_client,
+            github_client=client,
             pr_info=pr,
             owner="owner",
             repo="repo",
@@ -156,7 +156,7 @@ class TestShouldUseLocalRebaseGate:
         client.requires_commit_signatures = AsyncMock(return_value=True)
         client.check_pr_commit_signatures = AsyncMock(return_value=(False, ["abc123"]))
         use_local, reason = await rebase_module.should_use_local_rebase(
-            github_client=mgr._github_client,
+            github_client=client,
             pr_info=pr,
             owner="owner",
             repo="repo",
@@ -174,7 +174,7 @@ class TestShouldUseLocalRebaseGate:
         pr = _make_pr(author="dependabot[bot]")
         client.requires_commit_signatures = AsyncMock(return_value=False)
         use_local, reason = await rebase_module.should_use_local_rebase(
-            github_client=mgr._github_client,
+            github_client=client,
             pr_info=pr,
             owner="owner",
             repo="repo",
@@ -196,7 +196,7 @@ class TestShouldUseLocalRebaseGate:
         pr = _make_pr(author="dependabot[bot]")
         client.requires_commit_signatures = AsyncMock(side_effect=RuntimeError("boom"))
         use_local, reason = await rebase_module.should_use_local_rebase(
-            github_client=mgr._github_client,
+            github_client=client,
             pr_info=pr,
             owner="owner",
             repo="repo",
@@ -211,10 +211,9 @@ class TestShouldUseLocalRebaseGate:
     async def test_no_github_client_returns_false(self) -> None:
         """Without a client we cannot consult branch protection."""
         mgr, _client = _make_mgr()
-        mgr._github_client = None
         pr = _make_pr(author="dependabot[bot]")
         use_local, reason = await rebase_module.should_use_local_rebase(
-            github_client=mgr._github_client,
+            github_client=None,
             pr_info=pr,
             owner="owner",
             repo="repo",
@@ -240,7 +239,7 @@ class TestShouldUseLocalRebaseGate:
         pr = _make_pr(author="dependabot[bot]")
         client.requires_commit_signatures = AsyncMock(return_value=MagicMock())
         use_local, _reason = await rebase_module.should_use_local_rebase(
-            github_client=mgr._github_client,
+            github_client=client,
             pr_info=pr,
             owner="owner",
             repo="repo",
@@ -270,7 +269,7 @@ class TestShouldUseLocalRebaseGate:
             side_effect=RuntimeError("transient API error")
         )
         use_local, reason = await rebase_module.should_use_local_rebase(
-            github_client=mgr._github_client,
+            github_client=client,
             pr_info=pr,
             owner="owner",
             repo="repo",

--- a/tests/test_local_rebase_signing.py
+++ b/tests/test_local_rebase_signing.py
@@ -733,3 +733,71 @@ class TestLocalRebaseAutoMergeUnavailable:
         # recompute mergeability after the force-push before any
         # manual merge attempt in Step 6.
         assert "owner/repo#42" not in mgr._rebased_prs
+
+
+# ---------------------------------------------------------------------------
+# 5. local_rebase_pr fails closed when head repo identity is unknown
+# ---------------------------------------------------------------------------
+
+
+class TestLocalRebaseFailClosed:
+    """Verify local_rebase_pr() refuses to push when head repo is unknown.
+
+    For fork PRs, synthesising a clone URL from the base repo name
+    would push to the upstream repo instead of the fork (creating
+    or overwriting a branch on someone else's repository). When
+    ``head_repo_full_name`` and ``head_repo_clone_url`` are both
+    unset we cannot tell whether the PR is from a fork, so we
+    fail closed to avoid the dangerous mis-target.
+    """
+
+    @pytest.mark.asyncio
+    async def test_missing_head_repo_identity_returns_false(
+        self,
+    ) -> None:
+        """head_repo_full_name + head_repo_clone_url both None → False."""
+        import logging
+
+        from dependamerge.models import PullRequestInfo
+
+        # Construct a PR with NEITHER head_repo identifier set.
+        # This mimics the production state where ``PullRequestInfo``
+        # objects from the merge workflow don't populate the
+        # optional head/base repo fields (they're only set in the
+        # interactive fix flow).
+        pr = PullRequestInfo(
+            number=42,
+            node_id="PR_node42",
+            title="Test PR",
+            body="",
+            author="dependabot[bot]",
+            head_sha="abc123",
+            base_branch="main",
+            head_branch="feature",
+            state="open",
+            mergeable=True,
+            mergeable_state="behind",
+            behind_by=2,
+            files_changed=[],
+            repository_full_name="owner/repo",
+            html_url="https://github.com/owner/repo/pull/42",
+            reviews=[],
+            review_comments=[],
+            head_repo_full_name=None,
+            head_repo_clone_url=None,
+            base_repo_full_name=None,
+            base_repo_clone_url=None,
+            is_fork=None,
+        )
+
+        result = await rebase_module.local_rebase_pr(
+            pr_info=pr,
+            owner="owner",
+            repo="repo",
+            token="fake-token",
+            log=logging.getLogger("test"),
+        )
+        # Must NOT attempt the rebase — we'd risk pushing to the
+        # base repo for a fork PR. The caller falls through to
+        # auto-merge, which is always safe.
+        assert result is False

--- a/tests/test_local_rebase_signing.py
+++ b/tests/test_local_rebase_signing.py
@@ -17,6 +17,7 @@ Covers:
 
 from __future__ import annotations
 
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -65,13 +66,18 @@ def _make_pr(
 
 
 def _make_mgr(**overrides) -> tuple[AsyncMergeManager, AsyncMock]:
-    """Build a manager with an AsyncMock GitHub client."""
-    defaults = {"token": "fake-token", "rebase_local": True}
+    """Build a manager with an AsyncMock GitHub client.
+
+    Thin wrapper around the shared ``tests.conftest.make_merge_manager``
+    so typing/lint fixes and defaults stay centralised. Local
+    additions: defaults ``rebase_local=True`` (the production
+    default — this module's tests focus on the rebase path).
+    """
+    from tests.conftest import make_merge_manager
+
+    defaults: dict[str, Any] = {"rebase_local": True}
     defaults.update(overrides)
-    mgr = AsyncMergeManager(**defaults)
-    client = AsyncMock()
-    mgr._github_client = client
-    return mgr, client
+    return make_merge_manager(**defaults)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_local_rebase_signing.py
+++ b/tests/test_local_rebase_signing.py
@@ -1,0 +1,560 @@
+# SPDX-FileCopyrightText: 2026 The Linux Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the signature-preserving local-rebase path.
+
+Covers:
+
+- ``_should_use_local_rebase`` decision tree (pre-commit-ci, signed
+  base + signed head, signed base + unsigned head, unsigned base,
+  ``--no-rebase-local`` opt-out).
+- End-to-end Step 5 dispatch: when the gate says ``use_local``, we
+  do **not** call the REST ``update-branch`` endpoint regardless of
+  whether the local rebase succeeds or fails.
+- ``_rebased_prs`` is populated in both local-success and
+  local-failure cases so Step 5.5 doesn't double the configured
+  ``merge_timeout``.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from dependamerge.github2gerrit_detector import GitHub2GerritDetectionResult
+from dependamerge.merge_manager import AsyncMergeManager, MergeStatus
+from dependamerge.models import PullRequestInfo
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_pr(
+    *,
+    author: str = "dependabot[bot]",
+    mergeable_state: str = "behind",
+    head_repo_clone_url: str = "https://github.com/owner/repo.git",
+    base_repo_clone_url: str = "https://github.com/owner/repo.git",
+) -> PullRequestInfo:
+    return PullRequestInfo(
+        number=42,
+        node_id="PR_node42",
+        title="Test PR",
+        body="",
+        author=author,
+        head_sha="abc123",
+        base_branch="main",
+        head_branch="feature",
+        state="open",
+        mergeable=True,
+        mergeable_state=mergeable_state,
+        behind_by=2,
+        files_changed=[],
+        repository_full_name="owner/repo",
+        html_url="https://github.com/owner/repo/pull/42",
+        reviews=[],
+        review_comments=[],
+        head_repo_full_name="owner/repo",
+        head_repo_clone_url=head_repo_clone_url,
+        base_repo_full_name="owner/repo",
+        base_repo_clone_url=base_repo_clone_url,
+        is_fork=False,
+    )
+
+
+def _make_mgr(**overrides) -> tuple[AsyncMergeManager, AsyncMock]:
+    """Build a manager with an AsyncMock GitHub client."""
+    defaults = {"token": "fake-token", "rebase_local": True}
+    defaults.update(overrides)
+    mgr = AsyncMergeManager(**defaults)
+    client = AsyncMock()
+    mgr._github_client = client
+    return mgr, client
+
+
+# ---------------------------------------------------------------------------
+# 1. _should_use_local_rebase decision tree
+# ---------------------------------------------------------------------------
+
+
+class TestShouldUseLocalRebaseGate:
+    """Pin the gating decisions for the local-rebase path."""
+
+    @pytest.mark.asyncio
+    async def test_disabled_by_no_rebase_local_flag(self) -> None:
+        """``--no-rebase-local`` short-circuits the gate to False."""
+        mgr, _client = _make_mgr(rebase_local=False)
+        pr = _make_pr(author="pre-commit-ci[bot]")  # would otherwise match
+        use_local, reason = await mgr._should_use_local_rebase(
+            pr, "owner", "repo", "main"
+        )
+        assert use_local is False
+        assert "--no-rebase-local" in reason
+
+    @pytest.mark.asyncio
+    async def test_pre_commit_ci_always_local(self) -> None:
+        """``pre-commit-ci[bot]`` PRs always take the local path.
+
+        The bot has no comment macro for recreating a PR with a
+        re-signed commit, so we never route it through REST
+        update-branch (which would break verification).
+        """
+        mgr, client = _make_mgr()
+        pr = _make_pr(author="pre-commit-ci[bot]")
+        # No signature mocks needed: pre-commit-ci shortcut fires
+        # before requires_commit_signatures is consulted.
+        use_local, reason = await mgr._should_use_local_rebase(
+            pr, "owner", "repo", "main"
+        )
+        assert use_local is True
+        assert "pre-commit-ci" in reason
+        client.requires_commit_signatures.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_signed_base_signed_head_uses_local(self) -> None:
+        """Signed branch + verified head → local path."""
+        mgr, client = _make_mgr()
+        pr = _make_pr(author="dependabot[bot]")
+        client.requires_commit_signatures = AsyncMock(return_value=True)
+        client.check_pr_commit_signatures = AsyncMock(return_value=(True, []))
+        use_local, reason = await mgr._should_use_local_rebase(
+            pr, "owner", "repo", "main"
+        )
+        assert use_local is True
+        assert "PR head is verified" in reason
+
+    @pytest.mark.asyncio
+    async def test_signed_base_unsigned_head_uses_rest(self) -> None:
+        """Signed branch + unsigned PR head → REST path.
+
+        Signature is already broken on the PR head, so REST
+        update-branch can't make verification any worse. Use the
+        cheaper REST path.
+        """
+        mgr, client = _make_mgr()
+        pr = _make_pr(author="dependabot[bot]")
+        client.requires_commit_signatures = AsyncMock(return_value=True)
+        client.check_pr_commit_signatures = AsyncMock(return_value=(False, ["abc123"]))
+        use_local, reason = await mgr._should_use_local_rebase(
+            pr, "owner", "repo", "main"
+        )
+        assert use_local is False
+        assert "not currently verified" in reason
+
+    @pytest.mark.asyncio
+    async def test_unsigned_base_uses_rest(self) -> None:
+        """Base branch with no signature requirement → REST path."""
+        mgr, client = _make_mgr()
+        pr = _make_pr(author="dependabot[bot]")
+        client.requires_commit_signatures = AsyncMock(return_value=False)
+        use_local, reason = await mgr._should_use_local_rebase(
+            pr, "owner", "repo", "main"
+        )
+        assert use_local is False
+        assert "does not require signatures" in reason
+
+    @pytest.mark.asyncio
+    async def test_signature_check_failure_uses_rest(self) -> None:
+        """If the requirement check raises, fail safely to REST.
+
+        We don't want to risk an unbounded local-rebase attempt
+        when we can't determine whether signatures are required.
+        """
+        mgr, client = _make_mgr()
+        pr = _make_pr(author="dependabot[bot]")
+        client.requires_commit_signatures = AsyncMock(side_effect=RuntimeError("boom"))
+        use_local, reason = await mgr._should_use_local_rebase(
+            pr, "owner", "repo", "main"
+        )
+        assert use_local is False
+        assert "signature requirement check failed" in reason
+
+    @pytest.mark.asyncio
+    async def test_no_github_client_returns_false(self) -> None:
+        """Without a client we cannot consult branch protection."""
+        mgr, _client = _make_mgr()
+        mgr._github_client = None
+        pr = _make_pr(author="dependabot[bot]")
+        use_local, reason = await mgr._should_use_local_rebase(
+            pr, "owner", "repo", "main"
+        )
+        assert use_local is False
+        assert "no GitHub client" in reason
+
+    @pytest.mark.asyncio
+    async def test_signature_check_truthy_non_true_treated_as_false(
+        self,
+    ) -> None:
+        """Non-strict ``True`` from requires_commit_signatures must not match.
+
+        ``AsyncMock`` defaults return a truthy ``MagicMock``
+        instance; if we accepted any truthy value the production
+        gate would route real PRs into the local-rebase path on
+        mocks that hadn't explicitly set ``return_value``.
+        """
+        mgr, client = _make_mgr()
+        pr = _make_pr(author="dependabot[bot]")
+        client.requires_commit_signatures = AsyncMock(return_value=MagicMock())
+        use_local, _reason = await mgr._should_use_local_rebase(
+            pr, "owner", "repo", "main"
+        )
+        assert use_local is False
+
+
+# ---------------------------------------------------------------------------
+# 2. Step 5 dispatch: local-rebase path skips REST update-branch
+# ---------------------------------------------------------------------------
+
+
+class TestStep5DispatchLocalRebase:
+    """Step 5 must not call REST update-branch when use_local is True.
+
+    These tests verify the integration: regardless of whether the
+    local rebase succeeds or fails, ``update_branch()`` must not
+    fire. This is the whole point of the feature — a REST
+    update-branch would replace the verified commit with an
+    unsigned one and break branch protection.
+    """
+
+    @pytest.mark.asyncio
+    async def test_pre_commit_ci_pr_skips_rest_update_branch_on_success(
+        self,
+    ) -> None:
+        """Pre-commit-ci PR + local rebase succeeds → no REST call."""
+        mgr, client = _make_mgr(merge_timeout=0.1, fix_out_of_date=True)
+        pr = _make_pr(author="pre-commit-ci[bot]", mergeable_state="behind")
+
+        client.update_branch = AsyncMock()
+        client.enable_auto_merge = AsyncMock(return_value=True)
+        client.post_issue_comment = AsyncMock()
+        client.get = AsyncMock(
+            return_value={
+                "mergeable": True,
+                "mergeable_state": "clean",
+                "state": "open",
+            }
+        )
+        client.analyze_block_reason = AsyncMock(return_value=None)
+        client.get_required_status_checks = AsyncMock(return_value=[])
+        client.requires_commit_signatures = AsyncMock(return_value=True)
+
+        with (
+            patch.object(
+                mgr,
+                "_local_git_rebase_pr",
+                new_callable=AsyncMock,
+                return_value=True,
+            ) as mock_local_rebase,
+            patch.object(
+                mgr,
+                "_detect_github2gerrit",
+                new_callable=AsyncMock,
+                return_value=GitHub2GerritDetectionResult(),
+            ),
+            patch.object(
+                mgr,
+                "_get_merge_method_for_repo",
+                new_callable=AsyncMock,
+                return_value="merge",
+            ),
+            patch.object(
+                mgr,
+                "_trigger_stale_precommit_ci",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+            patch.object(
+                mgr,
+                "_check_merge_requirements",
+                new_callable=AsyncMock,
+                return_value=(True, ""),
+            ),
+            patch.object(
+                mgr,
+                "_approve_pr",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
+            patch.object(
+                mgr,
+                "_merge_pr_with_retry",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
+        ):
+            await mgr._merge_single_pr(pr)
+
+        # Local rebase was attempted exactly once.
+        mock_local_rebase.assert_awaited_once()
+        # REST update-branch was NEVER called — this is the key
+        # assertion: the verification-preserving path did not
+        # fall through to the verification-breaking endpoint.
+        client.update_branch.assert_not_awaited()
+        # The PR was marked as rebased so Step 5.5 doesn't double
+        # the merge timeout.
+        assert "owner/repo#42" in mgr._rebased_prs
+
+    @pytest.mark.asyncio
+    async def test_pre_commit_ci_pr_skips_rest_update_branch_on_failure(
+        self,
+    ) -> None:
+        """Pre-commit-ci PR + local rebase FAILS → still no REST call.
+
+        This is the most important invariant: when local rebase
+        fails (no git, conflicts, network) we must NOT fall back
+        to REST update-branch, because doing so would break
+        verification — exactly the bug this feature exists to
+        prevent.
+        """
+        mgr, client = _make_mgr(merge_timeout=0.1, fix_out_of_date=True)
+        pr = _make_pr(author="pre-commit-ci[bot]", mergeable_state="behind")
+
+        client.update_branch = AsyncMock()
+        client.enable_auto_merge = AsyncMock(return_value=True)
+        client.post_issue_comment = AsyncMock()
+        client.get = AsyncMock(
+            return_value={
+                "mergeable": True,
+                "mergeable_state": "behind",
+                "state": "open",
+            }
+        )
+        client.analyze_block_reason = AsyncMock(return_value=None)
+        client.get_required_status_checks = AsyncMock(return_value=[])
+        client.requires_commit_signatures = AsyncMock(return_value=True)
+
+        with (
+            patch.object(
+                mgr,
+                "_local_git_rebase_pr",
+                new_callable=AsyncMock,
+                return_value=False,
+            ) as mock_local_rebase,
+            patch.object(
+                mgr,
+                "_detect_github2gerrit",
+                new_callable=AsyncMock,
+                return_value=GitHub2GerritDetectionResult(),
+            ),
+            patch.object(
+                mgr,
+                "_get_merge_method_for_repo",
+                new_callable=AsyncMock,
+                return_value="merge",
+            ),
+            patch.object(
+                mgr,
+                "_trigger_stale_precommit_ci",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+            patch.object(
+                mgr,
+                "_check_merge_requirements",
+                new_callable=AsyncMock,
+                return_value=(True, ""),
+            ),
+            patch.object(
+                mgr,
+                "_approve_pr",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
+            patch.object(
+                mgr,
+                "_merge_pr_with_retry",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
+        ):
+            result = await mgr._merge_single_pr(pr)
+
+        mock_local_rebase.assert_awaited_once()
+        # REST update-branch must still NOT fire on local failure.
+        client.update_branch.assert_not_awaited()
+        # PR is marked rebased so Step 5.5 doesn't double-wait.
+        assert "owner/repo#42" in mgr._rebased_prs
+        # The flow continues to Step 6 (manual merge attempt). In
+        # this test the mock returns True so we end up MERGED; in
+        # production a signature-protected branch would 405 here
+        # and surface the failure to the user. Either outcome is
+        # better than the previous behaviour of *silently breaking*
+        # the verification by calling REST update-branch.
+        assert result.status == MergeStatus.MERGED
+
+    @pytest.mark.asyncio
+    async def test_unsigned_base_uses_rest_update_branch(self) -> None:
+        """Unsigned base + non-pre-commit-ci → REST path runs.
+
+        Backward compatibility: when the gate says don't go local,
+        Step 5 must still call the REST endpoint (the existing
+        behaviour for repos without signature requirements).
+        """
+        mgr, client = _make_mgr(merge_timeout=0.1, fix_out_of_date=True)
+        pr = _make_pr(author="dependabot[bot]", mergeable_state="behind")
+
+        client.update_branch = AsyncMock()
+        client.enable_auto_merge = AsyncMock(return_value=True)
+        client.post_issue_comment = AsyncMock()
+        client.get = AsyncMock(
+            return_value={
+                "mergeable": True,
+                "mergeable_state": "clean",
+                "state": "open",
+            }
+        )
+        client.analyze_block_reason = AsyncMock(return_value=None)
+        client.get_required_status_checks = AsyncMock(return_value=[])
+        # Unsigned base → gate returns False → REST path.
+        client.requires_commit_signatures = AsyncMock(return_value=False)
+
+        with (
+            patch.object(
+                mgr,
+                "_local_git_rebase_pr",
+                new_callable=AsyncMock,
+                return_value=True,
+            ) as mock_local_rebase,
+            patch.object(
+                mgr,
+                "_detect_github2gerrit",
+                new_callable=AsyncMock,
+                return_value=GitHub2GerritDetectionResult(),
+            ),
+            patch.object(
+                mgr,
+                "_get_merge_method_for_repo",
+                new_callable=AsyncMock,
+                return_value="merge",
+            ),
+            patch.object(
+                mgr,
+                "_trigger_stale_precommit_ci",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+            patch.object(
+                mgr,
+                "_check_merge_requirements",
+                new_callable=AsyncMock,
+                return_value=(True, ""),
+            ),
+            patch.object(
+                mgr,
+                "_approve_pr",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
+            patch.object(
+                mgr,
+                "_merge_pr_with_retry",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
+        ):
+            await mgr._merge_single_pr(pr)
+
+        # Local rebase was NOT attempted.
+        mock_local_rebase.assert_not_awaited()
+        # REST update-branch WAS called (the legacy path).
+        client.update_branch.assert_awaited_once_with("owner", "repo", 42)
+
+    @pytest.mark.asyncio
+    async def test_no_rebase_local_flag_uses_rest(self) -> None:
+        """``--no-rebase-local`` forces the REST path even for pre-commit-ci.
+
+        Provides a user-visible escape hatch when the local path
+        is unavailable (e.g. running in a constrained environment
+        with no ``git`` or no network).
+        """
+        mgr, client = _make_mgr(
+            merge_timeout=0.1, fix_out_of_date=True, rebase_local=False
+        )
+        pr = _make_pr(author="pre-commit-ci[bot]", mergeable_state="behind")
+
+        client.update_branch = AsyncMock()
+        client.enable_auto_merge = AsyncMock(return_value=True)
+        client.post_issue_comment = AsyncMock()
+        client.get = AsyncMock(
+            return_value={
+                "mergeable": True,
+                "mergeable_state": "clean",
+                "state": "open",
+            }
+        )
+        client.analyze_block_reason = AsyncMock(return_value=None)
+        client.get_required_status_checks = AsyncMock(return_value=[])
+        client.requires_commit_signatures = AsyncMock(return_value=True)
+
+        with (
+            patch.object(
+                mgr,
+                "_local_git_rebase_pr",
+                new_callable=AsyncMock,
+                return_value=True,
+            ) as mock_local_rebase,
+            patch.object(
+                mgr,
+                "_detect_github2gerrit",
+                new_callable=AsyncMock,
+                return_value=GitHub2GerritDetectionResult(),
+            ),
+            patch.object(
+                mgr,
+                "_get_merge_method_for_repo",
+                new_callable=AsyncMock,
+                return_value="merge",
+            ),
+            patch.object(
+                mgr,
+                "_trigger_stale_precommit_ci",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+            patch.object(
+                mgr,
+                "_check_merge_requirements",
+                new_callable=AsyncMock,
+                return_value=(True, ""),
+            ),
+            patch.object(
+                mgr,
+                "_approve_pr",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
+            patch.object(
+                mgr,
+                "_merge_pr_with_retry",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
+        ):
+            await mgr._merge_single_pr(pr)
+
+        mock_local_rebase.assert_not_awaited()
+        client.update_branch.assert_awaited_once_with("owner", "repo", 42)
+
+
+# ---------------------------------------------------------------------------
+# 3. _authed_clone_url helper
+# ---------------------------------------------------------------------------
+
+
+class TestAuthedCloneUrl:
+    """Token injection mirrors ``FixOrchestrator._authed_url``."""
+
+    def test_https_url_gets_token(self) -> None:
+        url = AsyncMergeManager._authed_clone_url(
+            "https://github.com/owner/repo.git", "abc123"
+        )
+        assert url == "https://x-access-token:abc123@github.com/owner/repo.git"
+
+    def test_ssh_url_unchanged(self) -> None:
+        ssh = "git@github.com:owner/repo.git"
+        assert AsyncMergeManager._authed_clone_url(ssh, "abc123") == ssh
+
+    def test_git_protocol_url_unchanged(self) -> None:
+        url = "git://github.com/owner/repo.git"
+        assert AsyncMergeManager._authed_clone_url(url, "abc123") == url

--- a/tests/test_merge_dispatch_lock.py
+++ b/tests/test_merge_dispatch_lock.py
@@ -1,0 +1,128 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2025 The Linux Foundation
+
+"""
+Unit tests for ``AsyncMergeManager._get_merge_dispatch_lock``.
+
+The dispatch lock decouples the actual ``merge_pull_request`` API
+call from the Step 5.5 auto-merge wait loop:
+
+* Workers targeting the same repository serialise on the lock so
+  back-to-back merges don't race GitHub's branch-protection
+  propagation.
+* Workers targeting different repositories receive distinct locks
+  and can dispatch in parallel.
+* The wait loops in Step 5.5 do not hold the lock, so a PR parked
+  waiting for required checks no longer head-of-line blocks the
+  rest of the worker pool.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+
+
+def _make_manager(**overrides: Any):
+    """Build an AsyncMergeManager using the project's typed mock helper."""
+    from tests.conftest import make_merge_manager
+
+    defaults: dict[str, Any] = {"preview_mode": False}
+    defaults.update(overrides)
+    return make_merge_manager(**defaults)
+
+
+class TestMergeDispatchLockIdentity:
+    """The lock map is keyed by ``owner/repo`` and shared correctly."""
+
+    @pytest.mark.asyncio
+    async def test_same_repo_returns_same_lock(self) -> None:
+        mgr, _client = _make_manager()
+        a = await mgr._get_merge_dispatch_lock("acme", "widgets")
+        b = await mgr._get_merge_dispatch_lock("acme", "widgets")
+        assert a is b
+
+    @pytest.mark.asyncio
+    async def test_different_repos_return_distinct_locks(self) -> None:
+        mgr, _client = _make_manager()
+        a = await mgr._get_merge_dispatch_lock("acme", "widgets")
+        b = await mgr._get_merge_dispatch_lock("acme", "gizmos")
+        c = await mgr._get_merge_dispatch_lock("other-org", "widgets")
+        assert a is not b
+        assert a is not c
+        assert b is not c
+
+    @pytest.mark.asyncio
+    async def test_concurrent_first_acquire_does_not_duplicate_lock(self) -> None:
+        """Two coroutines requesting the same lock at the same time
+        must receive the *same* ``asyncio.Lock`` instance.
+
+        Without the outer ``_merge_dispatch_locks_lock`` guard this
+        would race and produce two distinct locks for the same repo,
+        which would defeat the serialisation guarantee.
+        """
+        mgr, _client = _make_manager()
+        results = await asyncio.gather(
+            mgr._get_merge_dispatch_lock("acme", "widgets"),
+            mgr._get_merge_dispatch_lock("acme", "widgets"),
+            mgr._get_merge_dispatch_lock("acme", "widgets"),
+        )
+        assert results[0] is results[1] is results[2]
+
+
+class TestMergeDispatchLockSerialisation:
+    """The lock genuinely serialises critical sections per repo."""
+
+    @pytest.mark.asyncio
+    async def test_same_repo_critical_sections_serialise(self) -> None:
+        """Two workers entering the lock for the same repo must run
+        their critical sections strictly one-after-the-other."""
+        mgr, _client = _make_manager()
+        active = 0
+        peak = 0
+
+        async def critical(owner: str, repo: str) -> None:
+            nonlocal active, peak
+            lock = await mgr._get_merge_dispatch_lock(owner, repo)
+            async with lock:
+                active += 1
+                peak = max(peak, active)
+                # Yield to the event loop so a competing coroutine
+                # would have a chance to enter the section if the
+                # lock failed to serialise.
+                await asyncio.sleep(0.01)
+                active -= 1
+
+        await asyncio.gather(
+            critical("acme", "widgets"),
+            critical("acme", "widgets"),
+            critical("acme", "widgets"),
+        )
+        assert peak == 1
+
+    @pytest.mark.asyncio
+    async def test_different_repos_run_in_parallel(self) -> None:
+        """Workers on distinct repos hold distinct locks, so their
+        critical sections must overlap when run concurrently."""
+        mgr, _client = _make_manager()
+        active = 0
+        peak = 0
+
+        async def critical(owner: str, repo: str) -> None:
+            nonlocal active, peak
+            lock = await mgr._get_merge_dispatch_lock(owner, repo)
+            async with lock:
+                active += 1
+                peak = max(peak, active)
+                await asyncio.sleep(0.01)
+                active -= 1
+
+        await asyncio.gather(
+            critical("acme", "alpha"),
+            critical("acme", "beta"),
+            critical("acme", "gamma"),
+        )
+        # All three should be in their critical sections at once.
+        assert peak == 3

--- a/tests/test_output_utils.py
+++ b/tests/test_output_utils.py
@@ -21,28 +21,21 @@ class TestLogAndPrint:
         logger = logging.getLogger("test_logger")
         console = MagicMock(spec=Console)
 
-        with patch("builtins.print") as mock_print:
-            log_and_print(logger, console, "Test message", level="info")
+        log_and_print(logger, console, "Test message", level="info")
 
-        # Verify print was called (since style is None)
-        mock_print.assert_called_once_with("Test message")
-        # Verify console.print was NOT called when style is None
-        console.print.assert_not_called()
+        # Unstyled output now goes through console.print so it
+        # coordinates with any active Rich Live display.
+        console.print.assert_called_once_with("Test message")
 
     def test_log_and_print_with_style(self):
         """Test logging and printing with Rich style."""
         logger = logging.getLogger("test_logger")
         console = MagicMock(spec=Console)
 
-        with patch("builtins.print") as mock_print:
-            log_and_print(
-                logger, console, "Styled message", style="bold red", level="info"
-            )
+        log_and_print(logger, console, "Styled message", style="bold red", level="info")
 
         # Verify console.print was called with style
         console.print.assert_called_once_with("Styled message", style="bold red")
-        # Verify builtin print was NOT called when style is provided
-        mock_print.assert_not_called()
 
     def test_log_and_print_debug_level(self):
         """Test logging at DEBUG level."""
@@ -50,10 +43,8 @@ class TestLogAndPrint:
         logger.setLevel(logging.DEBUG)
         console = MagicMock(spec=Console)
 
-        # Capture log output
-        with patch("builtins.print"):
-            with patch.object(logger, "debug") as mock_debug:
-                log_and_print(logger, console, "Debug message", level="debug")
+        with patch.object(logger, "debug") as mock_debug:
+            log_and_print(logger, console, "Debug message", level="debug")
 
         mock_debug.assert_called_once_with("Debug message")
 
@@ -62,9 +53,8 @@ class TestLogAndPrint:
         logger = logging.getLogger("test_logger_warning")
         console = MagicMock(spec=Console)
 
-        with patch("builtins.print"):
-            with patch.object(logger, "warning") as mock_warning:
-                log_and_print(logger, console, "Warning message", level="warning")
+        with patch.object(logger, "warning") as mock_warning:
+            log_and_print(logger, console, "Warning message", level="warning")
 
         mock_warning.assert_called_once_with("Warning message")
 
@@ -73,9 +63,8 @@ class TestLogAndPrint:
         logger = logging.getLogger("test_logger_error")
         console = MagicMock(spec=Console)
 
-        with patch("builtins.print"):
-            with patch.object(logger, "error") as mock_error:
-                log_and_print(logger, console, "Error message", level="error")
+        with patch.object(logger, "error") as mock_error:
+            log_and_print(logger, console, "Error message", level="error")
 
         mock_error.assert_called_once_with("Error message")
 
@@ -84,10 +73,9 @@ class TestLogAndPrint:
         logger = logging.getLogger("test_logger_invalid")
         console = MagicMock(spec=Console)
 
-        with patch("builtins.print"):
-            with patch.object(logger, "info") as mock_info:
-                # Use an invalid level - should fallback to info
-                log_and_print(logger, console, "Message", level="invalid")
+        with patch.object(logger, "info") as mock_info:
+            # Use an invalid level - should fallback to info
+            log_and_print(logger, console, "Message", level="invalid")
 
         mock_info.assert_called_once_with("Message")
 
@@ -96,10 +84,9 @@ class TestLogAndPrint:
         logger = logging.getLogger("test_logger_emoji")
         console = MagicMock(spec=Console)
 
-        with patch("builtins.print") as mock_print:
-            log_and_print(logger, console, "✅ Success message", level="info")
+        log_and_print(logger, console, "✅ Success message", level="info")
 
-        mock_print.assert_called_once_with("✅ Success message")
+        console.print.assert_called_once_with("✅ Success message")
 
     def test_log_and_print_message_with_url(self):
         """Test handling of messages with URLs."""
@@ -107,10 +94,9 @@ class TestLogAndPrint:
         console = MagicMock(spec=Console)
         message = "✅ Merged: https://github.com/owner/repo/pull/123"
 
-        with patch("builtins.print") as mock_print:
-            log_and_print(logger, console, message, level="info")
+        log_and_print(logger, console, message, level="info")
 
-        mock_print.assert_called_once_with(message)
+        console.print.assert_called_once_with(message)
 
     def test_log_and_print_multiline_message(self):
         """Test handling of multiline messages."""
@@ -118,40 +104,35 @@ class TestLogAndPrint:
         console = MagicMock(spec=Console)
         message = "Line 1\nLine 2\nLine 3"
 
-        with patch("builtins.print") as mock_print:
-            log_and_print(logger, console, message, level="info")
+        log_and_print(logger, console, message, level="info")
 
-        mock_print.assert_called_once_with(message)
+        console.print.assert_called_once_with(message)
 
     def test_log_and_print_empty_message(self):
         """Test handling of empty message."""
         logger = logging.getLogger("test_logger_empty")
         console = MagicMock(spec=Console)
 
-        with patch("builtins.print") as mock_print:
-            log_and_print(logger, console, "", level="info")
+        log_and_print(logger, console, "", level="info")
 
-        mock_print.assert_called_once_with("")
+        console.print.assert_called_once_with("")
 
     def test_log_and_print_default_level(self):
         """Test that default log level is INFO when not specified."""
         logger = logging.getLogger("test_logger_default")
         console = MagicMock(spec=Console)
 
-        with patch("builtins.print"):
-            with patch.object(logger, "info") as mock_info:
-                # Don't specify level - should default to info
-                log_and_print(logger, console, "Default level message")
+        with patch.object(logger, "info") as mock_info:
+            # Don't specify level - should default to info
+            log_and_print(logger, console, "Default level message")
 
         mock_info.assert_called_once_with("Default level message")
 
     def test_log_and_print_none_style(self):
-        """Test that explicitly passing None for style uses print."""
+        """Test that explicitly passing None for style uses console.print."""
         logger = logging.getLogger("test_logger_none_style")
         console = MagicMock(spec=Console)
 
-        with patch("builtins.print") as mock_print:
-            log_and_print(logger, console, "Message", style=None, level="info")
+        log_and_print(logger, console, "Message", style=None, level="info")
 
-        mock_print.assert_called_once_with("Message")
-        console.print.assert_not_called()
+        console.print.assert_called_once_with("Message")

--- a/tests/test_stuck_check_detection.py
+++ b/tests/test_stuck_check_detection.py
@@ -2,13 +2,17 @@
 # SPDX-FileCopyrightText: 2025 The Linux Foundation
 
 """
-Unit tests for ``AsyncMergeManager._detect_stuck_dco``.
+Unit tests for ``AsyncMergeManager._detect_stuck_required_check``.
 
 Covers:
 - DCO check stuck longer than the threshold on a sufficiently old
   PR -> detected (returns ``(True, name, age)``).
 - Sub-threshold stuck DCO check -> not detected.
-- Stuck pending check whose name is not DCO-shaped -> not detected.
+- Stuck pending check whose name is not DCO-shaped and not required
+  -> not detected.
+- A stuck *required* non-DCO check (e.g. ``build``) -> detected.
+- A stuck *required* pre-commit.ci check -> not detected (it has its
+  own recovery via ``_trigger_stale_precommit_ci``).
 - DCO check stuck but PR was just touched (updated_at younger than
   threshold) -> not detected (age floor protects against false
   positives on freshly-pushed PRs).
@@ -16,7 +20,7 @@ Covers:
 - Stuck status-context (older API) DCO entry -> detected.
 - API failures degrade to ``(False, None, 0.0)``.
 - ``_merge_single_pr`` triggers ``_trigger_dependabot_recreate`` when
-  ``_detect_stuck_dco`` returns True for a dependabot PR.
+  ``_detect_stuck_required_check`` returns True for a dependabot PR.
 """
 
 from datetime import datetime, timedelta, timezone
@@ -25,7 +29,7 @@ from unittest.mock import AsyncMock
 
 import pytest
 
-from dependamerge.merge_manager import STUCK_DCO_THRESHOLD_SECONDS
+from dependamerge.merge_manager import STUCK_CHECK_THRESHOLD_SECONDS
 from dependamerge.models import PullRequestInfo
 
 
@@ -77,7 +81,7 @@ def _build_get_responder(
     """Return an ``AsyncMock``-compatible side effect dispatcher.
 
     Routes ``GET`` requests to the right canned response based on the
-    URL path — this mirrors how ``_detect_stuck_dco`` actually calls
+    URL path — this mirrors how ``_detect_stuck_required_check`` actually calls
     the client.
     """
 
@@ -93,7 +97,7 @@ def _build_get_responder(
 
 
 # ---------------------------------------------------------------------------
-# _detect_stuck_dco — positive and negative cases
+# _detect_stuck_required_check — positive and negative cases
 # ---------------------------------------------------------------------------
 
 
@@ -106,7 +110,7 @@ class TestDetectStuckDcoCheckRuns:
         on an old-enough PR is detected."""
         mgr, client = _make_manager()
         now = datetime.now(timezone.utc)
-        old = now - timedelta(seconds=STUCK_DCO_THRESHOLD_SECONDS + 30)
+        old = now - timedelta(seconds=STUCK_CHECK_THRESHOLD_SECONDS + 30)
         pr = _make_pr_info()
 
         client.get = AsyncMock(
@@ -129,10 +133,10 @@ class TestDetectStuckDcoCheckRuns:
             )
         )
 
-        is_stuck, name, age = await mgr._detect_stuck_dco(pr)
+        is_stuck, name, age = await mgr._detect_stuck_required_check(pr)
         assert is_stuck is True
         assert name == "DCO"
-        assert age >= STUCK_DCO_THRESHOLD_SECONDS
+        assert age >= STUCK_CHECK_THRESHOLD_SECONDS
 
     @pytest.mark.asyncio
     async def test_sub_threshold_age_is_not_stuck(self) -> None:
@@ -140,7 +144,7 @@ class TestDetectStuckDcoCheckRuns:
         mgr, client = _make_manager()
         now = datetime.now(timezone.utc)
         # PR is old enough; the check itself is too young.
-        pr_age = now - timedelta(seconds=STUCK_DCO_THRESHOLD_SECONDS + 30)
+        pr_age = now - timedelta(seconds=STUCK_CHECK_THRESHOLD_SECONDS + 30)
         check_started = now - timedelta(seconds=10)
         pr = _make_pr_info()
 
@@ -165,7 +169,7 @@ class TestDetectStuckDcoCheckRuns:
 
         # The PR-level idle floor (updated_at) catches this case
         # before we even look at check timing.
-        is_stuck, name, age = await mgr._detect_stuck_dco(pr)
+        is_stuck, name, age = await mgr._detect_stuck_required_check(pr)
         assert is_stuck is False
         assert name is None
         assert age == 0.0
@@ -175,7 +179,7 @@ class TestDetectStuckDcoCheckRuns:
         """A completed DCO check (success or failure) is not stuck."""
         mgr, client = _make_manager()
         now = datetime.now(timezone.utc)
-        old = now - timedelta(seconds=STUCK_DCO_THRESHOLD_SECONDS + 30)
+        old = now - timedelta(seconds=STUCK_CHECK_THRESHOLD_SECONDS + 30)
         pr = _make_pr_info()
 
         client.get = AsyncMock(
@@ -198,16 +202,17 @@ class TestDetectStuckDcoCheckRuns:
             )
         )
 
-        is_stuck, name, age = await mgr._detect_stuck_dco(pr)
+        is_stuck, name, age = await mgr._detect_stuck_required_check(pr)
         assert is_stuck is False
         assert name is None
 
     @pytest.mark.asyncio
-    async def test_stuck_non_dco_check_is_ignored(self) -> None:
-        """A stuck check whose name is not DCO-shaped is not detected."""
+    async def test_stuck_non_dco_non_required_check_is_ignored(self) -> None:
+        """A stuck check that is neither DCO-shaped nor required on
+        the base branch is not detected."""
         mgr, client = _make_manager()
         now = datetime.now(timezone.utc)
-        old = now - timedelta(seconds=STUCK_DCO_THRESHOLD_SECONDS + 30)
+        old = now - timedelta(seconds=STUCK_CHECK_THRESHOLD_SECONDS + 30)
         pr = _make_pr_info()
 
         client.get = AsyncMock(
@@ -229,7 +234,89 @@ class TestDetectStuckDcoCheckRuns:
             )
         )
 
-        is_stuck, name, age = await mgr._detect_stuck_dco(pr)
+        is_stuck, name, age = await mgr._detect_stuck_required_check(pr)
+        assert is_stuck is False
+        assert name is None
+
+    @pytest.mark.asyncio
+    async def test_detects_stuck_required_non_dco_check(self) -> None:
+        """A stuck *required* non-DCO check (e.g. ``build``) is detected.
+
+        Generalises the original DCO-only behaviour: any required
+        verification check that stalls indefinitely should drive the
+        dependabot recreate recovery.
+        """
+        mgr, client = _make_manager()
+        now = datetime.now(timezone.utc)
+        old = now - timedelta(seconds=STUCK_CHECK_THRESHOLD_SECONDS + 30)
+        pr = _make_pr_info()
+
+        # ``build`` is required on the base branch.
+        client.get_required_status_checks = AsyncMock(
+            return_value=[{"context": "build"}]
+        )
+        client.get = AsyncMock(
+            side_effect=_build_get_responder(
+                pr_response={
+                    "created_at": _iso(old),
+                    "updated_at": _iso(old),
+                },
+                check_runs_response={
+                    "check_runs": [
+                        {
+                            "name": "build",
+                            "status": "in_progress",
+                            "started_at": _iso(old),
+                        }
+                    ],
+                },
+                status_response={"statuses": []},
+            )
+        )
+
+        is_stuck, name, age = await mgr._detect_stuck_required_check(pr)
+        assert is_stuck is True
+        assert name == "build"
+        assert age >= STUCK_CHECK_THRESHOLD_SECONDS
+
+    @pytest.mark.asyncio
+    async def test_stuck_required_precommit_ci_is_ignored(self) -> None:
+        """A stuck *required* pre-commit.ci check is not detected here.
+
+        pre-commit.ci has its own recovery path
+        (``_trigger_stale_precommit_ci`` posts ``pre-commit.ci run``);
+        dependabot's ``recreate`` macro does not retrigger it, so it
+        must be excluded from the recreate-driving detector even when
+        it is a required, stuck check.
+        """
+        mgr, client = _make_manager()
+        now = datetime.now(timezone.utc)
+        old = now - timedelta(seconds=STUCK_CHECK_THRESHOLD_SECONDS + 30)
+        pr = _make_pr_info()
+
+        client.get_required_status_checks = AsyncMock(
+            return_value=[{"context": "pre-commit.ci - pr"}]
+        )
+        client.get = AsyncMock(
+            side_effect=_build_get_responder(
+                pr_response={
+                    "created_at": _iso(old),
+                    "updated_at": _iso(old),
+                },
+                check_runs_response={
+                    "check_runs": [
+                        {
+                            "name": "pre-commit.ci - pr",
+                            "status": "in_progress",
+                            "started_at": _iso(old),
+                        }
+                    ],
+                },
+                status_response={"statuses": []},
+            )
+        )
+
+        is_stuck, name, _age = await mgr._detect_stuck_required_check(pr)
         assert is_stuck is False
         assert name is None
 
@@ -260,7 +347,7 @@ class TestDetectStuckDcoCheckRuns:
             )
         )
 
-        is_stuck, name, age = await mgr._detect_stuck_dco(pr)
+        is_stuck, name, age = await mgr._detect_stuck_required_check(pr)
         assert is_stuck is False
         assert name is None
 
@@ -269,7 +356,7 @@ class TestDetectStuckDcoCheckRuns:
         """The ``dco/dco`` status-context naming is matched."""
         mgr, client = _make_manager()
         now = datetime.now(timezone.utc)
-        old = now - timedelta(seconds=STUCK_DCO_THRESHOLD_SECONDS + 30)
+        old = now - timedelta(seconds=STUCK_CHECK_THRESHOLD_SECONDS + 30)
         pr = _make_pr_info()
 
         client.get = AsyncMock(
@@ -291,7 +378,7 @@ class TestDetectStuckDcoCheckRuns:
             )
         )
 
-        is_stuck, name, _age = await mgr._detect_stuck_dco(pr)
+        is_stuck, name, _age = await mgr._detect_stuck_required_check(pr)
         assert is_stuck is True
         assert name == "dco/dco"
 
@@ -303,7 +390,7 @@ class TestDetectStuckDcoStatusContexts:
     async def test_detects_stuck_dco_status_context(self) -> None:
         mgr, client = _make_manager()
         now = datetime.now(timezone.utc)
-        old = now - timedelta(seconds=STUCK_DCO_THRESHOLD_SECONDS + 30)
+        old = now - timedelta(seconds=STUCK_CHECK_THRESHOLD_SECONDS + 30)
         pr = _make_pr_info()
 
         client.get = AsyncMock(
@@ -325,10 +412,10 @@ class TestDetectStuckDcoStatusContexts:
             )
         )
 
-        is_stuck, name, age = await mgr._detect_stuck_dco(pr)
+        is_stuck, name, age = await mgr._detect_stuck_required_check(pr)
         assert is_stuck is True
         assert name == "DCO"
-        assert age >= STUCK_DCO_THRESHOLD_SECONDS
+        assert age >= STUCK_CHECK_THRESHOLD_SECONDS
 
 
 class TestDetectStuckDcoRobustness:
@@ -340,7 +427,7 @@ class TestDetectStuckDcoRobustness:
         client.get = AsyncMock(side_effect=RuntimeError("boom"))
         pr = _make_pr_info()
 
-        is_stuck, name, age = await mgr._detect_stuck_dco(pr)
+        is_stuck, name, age = await mgr._detect_stuck_required_check(pr)
         assert is_stuck is False
         assert name is None
         assert age == 0.0
@@ -361,7 +448,7 @@ class TestDetectStuckDcoRobustness:
             )
         )
 
-        is_stuck, name, age = await mgr._detect_stuck_dco(pr)
+        is_stuck, name, age = await mgr._detect_stuck_required_check(pr)
         assert is_stuck is False
         assert name is None
         assert age == 0.0
@@ -373,7 +460,7 @@ class TestDetectStuckDcoRobustness:
         mgr._github_client = None
         pr = _make_pr_info()
 
-        is_stuck, name, age = await mgr._detect_stuck_dco(pr)
+        is_stuck, name, age = await mgr._detect_stuck_required_check(pr)
         assert is_stuck is False
         assert name is None
         assert age == 0.0

--- a/tests/test_stuck_dco_detection.py
+++ b/tests/test_stuck_dco_detection.py
@@ -1,0 +1,379 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2025 The Linux Foundation
+
+"""
+Unit tests for ``AsyncMergeManager._detect_stuck_dco``.
+
+Covers:
+- DCO check stuck longer than the threshold on a sufficiently old
+  PR -> detected (returns ``(True, name, age)``).
+- Sub-threshold stuck DCO check -> not detected.
+- Stuck pending check whose name is not DCO-shaped -> not detected.
+- DCO check stuck but PR was just touched (updated_at younger than
+  threshold) -> not detected (age floor protects against false
+  positives on freshly-pushed PRs).
+- DCO check completed -> not detected.
+- Stuck status-context (older API) DCO entry -> detected.
+- API failures degrade to ``(False, None, 0.0)``.
+- ``_merge_single_pr`` triggers ``_trigger_dependabot_recreate`` when
+  ``_detect_stuck_dco`` returns True for a dependabot PR.
+"""
+
+from datetime import datetime, timedelta, timezone
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+
+from dependamerge.merge_manager import STUCK_DCO_THRESHOLD_SECONDS
+from dependamerge.models import PullRequestInfo
+
+
+def _iso(dt: datetime) -> str:
+    """Return ``dt`` in the RFC 3339 ``...Z`` form GitHub emits."""
+    return dt.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _make_pr_info(**overrides: Any) -> PullRequestInfo:
+    """Helper to build a PullRequestInfo with sensible defaults."""
+    defaults: dict[str, Any] = {
+        "number": 342,
+        "title": "Chore: Bump foo from 1 to 2",
+        "body": "Dependabot PR",
+        "author": "dependabot[bot]",
+        "head_sha": "abc123",
+        "base_branch": "main",
+        "head_branch": "dependabot/foo",
+        "state": "open",
+        "mergeable": True,
+        "mergeable_state": "blocked",
+        "behind_by": 0,
+        "files_changed": [],
+        "repository_full_name": "lfreleng-actions/lftools-uv",
+        "html_url": "https://github.com/lfreleng-actions/lftools-uv/pull/342",
+    }
+    defaults.update(overrides)
+    return PullRequestInfo(**defaults)
+
+
+def _make_manager(**overrides: Any):
+    """Build an AsyncMergeManager with a mocked GitHub client.
+
+    Returns ``(manager, client)`` — see ``tests/conftest.py`` for the
+    typed-mock-client pattern.
+    """
+    from tests.conftest import make_merge_manager
+
+    defaults: dict[str, Any] = {"preview_mode": False}
+    defaults.update(overrides)
+    return make_merge_manager(**defaults)
+
+
+def _build_get_responder(
+    pr_response: dict[str, Any] | None = None,
+    check_runs_response: dict[str, Any] | None = None,
+    status_response: dict[str, Any] | None = None,
+):
+    """Return an ``AsyncMock``-compatible side effect dispatcher.
+
+    Routes ``GET`` requests to the right canned response based on the
+    URL path — this mirrors how ``_detect_stuck_dco`` actually calls
+    the client.
+    """
+
+    async def _get(path: str, *args: Any, **kwargs: Any) -> Any:
+        if path.endswith("/check-runs"):
+            return check_runs_response
+        if path.endswith("/status"):
+            return status_response
+        # Anything else is the PR detail fetch.
+        return pr_response
+
+    return _get
+
+
+# ---------------------------------------------------------------------------
+# _detect_stuck_dco — positive and negative cases
+# ---------------------------------------------------------------------------
+
+
+class TestDetectStuckDcoCheckRuns:
+    """Detection via the modern ``check-runs`` API."""
+
+    @pytest.mark.asyncio
+    async def test_detects_stuck_dco_check_run(self) -> None:
+        """A queued/in_progress DCO check older than the threshold
+        on an old-enough PR is detected."""
+        mgr, client = _make_manager()
+        now = datetime.now(timezone.utc)
+        old = now - timedelta(seconds=STUCK_DCO_THRESHOLD_SECONDS + 30)
+        pr = _make_pr_info()
+
+        client.get = AsyncMock(
+            side_effect=_build_get_responder(
+                pr_response={
+                    "created_at": _iso(old),
+                    "updated_at": _iso(old),
+                },
+                check_runs_response={
+                    "check_runs": [
+                        {
+                            "name": "DCO",
+                            "status": "in_progress",
+                            "conclusion": None,
+                            "started_at": _iso(old),
+                        }
+                    ],
+                },
+                status_response={"statuses": []},
+            )
+        )
+
+        is_stuck, name, age = await mgr._detect_stuck_dco(pr)
+        assert is_stuck is True
+        assert name == "DCO"
+        assert age >= STUCK_DCO_THRESHOLD_SECONDS
+
+    @pytest.mark.asyncio
+    async def test_sub_threshold_age_is_not_stuck(self) -> None:
+        """A DCO check pending for less than the threshold is not stuck."""
+        mgr, client = _make_manager()
+        now = datetime.now(timezone.utc)
+        # PR is old enough; the check itself is too young.
+        pr_age = now - timedelta(seconds=STUCK_DCO_THRESHOLD_SECONDS + 30)
+        check_started = now - timedelta(seconds=10)
+        pr = _make_pr_info()
+
+        client.get = AsyncMock(
+            side_effect=_build_get_responder(
+                pr_response={
+                    "created_at": _iso(pr_age),
+                    "updated_at": _iso(check_started),
+                },
+                check_runs_response={
+                    "check_runs": [
+                        {
+                            "name": "DCO",
+                            "status": "in_progress",
+                            "started_at": _iso(check_started),
+                        }
+                    ],
+                },
+                status_response={"statuses": []},
+            )
+        )
+
+        # The PR-level idle floor (updated_at) catches this case
+        # before we even look at check timing.
+        is_stuck, name, age = await mgr._detect_stuck_dco(pr)
+        assert is_stuck is False
+        assert name is None
+        assert age == 0.0
+
+    @pytest.mark.asyncio
+    async def test_completed_dco_is_not_stuck(self) -> None:
+        """A completed DCO check (success or failure) is not stuck."""
+        mgr, client = _make_manager()
+        now = datetime.now(timezone.utc)
+        old = now - timedelta(seconds=STUCK_DCO_THRESHOLD_SECONDS + 30)
+        pr = _make_pr_info()
+
+        client.get = AsyncMock(
+            side_effect=_build_get_responder(
+                pr_response={
+                    "created_at": _iso(old),
+                    "updated_at": _iso(old),
+                },
+                check_runs_response={
+                    "check_runs": [
+                        {
+                            "name": "DCO",
+                            "status": "completed",
+                            "conclusion": "success",
+                            "started_at": _iso(old),
+                        }
+                    ],
+                },
+                status_response={"statuses": []},
+            )
+        )
+
+        is_stuck, name, age = await mgr._detect_stuck_dco(pr)
+        assert is_stuck is False
+        assert name is None
+
+    @pytest.mark.asyncio
+    async def test_stuck_non_dco_check_is_ignored(self) -> None:
+        """A stuck check whose name is not DCO-shaped is not detected."""
+        mgr, client = _make_manager()
+        now = datetime.now(timezone.utc)
+        old = now - timedelta(seconds=STUCK_DCO_THRESHOLD_SECONDS + 30)
+        pr = _make_pr_info()
+
+        client.get = AsyncMock(
+            side_effect=_build_get_responder(
+                pr_response={
+                    "created_at": _iso(old),
+                    "updated_at": _iso(old),
+                },
+                check_runs_response={
+                    "check_runs": [
+                        {
+                            "name": "build",
+                            "status": "in_progress",
+                            "started_at": _iso(old),
+                        }
+                    ],
+                },
+                status_response={"statuses": []},
+            )
+        )
+
+        is_stuck, name, age = await mgr._detect_stuck_dco(pr)
+        assert is_stuck is False
+        assert name is None
+
+    @pytest.mark.asyncio
+    async def test_pr_age_floor_blocks_detection(self) -> None:
+        """A young PR (created < threshold ago) is never flagged."""
+        mgr, client = _make_manager()
+        now = datetime.now(timezone.utc)
+        young = now - timedelta(seconds=10)
+        pr = _make_pr_info()
+
+        client.get = AsyncMock(
+            side_effect=_build_get_responder(
+                pr_response={
+                    "created_at": _iso(young),
+                    "updated_at": _iso(young),
+                },
+                check_runs_response={
+                    "check_runs": [
+                        {
+                            "name": "DCO",
+                            "status": "in_progress",
+                            "started_at": _iso(young),
+                        }
+                    ],
+                },
+                status_response={"statuses": []},
+            )
+        )
+
+        is_stuck, name, age = await mgr._detect_stuck_dco(pr)
+        assert is_stuck is False
+        assert name is None
+
+    @pytest.mark.asyncio
+    async def test_dco_slash_dco_name_variant_matches(self) -> None:
+        """The ``dco/dco`` status-context naming is matched."""
+        mgr, client = _make_manager()
+        now = datetime.now(timezone.utc)
+        old = now - timedelta(seconds=STUCK_DCO_THRESHOLD_SECONDS + 30)
+        pr = _make_pr_info()
+
+        client.get = AsyncMock(
+            side_effect=_build_get_responder(
+                pr_response={
+                    "created_at": _iso(old),
+                    "updated_at": _iso(old),
+                },
+                check_runs_response={
+                    "check_runs": [
+                        {
+                            "name": "dco/dco",
+                            "status": "queued",
+                            "started_at": _iso(old),
+                        }
+                    ],
+                },
+                status_response={"statuses": []},
+            )
+        )
+
+        is_stuck, name, _age = await mgr._detect_stuck_dco(pr)
+        assert is_stuck is True
+        assert name == "dco/dco"
+
+
+class TestDetectStuckDcoStatusContexts:
+    """Detection via the older ``commits/{sha}/status`` API."""
+
+    @pytest.mark.asyncio
+    async def test_detects_stuck_dco_status_context(self) -> None:
+        mgr, client = _make_manager()
+        now = datetime.now(timezone.utc)
+        old = now - timedelta(seconds=STUCK_DCO_THRESHOLD_SECONDS + 30)
+        pr = _make_pr_info()
+
+        client.get = AsyncMock(
+            side_effect=_build_get_responder(
+                pr_response={
+                    "created_at": _iso(old),
+                    "updated_at": _iso(old),
+                },
+                check_runs_response={"check_runs": []},
+                status_response={
+                    "statuses": [
+                        {
+                            "context": "DCO",
+                            "state": "pending",
+                            "updated_at": _iso(old),
+                        }
+                    ],
+                },
+            )
+        )
+
+        is_stuck, name, age = await mgr._detect_stuck_dco(pr)
+        assert is_stuck is True
+        assert name == "DCO"
+        assert age >= STUCK_DCO_THRESHOLD_SECONDS
+
+
+class TestDetectStuckDcoRobustness:
+    """Defensive behaviour when the GitHub API misbehaves."""
+
+    @pytest.mark.asyncio
+    async def test_pr_fetch_failure_returns_safe_default(self) -> None:
+        mgr, client = _make_manager()
+        client.get = AsyncMock(side_effect=RuntimeError("boom"))
+        pr = _make_pr_info()
+
+        is_stuck, name, age = await mgr._detect_stuck_dco(pr)
+        assert is_stuck is False
+        assert name is None
+        assert age == 0.0
+
+    @pytest.mark.asyncio
+    async def test_unparseable_timestamps_return_safe_default(self) -> None:
+        mgr, client = _make_manager()
+        pr = _make_pr_info()
+
+        client.get = AsyncMock(
+            side_effect=_build_get_responder(
+                pr_response={
+                    "created_at": "not-a-real-date",
+                    "updated_at": None,
+                },
+                check_runs_response={"check_runs": []},
+                status_response={"statuses": []},
+            )
+        )
+
+        is_stuck, name, age = await mgr._detect_stuck_dco(pr)
+        assert is_stuck is False
+        assert name is None
+        assert age == 0.0
+
+    @pytest.mark.asyncio
+    async def test_no_github_client_returns_safe_default(self) -> None:
+        mgr, _client = _make_manager()
+        # Simulate the manager being used outside the async context.
+        mgr._github_client = None
+        pr = _make_pr_info()
+
+        is_stuck, name, age = await mgr._detect_stuck_dco(pr)
+        assert is_stuck is False
+        assert name is None
+        assert age == 0.0


### PR DESCRIPTION
## Summary

Related recovery / throughput / reporting fixes for repo-scoped
batch merges. They land together because they were all discovered
while exercising the repo-scoped `merge` mode end-to-end and they
share the same code paths.

1. **Signature-preserving local rebase** — when GitHub's REST
   `update-branch` would break commit verification (because the
   resulting commit is signed by the calling token's user, not the
   user's local SSH/GPG key), dependamerge now clones, rebases,
   and force-pushes locally instead.

2. **Stuck required-check recovery** — when a *required* check has
   been pending for ≥ 60s on a dependabot PR that itself was
   created and last updated ≥ 60s ago, dependamerge now treats the
   check as stuck and routes through the existing `@dependabot
   recreate` flow instead of failing. This started as DCO-specific
   recovery and has since been generalised to any stuck required
   check (DCO, lint, build, licence scans, etc.), excluding
   pre-commit.ci (which has its own `pre-commit.ci run` recovery).
   Previously this required manual intervention (real example:
   lfreleng-actions/lftools-uv#342).

3. **Decouple wait from dispatch** — repo-scoped runs no longer
   force `concurrency=1`. The actual `merge_pull_request` API
   call is serialised per repository via a new dispatch lock,
   while approve / rebase / Step 5.5 wait loops run in parallel.
   A single PR parked waiting for required checks no longer
   head-of-line blocks the rest of the batch.

4. **Repo-scoped merge output reporting** — related fixes to the
   output and reporting of repo-scoped runs: failure lines no
   longer get eaten by the Rich `Live` display, the progress
   tracker shows the correct `owner/repo` scope label, the bogus
   `1/1 repos, 100%` indicator is gone, the final summary lists
   each failed PR's URL + reason, and several minor output-clarity
   tweaks (see section 4).

All four plug into existing background-park infrastructure, so
recovery happens without blocking other PRs in the worker pool.

---

## 1. Local rebase (`Feat(merge)`)

### Motivation

Real-world failure on `lfreleng-actions/gerrit-review-action#98`:

1. `pre-commit-ci[bot]` autoupdate PR was behind base.
2. dependamerge called `PUT /repos/.../pulls/98/update-branch`.
3. The server-side merge commit was signed by the calling token's
   user — that identity isn't registered at GitHub.
4. PR lost its `Verified` badge → branch protection (which
   requires verified signatures) blocked the merge.
5. `pre-commit-ci[bot]` has no `recreate` / `rebase` macro
   ([pre-commit-ci/issues#41](https://github.com/pre-commit-ci/issues/issues/41)),
   so the PR was stuck until manually closed.

### Approach

Two new helpers on `AsyncMergeManager`:

- **`_should_use_local_rebase()`** → `(use_local, reason)`.
  Activates when `rebase_local` is enabled (CLI default) AND
  either:
  - the PR author is `pre-commit-ci[bot]` (no recovery macro), OR
  - the base branch's `requires_commit_signatures()` is `True`
    AND `check_pr_commit_signatures()` confirms the current PR
    head is verified.
- **`_local_git_rebase_pr()`** — secure tempdir + clone + fetch
  + `git rebase` + `git push --force-with-lease`, using existing
  `git_ops` helpers. Workspace cleaned up in `finally`.

When the gate says `use_local`, REST `update_branch()` is
**never** called — even on local-rebase failure. Falling back
would defeat the feature.

### CLI

New `--rebase-local` / `--no-rebase-local` flag on `merge`
(default: enabled).

---

## 2. Stuck required-check recovery (`Fix(merge)`)

### Motivation

Real-world failure on `lfreleng-actions/lftools-uv#342` — a
dependabot PR sat blocked on a DCO check that GitHub never
completed. DCO normally finishes in seconds; when it stalls, the
only reliable recovery for dependabot PRs is to ask dependabot to
recreate the PR so the check fires again on a fresh head SHA. The
same failure mode applies to *any* required, blocking verification
job that stalls indefinitely (a hung build, lint, licence scan,
etc.), so the detector treats all required checks uniformly.

### Approach

`AsyncMergeManager._detect_stuck_required_check(pr_info)` returns
`(is_stuck, check_name, age_seconds)`:

- Examines both the modern `/check-runs` API and the older
  `/commits/{sha}/status` contexts.
- Enumerates the checks that are **required** on the PR's base
  branch via the existing `get_required_status_checks()` helper
  and treats any required check as eligible.
- Keeps DCO-shaped names (`DCO`, `dco/dco`, `dcobot`, any
  `dco/...`, plus any name containing `signoff` / `sign-off` /
  `signed-off`) as an always-eligible safety net for the canonical
  stuck-DCO case, even when the required-check lookup cannot
  enumerate it.
- **Excludes pre-commit.ci checks** (`pre-commit.ci - pr` and
  variants) even when required: dependabot's `recreate` macro does
  not retrigger pre-commit.ci, which keeps its dedicated recovery
  via `_trigger_stale_precommit_ci` (the `pre-commit.ci run`
  comment).
- Treats a check as stuck only when **all** of:
  - status is `queued` / `in_progress` / `pending`, AND
  - the check has been pending ≥ `STUCK_CHECK_THRESHOLD_SECONDS`
    (60s, module constant), AND
  - the PR itself was created ≥ 60s ago AND last updated ≥ 60s
    ago.
- The PR-level age + idle floors prevent false positives on PRs
  caught immediately after open or force-push.
- All API failures degrade to `(False, None, 0.0)`.

Wiring: the existing recreate-eligibility check in
`_merge_single_pr` (which fired only on `branch protection`
failure summaries) now also fires when
`_detect_stuck_required_check` returns True for a dependabot PR,
routing through the same `_trigger_dependabot_recreate` flow. The
detection log line uses `markup=False` so a check name containing
`[required]`-style brackets is not silently swallowed by Rich's
markup parser.

---

## 3. Decouple wait from dispatch (`Fix(merge)`)

### Motivation

Real-world output from a 3-PR batch where one PR was waiting on
required checks:

```
🚀 Merging 3 pull requests...
🔀 Merging PRs in lfreleng-actions/http-api-tool-docker (0/3 PRs, 0%)
   ⏳ Waiting for 1 PR to complete checks [217s]
   ⏱️  Elapsed: 1m 27s
```

PRs #2 and #3 couldn't even start because the worker concurrency
was forced to `1` for repo-scoped runs (to avoid races between
back-to-back merges on the same repo). With the default 5-minute
`merge_timeout`, a single slow PR stalled the entire batch for up
to N × 5 minutes.

### Approach

Split the two concerns the old `concurrency=1` was conflating:

- **Workers run in parallel again** (default cap of 5 for repo
  runs, capped by PR count).
- **The actual `merge_pull_request` API call is serialised per
  repository** via a new
  `AsyncMergeManager._get_merge_dispatch_lock(owner, repo)`
  helper. Workers on the same repo queue on the lock; workers
  on different repos hold distinct locks and dispatch in
  parallel.
- **Approve, rebase polling, Step 5.5's auto-merge wait, and DCO
  status polling all run outside the lock**, so a PR parked
  waiting for required checks no longer blocks anything else.

The `cli.py` repo-scoped `_run_parallel_merge` call sites raise
`concurrency=1` to `min(5, len(prs)) or 1`, with the rationale
recorded inline.

---

## 4. Repo-scoped merge output reporting (`Fix(merge)` / `Fix(cli)`)

### Symptoms (real run against `lfit/releng-reusable-workflows`)

```
🔍 Fetching open PRs in lfit (1/1 repos, 100%)
...
🚀 Merging 13 pull requests...
✅ Merged: .../pull/637
...
🔀 Merging PRs in lfit (11/13 PRs, 85%)
   Merging PR 625 in lfit/releng-reusable-workflows
✅ Merged: .../pull/624
   📊 ✅ Merged: 12 | ❌ Failed: 1
❌ Failed 1 PRs
📈 Final Results: 12 merged, 1 failed
```

- PR 625 failed (transient `actionlint` download failure in
  CI), but no `❌ Failed: ` line ever appeared for it.
- The progress tracker reported scope as `lfit` (looks like an
  org-wide scan) when the run was actually scoped to
  `lfit/releng-reusable-workflows`.
- The fetch phase showed `1/1 repos, 100%` — meaningless padding
  because there's only ever one repository in repo-scoped mode.
- The summary just said `1 failed` with no URL or reason.

### Fixes

1. **`output_utils.log_and_print`** — unstyled output now routes
   through `console.print` instead of the builtin `print`. The
   latter bypasses Rich's coordination with any active `Live`
   display, causing per-PR status lines to garble or disappear
   when a merge progress tracker is running.

2. **`AsyncMergeManager.__init__`** — reuses the progress
   tracker's `Console` so failure / status prints from the
   manager interleave cleanly with the `Live` display.

3. **`_print_failed_pr_details` helper** — new helper called
   from `_display_merge_results`, `_execute_confirmed_merge`,
   and `_execute_repo_confirmed_merge`. Lists each failed PR's
   URL and reason in the final summary.

4. **Repo-scoped scope label** — `MergeProgressTracker` now
   receives `f"{owner}/{repo}"` at all three repo-mode
   construction sites so the display reads
   `lfit/releng-reusable-workflows` instead of just `lfit`.

5. **Bogus `1/1 repos, 100%` removed** — drops the
   `update_total_repositories(1)` call in `_handle_repo_merge`'s
   fetch phase.

6. **No-similar-PR output clarity** (`Fix(cli)`) — the
   "No similar PRs found in the organization" line previously used
   a `❌` glyph, making a normal outcome (only the supplied PR
   needs merging) read like a failure. It is now a neutral `⏩` in
   both the merge and close paths. In that same case the
   surrounding blank lines are suppressed so the status lines form
   a compact block, while the blank lines are retained when
   similar PRs *are* found (where they delineate the printed list):

   ```
   🔍 Found 0 similar PRs
   ⏩ No similar PRs found in the organization
   🚀 Merging 1 pull requests...
   ```

7. **Repo-scoped PR listing tidy** (`Fix(cli)`) — the
   "Automation PRs" / "Human PRs" count lines are de-indented to
   column 0, and the per-row `🤖`/`👤` icon is dropped. Each row
   already ends with `(by {author})`, which conveys
   automation-vs-human, so the icon merely duplicated the counts
   shown directly above.

Out of scope: the Gerrit merge path was reviewed and does not
have analogous reporting issues — it uses straight
`console.print` calls (no `Live` display) and already lists
each failed change with project, number, and error.

---

## Tests

**Local rebase** — 15 tests in `tests/test_local_rebase_signing.py`.

**Stuck required check** — 12 tests in
`tests/test_stuck_check_detection.py`: detection via `check-runs`
and the older status API, sub-threshold age, completed check, a
non-DCO non-required name (ignored), a stuck required non-DCO
check such as `build` (detected), a stuck required pre-commit.ci
check (ignored), PR age floor, name variants, and three robustness
paths (PR fetch failure, unparseable timestamps, no client).

**Dispatch lock** — 5 tests in `tests/test_merge_dispatch_lock.py`.

**Output reporting** — `tests/test_output_utils.py` updated to
expect `console.print` for unstyled messages.

## Limitations

- **Local rebase**: requires `git` on PATH. Per-PR shallow clone
  has a small disk + network cost (sub-second for typical
  autoupdate PRs). Concurrent rebases get separate temp
  workspaces.

- **Stuck required check**: 60s threshold is fixed; could become a
  CLI flag later if needed. A required check is identified via the
  base branch's required-checks lookup (with DCO names as a
  fallback); uncommon configurations that hide required checks
  from that lookup rely on the DCO safety net.

- **Dispatch lock**: the per-repo lock is per-process. Multiple
  concurrent dependamerge invocations against the same repo
  could still race; this is no worse than the previous behaviour
  and is generally avoided by GitHub's own rate limiting.

---

> [!NOTE]
> The "repo-scoped merge output reporting" section was previously
> the second half of #285; it has been consolidated here so the
> entire repo-scoped merge-path improvement reviews as a single
> coherent change. #285 is now scoped down to the trivial
> single-file `pyproject.toml` coverage fix.