### PR TITLE
CI(harden-runner): Switch egress policy to block mode

### DIFF
--- a/.github/workflows/autolabeler.yaml
+++ b/.github/workflows/autolabeler.yaml
@@ -53,7 +53,9 @@ jobs:
       # yamllint disable-line rule:line-length
       - uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450  # v2.19.1
         with:
-          egress-policy: 'audit'
+          egress-policy: 'block'
+          allowed-endpoints: >
+            ${{ vars.CONNECTION_WHITELIST }}
 
       # yamllint disable-line rule:line-length
       - uses: release-drafter/release-drafter/autolabeler@563bf132657a13ded0b01fcb723c5a58cdd824e2  # v7.2.1

--- a/.github/workflows/build-test-release.yaml
+++ b/.github/workflows/build-test-release.yaml
@@ -30,7 +30,9 @@ jobs:
       # yamllint disable-line rule:line-length
       - uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450  # v2.19.1
         with:
-          egress-policy: audit
+          egress-policy: 'block'
+          allowed-endpoints: >
+            ${{ vars.CONNECTION_WHITELIST }}
 
       # yamllint disable-line rule:line-length
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
@@ -61,7 +63,9 @@ jobs:
       # yamllint disable-line rule:line-length
       - uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450  # v2.19.1
         with:
-          egress-policy: 'audit'
+          egress-policy: 'block'
+          allowed-endpoints: >
+            ${{ vars.CONNECTION_WHITELIST }}
 
       - name: 'Checkout repository'
         # yamllint disable-line rule:line-length
@@ -127,7 +131,9 @@ jobs:
       # yamllint disable-line rule:line-length
       - uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450  # v2.19.1
         with:
-          egress-policy: 'audit'
+          egress-policy: 'block'
+          allowed-endpoints: >
+            ${{ vars.CONNECTION_WHITELIST }}
 
       # yamllint disable-line rule:line-length
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
@@ -156,7 +162,9 @@ jobs:
       # yamllint disable-line rule:line-length
       - uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450  # v2.19.1
         with:
-          egress-policy: 'audit'
+          egress-policy: 'block'
+          allowed-endpoints: >
+            ${{ vars.CONNECTION_WHITELIST }}
 
       # yamllint disable-line rule:line-length
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
@@ -183,7 +191,9 @@ jobs:
       # yamllint disable-line rule:line-length
       - uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450  # v2.19.1
         with:
-          egress-policy: 'audit'
+          egress-policy: 'block'
+          allowed-endpoints: >
+            ${{ vars.CONNECTION_WHITELIST }}
 
       # yamllint disable-line rule:line-length
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
@@ -207,7 +217,9 @@ jobs:
       # yamllint disable-line rule:line-length
       - uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450  # v2.19.1
         with:
-          egress-policy: 'audit'
+          egress-policy: 'block'
+          allowed-endpoints: >
+            ${{ vars.CONNECTION_WHITELIST }}
 
       # yamllint disable-line rule:line-length
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
@@ -251,7 +263,9 @@ jobs:
       # yamllint disable-line rule:line-length
       - uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450  # v2.19.1
         with:
-          egress-policy: 'audit'
+          egress-policy: 'block'
+          allowed-endpoints: >
+            ${{ vars.CONNECTION_WHITELIST }}
 
       - name: "Download SBOM artefact"
         # yamllint disable-line rule:line-length
@@ -422,7 +436,9 @@ jobs:
       # yamllint disable-line rule:line-length
       - uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450  # v2.19.1
         with:
-          egress-policy: 'audit'
+          egress-policy: 'block'
+          allowed-endpoints: >
+            ${{ vars.CONNECTION_WHITELIST }}
 
       - name: 'Test PyPI publishing'
         # yamllint disable-line rule:line-length
@@ -449,7 +465,9 @@ jobs:
       # yamllint disable-line rule:line-length
       - uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450  # v2.19.1
         with:
-          egress-policy: 'audit'
+          egress-policy: 'block'
+          allowed-endpoints: >
+            ${{ vars.CONNECTION_WHITELIST }}
 
       - name: 'PyPI release'
         # yamllint disable-line rule:line-length
@@ -486,7 +504,9 @@ jobs:
       # yamllint disable-line rule:line-length
       - uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450  # v2.19.1
         with:
-          egress-policy: 'audit'
+          egress-policy: 'block'
+          allowed-endpoints: >
+            ${{ vars.CONNECTION_WHITELIST }}
 
       # yamllint disable-line rule:line-length
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
@@ -524,7 +544,9 @@ jobs:
       # yamllint disable-line rule:line-length
       - uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450  # v2.19.1
         with:
-          egress-policy: 'audit'
+          egress-policy: 'block'
+          allowed-endpoints: >
+            ${{ vars.CONNECTION_WHITELIST }}
 
       # yamllint disable-line rule:line-length
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -43,7 +43,9 @@ jobs:
       # yamllint disable-line rule:line-length
       - uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450  # v2.19.1
         with:
-          egress-policy: audit
+          egress-policy: 'block'
+          allowed-endpoints: >
+            ${{ vars.CONNECTION_WHITELIST }}
 
       # yamllint disable-line rule:line-length
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
@@ -77,7 +79,9 @@ jobs:
       # yamllint disable-line rule:line-length
       - uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450  # v2.19.1
         with:
-          egress-policy: 'audit'
+          egress-policy: 'block'
+          allowed-endpoints: >
+            ${{ vars.CONNECTION_WHITELIST }}
 
       - name: 'Clear Python dependency caches'
         env:
@@ -160,7 +164,9 @@ jobs:
       # yamllint disable-line rule:line-length
       - uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450  # v2.19.1
         with:
-          egress-policy: 'audit'
+          egress-policy: 'block'
+          allowed-endpoints: >
+            ${{ vars.CONNECTION_WHITELIST }}
 
       # yamllint disable-line rule:line-length
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
@@ -187,7 +193,9 @@ jobs:
       # yamllint disable-line rule:line-length
       - uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450  # v2.19.1
         with:
-          egress-policy: audit
+          egress-policy: 'block'
+          allowed-endpoints: >
+            ${{ vars.CONNECTION_WHITELIST }}
 
       # yamllint disable-line rule:line-length
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
@@ -215,7 +223,9 @@ jobs:
       # yamllint disable-line rule:line-length
       - uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450  # v2.19.1
         with:
-          egress-policy: 'audit'
+          egress-policy: 'block'
+          allowed-endpoints: >
+            ${{ vars.CONNECTION_WHITELIST }}
 
       # yamllint disable-line rule:line-length
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
@@ -240,7 +250,9 @@ jobs:
       # yamllint disable-line rule:line-length
       - uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450  # v2.19.1
         with:
-          egress-policy: 'audit'
+          egress-policy: 'block'
+          allowed-endpoints: >
+            ${{ vars.CONNECTION_WHITELIST }}
 
       # yamllint disable-line rule:line-length
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
@@ -285,7 +297,9 @@ jobs:
       # yamllint disable-line rule:line-length
       - uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450  # v2.19.1
         with:
-          egress-policy: 'audit'
+          egress-policy: 'block'
+          allowed-endpoints: >
+            ${{ vars.CONNECTION_WHITELIST }}
 
       - name: "Download SBOM artefact"
         # yamllint disable-line rule:line-length

--- a/.github/workflows/release-drafter.yaml
+++ b/.github/workflows/release-drafter.yaml
@@ -29,7 +29,9 @@ jobs:
       # yamllint disable-line rule:line-length
       - uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450  # v2.19.1
         with:
-          egress-policy: 'audit'
+          egress-policy: 'block'
+          allowed-endpoints: >
+            ${{ vars.CONNECTION_WHITELIST }}
 
       # yamllint disable-line rule:line-length
       - uses: release-drafter/release-drafter@563bf132657a13ded0b01fcb723c5a58cdd824e2  # v7.2.1


### PR DESCRIPTION
## Summary

Flip `step-security/harden-runner` from `audit` to `block` mode across all workflows in this repository. Outbound network access from the GitHub Actions runners is now restricted to the endpoints listed in the repository-level `CONNECTION_WHITELIST` variable, supplied via the `allowed-endpoints` input.

The whitelist was produced from prior audit-mode runs (and the new `lfreleng-actions/github-network-audit` action) and is centrally managed as a repository variable so it can be updated without modifying workflows.

## Files changed

- `.github/workflows/autolabeler.yaml`
- `.github/workflows/build-test-release.yaml`
- `.github/workflows/build-test.yaml`
- `.github/workflows/release-drafter.yaml`

`codeql.yml` and `openssf-scorecard.yaml` do not call `harden-runner` and are unchanged.

## Validation

- `pre-commit run --all-files` (yamllint, actionlint, gha-workflow-linter, etc.) — passes locally.

---

Co-authored-by: Claude <claude@anthropic.com>