### PR TITLE
Fix(coverage): Use package name in coverage source list

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,7 +122,7 @@ markers = [
 ]
 
 [tool.coverage.run]
-source = ["src"]
+source = ["dependamerge"]
 omit = ["tests/*"]
 data_file = ".coverage"
 # relative_files = true


### PR DESCRIPTION
## Summary

Single-file, single-line fix to `pyproject.toml` correcting a
latent coverage configuration bug.

`[tool.coverage.run] source = ["src"]` is a filesystem path.
coverage.py treats entries containing a path separator (or
matching a directory on disk) as **path filters**. Under
[`lfreleng-actions/python-test-action`](https://github.com/lfreleng-actions/python-test-action)
v1.1.x — which installs the package **non-editably** into
`.venv/lib/pythonX.Y/site-packages/` — that filter never matches
the installed location, so coverage reports 0% with a
`No data was collected` warning.

The fix is to use the **import name** (`dependamerge`) instead.
coverage.py instruments the package wherever it is imported from,
regardless of install location.

### Why this is preventive

The bug is currently **masked** because `addopts` includes
`--cov=dependamerge`, which overrides the path-based `source`
list at the CLI. Removing the latent failure mode means the
project remains correctly measured if `addopts` changes or if
the action's flag handling evolves.

`[tool.coverage.paths]` is left in place: it does not affect
measurement, but does help when combining coverage data files
from multiple environments during reporting.

### Related fixes

The same root cause has been addressed in sibling projects:

- lfreleng-actions/markdown-table-fixer#129
- lfreleng-actions/gha-workflow-linter#196

### Change

```diff
 [tool.coverage.run]
-source = ["src"]
+source = ["dependamerge"]
```

---

> [!NOTE]
> This PR previously also carried the "repo-scoped merge output
> reporting" fixes; those have been consolidated into #277 so the
> two changes can be reviewed together as a single coherent merge-
> path improvement. This PR is now scoped to the trivial
> single-file coverage fix.
