### PR TITLE
CI(harden-runner): Add audit fallback for fork PR runs

### DIFF
--- a/.github/workflows/autolabeler.yaml
+++ b/.github/workflows/autolabeler.yaml
@@ -50,12 +50,28 @@ jobs:
     timeout-minutes: 3
     steps:
       # Harden the runner used by this workflow
-      # yamllint disable-line rule:line-length
-      - uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450  # v2.19.1
+      # When the CONNECTION_WHITELIST repo/org variable is exposed
+      # to this run (i.e. not a fork PR), use it to enforce a
+      # block-mode egress policy.
+      - name: 'Harden runner (block egress with whitelist)'
+        if: ${{ vars.CONNECTION_WHITELIST != '' }}
+        # yamllint disable-line rule:line-length
+        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450  # v2.19.1
         with:
           egress-policy: 'block'
           allowed-endpoints: >
             ${{ vars.CONNECTION_WHITELIST }}
+
+      # Fallback for fork PRs and other contexts where the
+      # CONNECTION_WHITELIST variable is not exposed to the
+      # workflow.  Audit-only mode logs all egress without
+      # blocking it so CI still runs.
+      - name: 'Harden runner (audit fallback, no whitelist available)'
+        if: ${{ vars.CONNECTION_WHITELIST == '' }}
+        # yamllint disable-line rule:line-length
+        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450  # v2.19.1
+        with:
+          egress-policy: 'audit'
 
       # yamllint disable-line rule:line-length
       - uses: release-drafter/release-drafter/autolabeler@c2e2804cc59f45f57076a99af580d0fedb697927  # v7.3.0

--- a/.github/workflows/build-test-release.yaml
+++ b/.github/workflows/build-test-release.yaml
@@ -27,12 +27,28 @@ jobs:
       pull-requests: read
     timeout-minutes: 5
     steps:
-      # yamllint disable-line rule:line-length
-      - uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450  # v2.19.1
+      # When the CONNECTION_WHITELIST repo/org variable is exposed
+      # to this run (i.e. not a fork PR), use it to enforce a
+      # block-mode egress policy.
+      - name: 'Harden runner (block egress with whitelist)'
+        if: ${{ vars.CONNECTION_WHITELIST != '' }}
+        # yamllint disable-line rule:line-length
+        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450  # v2.19.1
         with:
           egress-policy: 'block'
           allowed-endpoints: >
             ${{ vars.CONNECTION_WHITELIST }}
+
+      # Fallback for fork PRs and other contexts where the
+      # CONNECTION_WHITELIST variable is not exposed to the
+      # workflow.  Audit-only mode logs all egress without
+      # blocking it so CI still runs.
+      - name: 'Harden runner (audit fallback, no whitelist available)'
+        if: ${{ vars.CONNECTION_WHITELIST == '' }}
+        # yamllint disable-line rule:line-length
+        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450  # v2.19.1
+        with:
+          egress-policy: 'audit'
 
       # yamllint disable-line rule:line-length
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
@@ -60,12 +76,28 @@ jobs:
       tag: "${{ steps.tag-validate.outputs.tag_name }}"
     steps:
       # Harden the runner used by this workflow
-      # yamllint disable-line rule:line-length
-      - uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450  # v2.19.1
+      # When the CONNECTION_WHITELIST repo/org variable is exposed
+      # to this run (i.e. not a fork PR), use it to enforce a
+      # block-mode egress policy.
+      - name: 'Harden runner (block egress with whitelist)'
+        if: ${{ vars.CONNECTION_WHITELIST != '' }}
+        # yamllint disable-line rule:line-length
+        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450  # v2.19.1
         with:
           egress-policy: 'block'
           allowed-endpoints: >
             ${{ vars.CONNECTION_WHITELIST }}
+
+      # Fallback for fork PRs and other contexts where the
+      # CONNECTION_WHITELIST variable is not exposed to the
+      # workflow.  Audit-only mode logs all egress without
+      # blocking it so CI still runs.
+      - name: 'Harden runner (audit fallback, no whitelist available)'
+        if: ${{ vars.CONNECTION_WHITELIST == '' }}
+        # yamllint disable-line rule:line-length
+        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450  # v2.19.1
+        with:
+          egress-policy: 'audit'
 
       - name: 'Checkout repository'
         # yamllint disable-line rule:line-length
@@ -128,12 +160,28 @@ jobs:
       GH_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
     steps:
       # Harden the runner used by this workflow
-      # yamllint disable-line rule:line-length
-      - uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450  # v2.19.1
+      # When the CONNECTION_WHITELIST repo/org variable is exposed
+      # to this run (i.e. not a fork PR), use it to enforce a
+      # block-mode egress policy.
+      - name: 'Harden runner (block egress with whitelist)'
+        if: ${{ vars.CONNECTION_WHITELIST != '' }}
+        # yamllint disable-line rule:line-length
+        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450  # v2.19.1
         with:
           egress-policy: 'block'
           allowed-endpoints: >
             ${{ vars.CONNECTION_WHITELIST }}
+
+      # Fallback for fork PRs and other contexts where the
+      # CONNECTION_WHITELIST variable is not exposed to the
+      # workflow.  Audit-only mode logs all egress without
+      # blocking it so CI still runs.
+      - name: 'Harden runner (audit fallback, no whitelist available)'
+        if: ${{ vars.CONNECTION_WHITELIST == '' }}
+        # yamllint disable-line rule:line-length
+        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450  # v2.19.1
+        with:
+          egress-policy: 'audit'
 
       # yamllint disable-line rule:line-length
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
@@ -159,12 +207,28 @@ jobs:
     timeout-minutes: 12
     steps:
       # Harden the runner used by this workflow
-      # yamllint disable-line rule:line-length
-      - uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450  # v2.19.1
+      # When the CONNECTION_WHITELIST repo/org variable is exposed
+      # to this run (i.e. not a fork PR), use it to enforce a
+      # block-mode egress policy.
+      - name: 'Harden runner (block egress with whitelist)'
+        if: ${{ vars.CONNECTION_WHITELIST != '' }}
+        # yamllint disable-line rule:line-length
+        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450  # v2.19.1
         with:
           egress-policy: 'block'
           allowed-endpoints: >
             ${{ vars.CONNECTION_WHITELIST }}
+
+      # Fallback for fork PRs and other contexts where the
+      # CONNECTION_WHITELIST variable is not exposed to the
+      # workflow.  Audit-only mode logs all egress without
+      # blocking it so CI still runs.
+      - name: 'Harden runner (audit fallback, no whitelist available)'
+        if: ${{ vars.CONNECTION_WHITELIST == '' }}
+        # yamllint disable-line rule:line-length
+        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450  # v2.19.1
+        with:
+          egress-policy: 'audit'
 
       # yamllint disable-line rule:line-length
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
@@ -188,12 +252,28 @@ jobs:
     timeout-minutes: 10
     steps:
       # Harden the runner used by this workflow
-      # yamllint disable-line rule:line-length
-      - uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450  # v2.19.1
+      # When the CONNECTION_WHITELIST repo/org variable is exposed
+      # to this run (i.e. not a fork PR), use it to enforce a
+      # block-mode egress policy.
+      - name: 'Harden runner (block egress with whitelist)'
+        if: ${{ vars.CONNECTION_WHITELIST != '' }}
+        # yamllint disable-line rule:line-length
+        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450  # v2.19.1
         with:
           egress-policy: 'block'
           allowed-endpoints: >
             ${{ vars.CONNECTION_WHITELIST }}
+
+      # Fallback for fork PRs and other contexts where the
+      # CONNECTION_WHITELIST variable is not exposed to the
+      # workflow.  Audit-only mode logs all egress without
+      # blocking it so CI still runs.
+      - name: 'Harden runner (audit fallback, no whitelist available)'
+        if: ${{ vars.CONNECTION_WHITELIST == '' }}
+        # yamllint disable-line rule:line-length
+        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450  # v2.19.1
+        with:
+          egress-policy: 'audit'
 
       # yamllint disable-line rule:line-length
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
@@ -214,12 +294,28 @@ jobs:
       contents: read
     steps:
       # Harden the runner used by this workflow
-      # yamllint disable-line rule:line-length
-      - uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450  # v2.19.1
+      # When the CONNECTION_WHITELIST repo/org variable is exposed
+      # to this run (i.e. not a fork PR), use it to enforce a
+      # block-mode egress policy.
+      - name: 'Harden runner (block egress with whitelist)'
+        if: ${{ vars.CONNECTION_WHITELIST != '' }}
+        # yamllint disable-line rule:line-length
+        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450  # v2.19.1
         with:
           egress-policy: 'block'
           allowed-endpoints: >
             ${{ vars.CONNECTION_WHITELIST }}
+
+      # Fallback for fork PRs and other contexts where the
+      # CONNECTION_WHITELIST variable is not exposed to the
+      # workflow.  Audit-only mode logs all egress without
+      # blocking it so CI still runs.
+      - name: 'Harden runner (audit fallback, no whitelist available)'
+        if: ${{ vars.CONNECTION_WHITELIST == '' }}
+        # yamllint disable-line rule:line-length
+        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450  # v2.19.1
+        with:
+          egress-policy: 'audit'
 
       # yamllint disable-line rule:line-length
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
@@ -260,12 +356,28 @@ jobs:
       contents: read
     steps:
       # Harden the runner used by this workflow
-      # yamllint disable-line rule:line-length
-      - uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450  # v2.19.1
+      # When the CONNECTION_WHITELIST repo/org variable is exposed
+      # to this run (i.e. not a fork PR), use it to enforce a
+      # block-mode egress policy.
+      - name: 'Harden runner (block egress with whitelist)'
+        if: ${{ vars.CONNECTION_WHITELIST != '' }}
+        # yamllint disable-line rule:line-length
+        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450  # v2.19.1
         with:
           egress-policy: 'block'
           allowed-endpoints: >
             ${{ vars.CONNECTION_WHITELIST }}
+
+      # Fallback for fork PRs and other contexts where the
+      # CONNECTION_WHITELIST variable is not exposed to the
+      # workflow.  Audit-only mode logs all egress without
+      # blocking it so CI still runs.
+      - name: 'Harden runner (audit fallback, no whitelist available)'
+        if: ${{ vars.CONNECTION_WHITELIST == '' }}
+        # yamllint disable-line rule:line-length
+        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450  # v2.19.1
+        with:
+          egress-policy: 'audit'
 
       - name: "Download SBOM artefact"
         # yamllint disable-line rule:line-length
@@ -433,12 +545,28 @@ jobs:
     timeout-minutes: 5
     steps:
       # Harden the runner used by this workflow
-      # yamllint disable-line rule:line-length
-      - uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450  # v2.19.1
+      # When the CONNECTION_WHITELIST repo/org variable is exposed
+      # to this run (i.e. not a fork PR), use it to enforce a
+      # block-mode egress policy.
+      - name: 'Harden runner (block egress with whitelist)'
+        if: ${{ vars.CONNECTION_WHITELIST != '' }}
+        # yamllint disable-line rule:line-length
+        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450  # v2.19.1
         with:
           egress-policy: 'block'
           allowed-endpoints: >
             ${{ vars.CONNECTION_WHITELIST }}
+
+      # Fallback for fork PRs and other contexts where the
+      # CONNECTION_WHITELIST variable is not exposed to the
+      # workflow.  Audit-only mode logs all egress without
+      # blocking it so CI still runs.
+      - name: 'Harden runner (audit fallback, no whitelist available)'
+        if: ${{ vars.CONNECTION_WHITELIST == '' }}
+        # yamllint disable-line rule:line-length
+        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450  # v2.19.1
+        with:
+          egress-policy: 'audit'
 
       - name: 'Test PyPI publishing'
         # yamllint disable-line rule:line-length
@@ -462,12 +590,28 @@ jobs:
     timeout-minutes: 5
     steps:
       # Harden the runner used by this workflow
-      # yamllint disable-line rule:line-length
-      - uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450  # v2.19.1
+      # When the CONNECTION_WHITELIST repo/org variable is exposed
+      # to this run (i.e. not a fork PR), use it to enforce a
+      # block-mode egress policy.
+      - name: 'Harden runner (block egress with whitelist)'
+        if: ${{ vars.CONNECTION_WHITELIST != '' }}
+        # yamllint disable-line rule:line-length
+        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450  # v2.19.1
         with:
           egress-policy: 'block'
           allowed-endpoints: >
             ${{ vars.CONNECTION_WHITELIST }}
+
+      # Fallback for fork PRs and other contexts where the
+      # CONNECTION_WHITELIST variable is not exposed to the
+      # workflow.  Audit-only mode logs all egress without
+      # blocking it so CI still runs.
+      - name: 'Harden runner (audit fallback, no whitelist available)'
+        if: ${{ vars.CONNECTION_WHITELIST == '' }}
+        # yamllint disable-line rule:line-length
+        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450  # v2.19.1
+        with:
+          egress-policy: 'audit'
 
       - name: 'PyPI release'
         # yamllint disable-line rule:line-length
@@ -501,12 +645,28 @@ jobs:
       GH_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
     steps:
       # Harden the runner used by this workflow
-      # yamllint disable-line rule:line-length
-      - uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450  # v2.19.1
+      # When the CONNECTION_WHITELIST repo/org variable is exposed
+      # to this run (i.e. not a fork PR), use it to enforce a
+      # block-mode egress policy.
+      - name: 'Harden runner (block egress with whitelist)'
+        if: ${{ vars.CONNECTION_WHITELIST != '' }}
+        # yamllint disable-line rule:line-length
+        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450  # v2.19.1
         with:
           egress-policy: 'block'
           allowed-endpoints: >
             ${{ vars.CONNECTION_WHITELIST }}
+
+      # Fallback for fork PRs and other contexts where the
+      # CONNECTION_WHITELIST variable is not exposed to the
+      # workflow.  Audit-only mode logs all egress without
+      # blocking it so CI still runs.
+      - name: 'Harden runner (audit fallback, no whitelist available)'
+        if: ${{ vars.CONNECTION_WHITELIST == '' }}
+        # yamllint disable-line rule:line-length
+        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450  # v2.19.1
+        with:
+          egress-policy: 'audit'
 
       # yamllint disable-line rule:line-length
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
@@ -541,12 +701,28 @@ jobs:
       release_url: "${{ steps.promote-release.outputs.release_url || steps.set-promoted-url.outputs.release_url }}"
     steps:
       # Harden the runner used by this workflow
-      # yamllint disable-line rule:line-length
-      - uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450  # v2.19.1
+      # When the CONNECTION_WHITELIST repo/org variable is exposed
+      # to this run (i.e. not a fork PR), use it to enforce a
+      # block-mode egress policy.
+      - name: 'Harden runner (block egress with whitelist)'
+        if: ${{ vars.CONNECTION_WHITELIST != '' }}
+        # yamllint disable-line rule:line-length
+        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450  # v2.19.1
         with:
           egress-policy: 'block'
           allowed-endpoints: >
             ${{ vars.CONNECTION_WHITELIST }}
+
+      # Fallback for fork PRs and other contexts where the
+      # CONNECTION_WHITELIST variable is not exposed to the
+      # workflow.  Audit-only mode logs all egress without
+      # blocking it so CI still runs.
+      - name: 'Harden runner (audit fallback, no whitelist available)'
+        if: ${{ vars.CONNECTION_WHITELIST == '' }}
+        # yamllint disable-line rule:line-length
+        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450  # v2.19.1
+        with:
+          egress-policy: 'audit'
 
       # yamllint disable-line rule:line-length
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -40,12 +40,28 @@ jobs:
       pull-requests: read
     timeout-minutes: 5
     steps:
-      # yamllint disable-line rule:line-length
-      - uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450  # v2.19.1
+      # When the CONNECTION_WHITELIST repo/org variable is exposed
+      # to this run (i.e. not a fork PR), use it to enforce a
+      # block-mode egress policy.
+      - name: 'Harden runner (block egress with whitelist)'
+        if: ${{ vars.CONNECTION_WHITELIST != '' }}
+        # yamllint disable-line rule:line-length
+        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450  # v2.19.1
         with:
           egress-policy: 'block'
           allowed-endpoints: >
             ${{ vars.CONNECTION_WHITELIST }}
+
+      # Fallback for fork PRs and other contexts where the
+      # CONNECTION_WHITELIST variable is not exposed to the
+      # workflow.  Audit-only mode logs all egress without
+      # blocking it so CI still runs.
+      - name: 'Harden runner (audit fallback, no whitelist available)'
+        if: ${{ vars.CONNECTION_WHITELIST == '' }}
+        # yamllint disable-line rule:line-length
+        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450  # v2.19.1
+        with:
+          egress-policy: 'audit'
 
       # yamllint disable-line rule:line-length
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
@@ -76,12 +92,28 @@ jobs:
     env:
       GH_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
     steps:
-      # yamllint disable-line rule:line-length
-      - uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450  # v2.19.1
+      # When the CONNECTION_WHITELIST repo/org variable is exposed
+      # to this run (i.e. not a fork PR), use it to enforce a
+      # block-mode egress policy.
+      - name: 'Harden runner (block egress with whitelist)'
+        if: ${{ vars.CONNECTION_WHITELIST != '' }}
+        # yamllint disable-line rule:line-length
+        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450  # v2.19.1
         with:
           egress-policy: 'block'
           allowed-endpoints: >
             ${{ vars.CONNECTION_WHITELIST }}
+
+      # Fallback for fork PRs and other contexts where the
+      # CONNECTION_WHITELIST variable is not exposed to the
+      # workflow.  Audit-only mode logs all egress without
+      # blocking it so CI still runs.
+      - name: 'Harden runner (audit fallback, no whitelist available)'
+        if: ${{ vars.CONNECTION_WHITELIST == '' }}
+        # yamllint disable-line rule:line-length
+        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450  # v2.19.1
+        with:
+          egress-policy: 'audit'
 
       - name: 'Clear Python dependency caches'
         env:
@@ -161,12 +193,28 @@ jobs:
     timeout-minutes: 12
     steps:
       # Harden the runner used by this workflow
-      # yamllint disable-line rule:line-length
-      - uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450  # v2.19.1
+      # When the CONNECTION_WHITELIST repo/org variable is exposed
+      # to this run (i.e. not a fork PR), use it to enforce a
+      # block-mode egress policy.
+      - name: 'Harden runner (block egress with whitelist)'
+        if: ${{ vars.CONNECTION_WHITELIST != '' }}
+        # yamllint disable-line rule:line-length
+        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450  # v2.19.1
         with:
           egress-policy: 'block'
           allowed-endpoints: >
             ${{ vars.CONNECTION_WHITELIST }}
+
+      # Fallback for fork PRs and other contexts where the
+      # CONNECTION_WHITELIST variable is not exposed to the
+      # workflow.  Audit-only mode logs all egress without
+      # blocking it so CI still runs.
+      - name: 'Harden runner (audit fallback, no whitelist available)'
+        if: ${{ vars.CONNECTION_WHITELIST == '' }}
+        # yamllint disable-line rule:line-length
+        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450  # v2.19.1
+        with:
+          egress-policy: 'audit'
 
       # yamllint disable-line rule:line-length
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
@@ -190,12 +238,28 @@ jobs:
     timeout-minutes: 12
     steps:
       # Harden the runner used by this workflow
-      # yamllint disable-line rule:line-length
-      - uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450  # v2.19.1
+      # When the CONNECTION_WHITELIST repo/org variable is exposed
+      # to this run (i.e. not a fork PR), use it to enforce a
+      # block-mode egress policy.
+      - name: 'Harden runner (block egress with whitelist)'
+        if: ${{ vars.CONNECTION_WHITELIST != '' }}
+        # yamllint disable-line rule:line-length
+        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450  # v2.19.1
         with:
           egress-policy: 'block'
           allowed-endpoints: >
             ${{ vars.CONNECTION_WHITELIST }}
+
+      # Fallback for fork PRs and other contexts where the
+      # CONNECTION_WHITELIST variable is not exposed to the
+      # workflow.  Audit-only mode logs all egress without
+      # blocking it so CI still runs.
+      - name: 'Harden runner (audit fallback, no whitelist available)'
+        if: ${{ vars.CONNECTION_WHITELIST == '' }}
+        # yamllint disable-line rule:line-length
+        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450  # v2.19.1
+        with:
+          egress-policy: 'audit'
 
       # yamllint disable-line rule:line-length
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
@@ -220,12 +284,28 @@ jobs:
     timeout-minutes: 10
     steps:
       # Harden the runner used by this workflow
-      # yamllint disable-line rule:line-length
-      - uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450  # v2.19.1
+      # When the CONNECTION_WHITELIST repo/org variable is exposed
+      # to this run (i.e. not a fork PR), use it to enforce a
+      # block-mode egress policy.
+      - name: 'Harden runner (block egress with whitelist)'
+        if: ${{ vars.CONNECTION_WHITELIST != '' }}
+        # yamllint disable-line rule:line-length
+        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450  # v2.19.1
         with:
           egress-policy: 'block'
           allowed-endpoints: >
             ${{ vars.CONNECTION_WHITELIST }}
+
+      # Fallback for fork PRs and other contexts where the
+      # CONNECTION_WHITELIST variable is not exposed to the
+      # workflow.  Audit-only mode logs all egress without
+      # blocking it so CI still runs.
+      - name: 'Harden runner (audit fallback, no whitelist available)'
+        if: ${{ vars.CONNECTION_WHITELIST == '' }}
+        # yamllint disable-line rule:line-length
+        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450  # v2.19.1
+        with:
+          egress-policy: 'audit'
 
       # yamllint disable-line rule:line-length
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
@@ -247,12 +327,28 @@ jobs:
       contents: read
     steps:
       # Harden the runner used by this workflow
-      # yamllint disable-line rule:line-length
-      - uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450  # v2.19.1
+      # When the CONNECTION_WHITELIST repo/org variable is exposed
+      # to this run (i.e. not a fork PR), use it to enforce a
+      # block-mode egress policy.
+      - name: 'Harden runner (block egress with whitelist)'
+        if: ${{ vars.CONNECTION_WHITELIST != '' }}
+        # yamllint disable-line rule:line-length
+        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450  # v2.19.1
         with:
           egress-policy: 'block'
           allowed-endpoints: >
             ${{ vars.CONNECTION_WHITELIST }}
+
+      # Fallback for fork PRs and other contexts where the
+      # CONNECTION_WHITELIST variable is not exposed to the
+      # workflow.  Audit-only mode logs all egress without
+      # blocking it so CI still runs.
+      - name: 'Harden runner (audit fallback, no whitelist available)'
+        if: ${{ vars.CONNECTION_WHITELIST == '' }}
+        # yamllint disable-line rule:line-length
+        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450  # v2.19.1
+        with:
+          egress-policy: 'audit'
 
       # yamllint disable-line rule:line-length
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
@@ -294,12 +390,28 @@ jobs:
       contents: read
     steps:
       # Harden the runner used by this workflow
-      # yamllint disable-line rule:line-length
-      - uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450  # v2.19.1
+      # When the CONNECTION_WHITELIST repo/org variable is exposed
+      # to this run (i.e. not a fork PR), use it to enforce a
+      # block-mode egress policy.
+      - name: 'Harden runner (block egress with whitelist)'
+        if: ${{ vars.CONNECTION_WHITELIST != '' }}
+        # yamllint disable-line rule:line-length
+        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450  # v2.19.1
         with:
           egress-policy: 'block'
           allowed-endpoints: >
             ${{ vars.CONNECTION_WHITELIST }}
+
+      # Fallback for fork PRs and other contexts where the
+      # CONNECTION_WHITELIST variable is not exposed to the
+      # workflow.  Audit-only mode logs all egress without
+      # blocking it so CI still runs.
+      - name: 'Harden runner (audit fallback, no whitelist available)'
+        if: ${{ vars.CONNECTION_WHITELIST == '' }}
+        # yamllint disable-line rule:line-length
+        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450  # v2.19.1
+        with:
+          egress-policy: 'audit'
 
       - name: "Download SBOM artefact"
         # yamllint disable-line rule:line-length

--- a/.github/workflows/release-drafter.yaml
+++ b/.github/workflows/release-drafter.yaml
@@ -26,12 +26,28 @@ jobs:
     timeout-minutes: 3
     steps:
       # Harden the runner used by this workflow
-      # yamllint disable-line rule:line-length
-      - uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450  # v2.19.1
+      # When the CONNECTION_WHITELIST repo/org variable is exposed
+      # to this run (i.e. not a fork PR), use it to enforce a
+      # block-mode egress policy.
+      - name: 'Harden runner (block egress with whitelist)'
+        if: ${{ vars.CONNECTION_WHITELIST != '' }}
+        # yamllint disable-line rule:line-length
+        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450  # v2.19.1
         with:
           egress-policy: 'block'
           allowed-endpoints: >
             ${{ vars.CONNECTION_WHITELIST }}
+
+      # Fallback for fork PRs and other contexts where the
+      # CONNECTION_WHITELIST variable is not exposed to the
+      # workflow.  Audit-only mode logs all egress without
+      # blocking it so CI still runs.
+      - name: 'Harden runner (audit fallback, no whitelist available)'
+        if: ${{ vars.CONNECTION_WHITELIST == '' }}
+        # yamllint disable-line rule:line-length
+        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450  # v2.19.1
+        with:
+          egress-policy: 'audit'
 
       # yamllint disable-line rule:line-length
       - uses: release-drafter/release-drafter@c2e2804cc59f45f57076a99af580d0fedb697927  # v7.3.0


### PR DESCRIPTION
## Summary

Both currently-open PRs to `lfit/dependamerge` (#277 and #285)
are blocked because they were raised from forks, where the
`CONNECTION_WHITELIST` repo/org variable is not exposed to the
workflow.  When the `allowed-endpoints` input to
`step-security/harden-runner` is empty, block-mode egress refuses
every outbound connection — uv installs, audit downloads, image
fetches, etc. all fail before doing useful work.

This PR replaces each existing single `harden-runner` step with
a conditional pair:

- **block-mode** step gated on `vars.CONNECTION_WHITELIST != ''`
- **audit-mode fallback** step gated on
  `vars.CONNECTION_WHITELIST == ''`

GitHub evaluates both `if` expressions independently and runs
exactly one step.  When the variable is present (push to main,
internal branches) we keep the existing strict block-mode policy
unchanged.  When the variable is absent (fork PRs) we fall back
to **audit-only**, which logs every egress destination without
blocking it so the job still runs.  The audit log is still
attached to the run and remains available for review.

## Why audit-only for fork PRs

Fork PRs cannot leverage the org-curated whitelist anyway, so
the realistic alternatives are:

1. **Block everything** (status quo) — every fork PR fails CI.
   Contributors can't get review feedback on automation
   workflows.
2. **Audit-only fallback** (this PR) — fork PRs run normally;
   egress destinations are recorded for post-hoc review.
3. **Hard-coded fork-PR whitelist** — would need ongoing
   maintenance and would still drift from the canonical list.

Option 2 is the standard step-security pattern for this case
and matches what other LF projects use.

## Sites updated

20 `harden-runner` blocks across 4 workflow files:

| File | Blocks |
|------|--------|
| `.github/workflows/autolabeler.yaml` | 1 |
| `.github/workflows/build-test-release.yaml` | 11 |
| `.github/workflows/build-test.yaml` | 7 |
| `.github/workflows/release-drafter.yaml` | 1 |

Same `step-security/harden-runner` SHA pin
(`a5ad31d6a139d249332a2605b85202e8c0b78450`, v2.19.1) preserved
on every site.  No other behavioural changes.

## Validation

- **actionlint**: clean for all modified files.
- **yamllint**: clean for all modified files (the 2 remaining
  warnings in `openssf-scorecard.yaml` are pre-existing and
  unrelated).
- **pre-commit**: all hooks pass on the commit.

Once this lands, rebasing #277 and #285 onto `main` should
unblock their CI.

## Diff shape (per-site)

```diff
-      # yamllint disable-line rule:line-length
-      - uses: step-security/harden-runner@<sha>  # v2.19.1
-        with:
-          egress-policy: 'block'
-          allowed-endpoints: >
-            ${{ vars.CONNECTION_WHITELIST }}
+      # When the CONNECTION_WHITELIST repo/org variable is exposed
+      # to this run (i.e. not a fork PR), use it to enforce a
+      # block-mode egress policy.
+      - name: 'Harden runner (block egress with whitelist)'
+        if: ${{ vars.CONNECTION_WHITELIST != '' }}
+        # yamllint disable-line rule:line-length
+        uses: step-security/harden-runner@<sha>  # v2.19.1
+        with:
+          egress-policy: 'block'
+          allowed-endpoints: >
+            ${{ vars.CONNECTION_WHITELIST }}
+
+      # Fallback for fork PRs and other contexts where the
+      # CONNECTION_WHITELIST variable is not exposed to the
+      # workflow.  Audit-only mode logs all egress without
+      # blocking it so CI still runs.
+      - name: 'Harden runner (audit fallback, no whitelist available)'
+        if: ${{ vars.CONNECTION_WHITELIST == '' }}
+        # yamllint disable-line rule:line-length
+        uses: step-security/harden-runner@<sha>  # v2.19.1
+        with:
+          egress-policy: 'audit'
```
