### PR TITLE
CI: Add harden-runner-block-action to load egress allow-list

### DIFF
--- a/.github/workflows/autolabeler.yaml
+++ b/.github/workflows/autolabeler.yaml
@@ -76,6 +76,23 @@ jobs:
       # When the CONNECTION_WHITELIST repo/org variable is exposed
       # to this run (i.e. not a fork PR), use it to enforce a
       # block-mode egress policy.
+      # Load the egress allow-list out-of-band from
+      # lfreleng-actions/.github so harden-runner can run in 'block' mode
+      # without depending on the org-level vars.CONNECTION_WHITELIST being
+      # reachable from this workflow (it is not, for PRs raised from
+      # forks). Publishes the sanitised list as $CONNECTION_WHITELIST for
+      # downstream steps to consume in a follow-up change.
+      #
+      # Temporarily pinned to a branch in a fork because the action
+      # is still under review in
+      # lfreleng-actions/harden-runner-block-action#5. Once that PR
+      # merges and is tagged, update this 'uses:' to a tagged release
+      # in lfreleng-actions/.
+      # yamllint disable-line rule:line-length
+      - uses: ModeSevenIndustrialSolutions/harden-runner-block-action@feat/whitelist-loader
+        with:
+          org: 'lfreleng-actions'
+
       - name: 'Harden runner (block egress with whitelist)'
         if: ${{ vars.CONNECTION_WHITELIST != '' }}
         # yamllint disable-line rule:line-length

--- a/.github/workflows/build-test-release.yaml
+++ b/.github/workflows/build-test-release.yaml
@@ -30,6 +30,23 @@ jobs:
       # When the CONNECTION_WHITELIST repo/org variable is exposed
       # to this run (i.e. not a fork PR), use it to enforce a
       # block-mode egress policy.
+      # Load the egress allow-list out-of-band from
+      # lfreleng-actions/.github so harden-runner can run in 'block' mode
+      # without depending on the org-level vars.CONNECTION_WHITELIST being
+      # reachable from this workflow (it is not, for PRs raised from
+      # forks). Publishes the sanitised list as $CONNECTION_WHITELIST for
+      # downstream steps to consume in a follow-up change.
+      #
+      # Temporarily pinned to a branch in a fork because the action
+      # is still under review in
+      # lfreleng-actions/harden-runner-block-action#5. Once that PR
+      # merges and is tagged, update this 'uses:' to a tagged release
+      # in lfreleng-actions/.
+      # yamllint disable-line rule:line-length
+      - uses: ModeSevenIndustrialSolutions/harden-runner-block-action@feat/whitelist-loader
+        with:
+          org: 'lfreleng-actions'
+
       - name: 'Harden runner (block egress with whitelist)'
         if: ${{ vars.CONNECTION_WHITELIST != '' }}
         # yamllint disable-line rule:line-length
@@ -79,6 +96,23 @@ jobs:
       # When the CONNECTION_WHITELIST repo/org variable is exposed
       # to this run (i.e. not a fork PR), use it to enforce a
       # block-mode egress policy.
+      # Load the egress allow-list out-of-band from
+      # lfreleng-actions/.github so harden-runner can run in 'block' mode
+      # without depending on the org-level vars.CONNECTION_WHITELIST being
+      # reachable from this workflow (it is not, for PRs raised from
+      # forks). Publishes the sanitised list as $CONNECTION_WHITELIST for
+      # downstream steps to consume in a follow-up change.
+      #
+      # Temporarily pinned to a branch in a fork because the action
+      # is still under review in
+      # lfreleng-actions/harden-runner-block-action#5. Once that PR
+      # merges and is tagged, update this 'uses:' to a tagged release
+      # in lfreleng-actions/.
+      # yamllint disable-line rule:line-length
+      - uses: ModeSevenIndustrialSolutions/harden-runner-block-action@feat/whitelist-loader
+        with:
+          org: 'lfreleng-actions'
+
       - name: 'Harden runner (block egress with whitelist)'
         if: ${{ vars.CONNECTION_WHITELIST != '' }}
         # yamllint disable-line rule:line-length
@@ -163,6 +197,23 @@ jobs:
       # When the CONNECTION_WHITELIST repo/org variable is exposed
       # to this run (i.e. not a fork PR), use it to enforce a
       # block-mode egress policy.
+      # Load the egress allow-list out-of-band from
+      # lfreleng-actions/.github so harden-runner can run in 'block' mode
+      # without depending on the org-level vars.CONNECTION_WHITELIST being
+      # reachable from this workflow (it is not, for PRs raised from
+      # forks). Publishes the sanitised list as $CONNECTION_WHITELIST for
+      # downstream steps to consume in a follow-up change.
+      #
+      # Temporarily pinned to a branch in a fork because the action
+      # is still under review in
+      # lfreleng-actions/harden-runner-block-action#5. Once that PR
+      # merges and is tagged, update this 'uses:' to a tagged release
+      # in lfreleng-actions/.
+      # yamllint disable-line rule:line-length
+      - uses: ModeSevenIndustrialSolutions/harden-runner-block-action@feat/whitelist-loader
+        with:
+          org: 'lfreleng-actions'
+
       - name: 'Harden runner (block egress with whitelist)'
         if: ${{ vars.CONNECTION_WHITELIST != '' }}
         # yamllint disable-line rule:line-length
@@ -210,6 +261,23 @@ jobs:
       # When the CONNECTION_WHITELIST repo/org variable is exposed
       # to this run (i.e. not a fork PR), use it to enforce a
       # block-mode egress policy.
+      # Load the egress allow-list out-of-band from
+      # lfreleng-actions/.github so harden-runner can run in 'block' mode
+      # without depending on the org-level vars.CONNECTION_WHITELIST being
+      # reachable from this workflow (it is not, for PRs raised from
+      # forks). Publishes the sanitised list as $CONNECTION_WHITELIST for
+      # downstream steps to consume in a follow-up change.
+      #
+      # Temporarily pinned to a branch in a fork because the action
+      # is still under review in
+      # lfreleng-actions/harden-runner-block-action#5. Once that PR
+      # merges and is tagged, update this 'uses:' to a tagged release
+      # in lfreleng-actions/.
+      # yamllint disable-line rule:line-length
+      - uses: ModeSevenIndustrialSolutions/harden-runner-block-action@feat/whitelist-loader
+        with:
+          org: 'lfreleng-actions'
+
       - name: 'Harden runner (block egress with whitelist)'
         if: ${{ vars.CONNECTION_WHITELIST != '' }}
         # yamllint disable-line rule:line-length
@@ -255,6 +323,23 @@ jobs:
       # When the CONNECTION_WHITELIST repo/org variable is exposed
       # to this run (i.e. not a fork PR), use it to enforce a
       # block-mode egress policy.
+      # Load the egress allow-list out-of-band from
+      # lfreleng-actions/.github so harden-runner can run in 'block' mode
+      # without depending on the org-level vars.CONNECTION_WHITELIST being
+      # reachable from this workflow (it is not, for PRs raised from
+      # forks). Publishes the sanitised list as $CONNECTION_WHITELIST for
+      # downstream steps to consume in a follow-up change.
+      #
+      # Temporarily pinned to a branch in a fork because the action
+      # is still under review in
+      # lfreleng-actions/harden-runner-block-action#5. Once that PR
+      # merges and is tagged, update this 'uses:' to a tagged release
+      # in lfreleng-actions/.
+      # yamllint disable-line rule:line-length
+      - uses: ModeSevenIndustrialSolutions/harden-runner-block-action@feat/whitelist-loader
+        with:
+          org: 'lfreleng-actions'
+
       - name: 'Harden runner (block egress with whitelist)'
         if: ${{ vars.CONNECTION_WHITELIST != '' }}
         # yamllint disable-line rule:line-length
@@ -297,6 +382,23 @@ jobs:
       # When the CONNECTION_WHITELIST repo/org variable is exposed
       # to this run (i.e. not a fork PR), use it to enforce a
       # block-mode egress policy.
+      # Load the egress allow-list out-of-band from
+      # lfreleng-actions/.github so harden-runner can run in 'block' mode
+      # without depending on the org-level vars.CONNECTION_WHITELIST being
+      # reachable from this workflow (it is not, for PRs raised from
+      # forks). Publishes the sanitised list as $CONNECTION_WHITELIST for
+      # downstream steps to consume in a follow-up change.
+      #
+      # Temporarily pinned to a branch in a fork because the action
+      # is still under review in
+      # lfreleng-actions/harden-runner-block-action#5. Once that PR
+      # merges and is tagged, update this 'uses:' to a tagged release
+      # in lfreleng-actions/.
+      # yamllint disable-line rule:line-length
+      - uses: ModeSevenIndustrialSolutions/harden-runner-block-action@feat/whitelist-loader
+        with:
+          org: 'lfreleng-actions'
+
       - name: 'Harden runner (block egress with whitelist)'
         if: ${{ vars.CONNECTION_WHITELIST != '' }}
         # yamllint disable-line rule:line-length
@@ -359,6 +461,23 @@ jobs:
       # When the CONNECTION_WHITELIST repo/org variable is exposed
       # to this run (i.e. not a fork PR), use it to enforce a
       # block-mode egress policy.
+      # Load the egress allow-list out-of-band from
+      # lfreleng-actions/.github so harden-runner can run in 'block' mode
+      # without depending on the org-level vars.CONNECTION_WHITELIST being
+      # reachable from this workflow (it is not, for PRs raised from
+      # forks). Publishes the sanitised list as $CONNECTION_WHITELIST for
+      # downstream steps to consume in a follow-up change.
+      #
+      # Temporarily pinned to a branch in a fork because the action
+      # is still under review in
+      # lfreleng-actions/harden-runner-block-action#5. Once that PR
+      # merges and is tagged, update this 'uses:' to a tagged release
+      # in lfreleng-actions/.
+      # yamllint disable-line rule:line-length
+      - uses: ModeSevenIndustrialSolutions/harden-runner-block-action@feat/whitelist-loader
+        with:
+          org: 'lfreleng-actions'
+
       - name: 'Harden runner (block egress with whitelist)'
         if: ${{ vars.CONNECTION_WHITELIST != '' }}
         # yamllint disable-line rule:line-length
@@ -548,6 +667,23 @@ jobs:
       # When the CONNECTION_WHITELIST repo/org variable is exposed
       # to this run (i.e. not a fork PR), use it to enforce a
       # block-mode egress policy.
+      # Load the egress allow-list out-of-band from
+      # lfreleng-actions/.github so harden-runner can run in 'block' mode
+      # without depending on the org-level vars.CONNECTION_WHITELIST being
+      # reachable from this workflow (it is not, for PRs raised from
+      # forks). Publishes the sanitised list as $CONNECTION_WHITELIST for
+      # downstream steps to consume in a follow-up change.
+      #
+      # Temporarily pinned to a branch in a fork because the action
+      # is still under review in
+      # lfreleng-actions/harden-runner-block-action#5. Once that PR
+      # merges and is tagged, update this 'uses:' to a tagged release
+      # in lfreleng-actions/.
+      # yamllint disable-line rule:line-length
+      - uses: ModeSevenIndustrialSolutions/harden-runner-block-action@feat/whitelist-loader
+        with:
+          org: 'lfreleng-actions'
+
       - name: 'Harden runner (block egress with whitelist)'
         if: ${{ vars.CONNECTION_WHITELIST != '' }}
         # yamllint disable-line rule:line-length
@@ -593,6 +729,23 @@ jobs:
       # When the CONNECTION_WHITELIST repo/org variable is exposed
       # to this run (i.e. not a fork PR), use it to enforce a
       # block-mode egress policy.
+      # Load the egress allow-list out-of-band from
+      # lfreleng-actions/.github so harden-runner can run in 'block' mode
+      # without depending on the org-level vars.CONNECTION_WHITELIST being
+      # reachable from this workflow (it is not, for PRs raised from
+      # forks). Publishes the sanitised list as $CONNECTION_WHITELIST for
+      # downstream steps to consume in a follow-up change.
+      #
+      # Temporarily pinned to a branch in a fork because the action
+      # is still under review in
+      # lfreleng-actions/harden-runner-block-action#5. Once that PR
+      # merges and is tagged, update this 'uses:' to a tagged release
+      # in lfreleng-actions/.
+      # yamllint disable-line rule:line-length
+      - uses: ModeSevenIndustrialSolutions/harden-runner-block-action@feat/whitelist-loader
+        with:
+          org: 'lfreleng-actions'
+
       - name: 'Harden runner (block egress with whitelist)'
         if: ${{ vars.CONNECTION_WHITELIST != '' }}
         # yamllint disable-line rule:line-length
@@ -648,6 +801,23 @@ jobs:
       # When the CONNECTION_WHITELIST repo/org variable is exposed
       # to this run (i.e. not a fork PR), use it to enforce a
       # block-mode egress policy.
+      # Load the egress allow-list out-of-band from
+      # lfreleng-actions/.github so harden-runner can run in 'block' mode
+      # without depending on the org-level vars.CONNECTION_WHITELIST being
+      # reachable from this workflow (it is not, for PRs raised from
+      # forks). Publishes the sanitised list as $CONNECTION_WHITELIST for
+      # downstream steps to consume in a follow-up change.
+      #
+      # Temporarily pinned to a branch in a fork because the action
+      # is still under review in
+      # lfreleng-actions/harden-runner-block-action#5. Once that PR
+      # merges and is tagged, update this 'uses:' to a tagged release
+      # in lfreleng-actions/.
+      # yamllint disable-line rule:line-length
+      - uses: ModeSevenIndustrialSolutions/harden-runner-block-action@feat/whitelist-loader
+        with:
+          org: 'lfreleng-actions'
+
       - name: 'Harden runner (block egress with whitelist)'
         if: ${{ vars.CONNECTION_WHITELIST != '' }}
         # yamllint disable-line rule:line-length
@@ -704,6 +874,23 @@ jobs:
       # When the CONNECTION_WHITELIST repo/org variable is exposed
       # to this run (i.e. not a fork PR), use it to enforce a
       # block-mode egress policy.
+      # Load the egress allow-list out-of-band from
+      # lfreleng-actions/.github so harden-runner can run in 'block' mode
+      # without depending on the org-level vars.CONNECTION_WHITELIST being
+      # reachable from this workflow (it is not, for PRs raised from
+      # forks). Publishes the sanitised list as $CONNECTION_WHITELIST for
+      # downstream steps to consume in a follow-up change.
+      #
+      # Temporarily pinned to a branch in a fork because the action
+      # is still under review in
+      # lfreleng-actions/harden-runner-block-action#5. Once that PR
+      # merges and is tagged, update this 'uses:' to a tagged release
+      # in lfreleng-actions/.
+      # yamllint disable-line rule:line-length
+      - uses: ModeSevenIndustrialSolutions/harden-runner-block-action@feat/whitelist-loader
+        with:
+          org: 'lfreleng-actions'
+
       - name: 'Harden runner (block egress with whitelist)'
         if: ${{ vars.CONNECTION_WHITELIST != '' }}
         # yamllint disable-line rule:line-length

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -43,6 +43,23 @@ jobs:
       # When the CONNECTION_WHITELIST repo/org variable is exposed
       # to this run (i.e. not a fork PR), use it to enforce a
       # block-mode egress policy.
+      # Load the egress allow-list out-of-band from
+      # lfreleng-actions/.github so harden-runner can run in 'block' mode
+      # without depending on the org-level vars.CONNECTION_WHITELIST being
+      # reachable from this workflow (it is not, for PRs raised from
+      # forks). Publishes the sanitised list as $CONNECTION_WHITELIST for
+      # downstream steps to consume in a follow-up change.
+      #
+      # Temporarily pinned to a branch in a fork because the action
+      # is still under review in
+      # lfreleng-actions/harden-runner-block-action#5. Once that PR
+      # merges and is tagged, update this 'uses:' to a tagged release
+      # in lfreleng-actions/.
+      # yamllint disable-line rule:line-length
+      - uses: ModeSevenIndustrialSolutions/harden-runner-block-action@feat/whitelist-loader
+        with:
+          org: 'lfreleng-actions'
+
       - name: 'Harden runner (block egress with whitelist)'
         if: ${{ vars.CONNECTION_WHITELIST != '' }}
         # yamllint disable-line rule:line-length
@@ -95,6 +112,23 @@ jobs:
       # When the CONNECTION_WHITELIST repo/org variable is exposed
       # to this run (i.e. not a fork PR), use it to enforce a
       # block-mode egress policy.
+      # Load the egress allow-list out-of-band from
+      # lfreleng-actions/.github so harden-runner can run in 'block' mode
+      # without depending on the org-level vars.CONNECTION_WHITELIST being
+      # reachable from this workflow (it is not, for PRs raised from
+      # forks). Publishes the sanitised list as $CONNECTION_WHITELIST for
+      # downstream steps to consume in a follow-up change.
+      #
+      # Temporarily pinned to a branch in a fork because the action
+      # is still under review in
+      # lfreleng-actions/harden-runner-block-action#5. Once that PR
+      # merges and is tagged, update this 'uses:' to a tagged release
+      # in lfreleng-actions/.
+      # yamllint disable-line rule:line-length
+      - uses: ModeSevenIndustrialSolutions/harden-runner-block-action@feat/whitelist-loader
+        with:
+          org: 'lfreleng-actions'
+
       - name: 'Harden runner (block egress with whitelist)'
         if: ${{ vars.CONNECTION_WHITELIST != '' }}
         # yamllint disable-line rule:line-length
@@ -196,6 +230,23 @@ jobs:
       # When the CONNECTION_WHITELIST repo/org variable is exposed
       # to this run (i.e. not a fork PR), use it to enforce a
       # block-mode egress policy.
+      # Load the egress allow-list out-of-band from
+      # lfreleng-actions/.github so harden-runner can run in 'block' mode
+      # without depending on the org-level vars.CONNECTION_WHITELIST being
+      # reachable from this workflow (it is not, for PRs raised from
+      # forks). Publishes the sanitised list as $CONNECTION_WHITELIST for
+      # downstream steps to consume in a follow-up change.
+      #
+      # Temporarily pinned to a branch in a fork because the action
+      # is still under review in
+      # lfreleng-actions/harden-runner-block-action#5. Once that PR
+      # merges and is tagged, update this 'uses:' to a tagged release
+      # in lfreleng-actions/.
+      # yamllint disable-line rule:line-length
+      - uses: ModeSevenIndustrialSolutions/harden-runner-block-action@feat/whitelist-loader
+        with:
+          org: 'lfreleng-actions'
+
       - name: 'Harden runner (block egress with whitelist)'
         if: ${{ vars.CONNECTION_WHITELIST != '' }}
         # yamllint disable-line rule:line-length
@@ -241,6 +292,23 @@ jobs:
       # When the CONNECTION_WHITELIST repo/org variable is exposed
       # to this run (i.e. not a fork PR), use it to enforce a
       # block-mode egress policy.
+      # Load the egress allow-list out-of-band from
+      # lfreleng-actions/.github so harden-runner can run in 'block' mode
+      # without depending on the org-level vars.CONNECTION_WHITELIST being
+      # reachable from this workflow (it is not, for PRs raised from
+      # forks). Publishes the sanitised list as $CONNECTION_WHITELIST for
+      # downstream steps to consume in a follow-up change.
+      #
+      # Temporarily pinned to a branch in a fork because the action
+      # is still under review in
+      # lfreleng-actions/harden-runner-block-action#5. Once that PR
+      # merges and is tagged, update this 'uses:' to a tagged release
+      # in lfreleng-actions/.
+      # yamllint disable-line rule:line-length
+      - uses: ModeSevenIndustrialSolutions/harden-runner-block-action@feat/whitelist-loader
+        with:
+          org: 'lfreleng-actions'
+
       - name: 'Harden runner (block egress with whitelist)'
         if: ${{ vars.CONNECTION_WHITELIST != '' }}
         # yamllint disable-line rule:line-length
@@ -287,6 +355,23 @@ jobs:
       # When the CONNECTION_WHITELIST repo/org variable is exposed
       # to this run (i.e. not a fork PR), use it to enforce a
       # block-mode egress policy.
+      # Load the egress allow-list out-of-band from
+      # lfreleng-actions/.github so harden-runner can run in 'block' mode
+      # without depending on the org-level vars.CONNECTION_WHITELIST being
+      # reachable from this workflow (it is not, for PRs raised from
+      # forks). Publishes the sanitised list as $CONNECTION_WHITELIST for
+      # downstream steps to consume in a follow-up change.
+      #
+      # Temporarily pinned to a branch in a fork because the action
+      # is still under review in
+      # lfreleng-actions/harden-runner-block-action#5. Once that PR
+      # merges and is tagged, update this 'uses:' to a tagged release
+      # in lfreleng-actions/.
+      # yamllint disable-line rule:line-length
+      - uses: ModeSevenIndustrialSolutions/harden-runner-block-action@feat/whitelist-loader
+        with:
+          org: 'lfreleng-actions'
+
       - name: 'Harden runner (block egress with whitelist)'
         if: ${{ vars.CONNECTION_WHITELIST != '' }}
         # yamllint disable-line rule:line-length
@@ -330,6 +415,23 @@ jobs:
       # When the CONNECTION_WHITELIST repo/org variable is exposed
       # to this run (i.e. not a fork PR), use it to enforce a
       # block-mode egress policy.
+      # Load the egress allow-list out-of-band from
+      # lfreleng-actions/.github so harden-runner can run in 'block' mode
+      # without depending on the org-level vars.CONNECTION_WHITELIST being
+      # reachable from this workflow (it is not, for PRs raised from
+      # forks). Publishes the sanitised list as $CONNECTION_WHITELIST for
+      # downstream steps to consume in a follow-up change.
+      #
+      # Temporarily pinned to a branch in a fork because the action
+      # is still under review in
+      # lfreleng-actions/harden-runner-block-action#5. Once that PR
+      # merges and is tagged, update this 'uses:' to a tagged release
+      # in lfreleng-actions/.
+      # yamllint disable-line rule:line-length
+      - uses: ModeSevenIndustrialSolutions/harden-runner-block-action@feat/whitelist-loader
+        with:
+          org: 'lfreleng-actions'
+
       - name: 'Harden runner (block egress with whitelist)'
         if: ${{ vars.CONNECTION_WHITELIST != '' }}
         # yamllint disable-line rule:line-length
@@ -393,6 +495,23 @@ jobs:
       # When the CONNECTION_WHITELIST repo/org variable is exposed
       # to this run (i.e. not a fork PR), use it to enforce a
       # block-mode egress policy.
+      # Load the egress allow-list out-of-band from
+      # lfreleng-actions/.github so harden-runner can run in 'block' mode
+      # without depending on the org-level vars.CONNECTION_WHITELIST being
+      # reachable from this workflow (it is not, for PRs raised from
+      # forks). Publishes the sanitised list as $CONNECTION_WHITELIST for
+      # downstream steps to consume in a follow-up change.
+      #
+      # Temporarily pinned to a branch in a fork because the action
+      # is still under review in
+      # lfreleng-actions/harden-runner-block-action#5. Once that PR
+      # merges and is tagged, update this 'uses:' to a tagged release
+      # in lfreleng-actions/.
+      # yamllint disable-line rule:line-length
+      - uses: ModeSevenIndustrialSolutions/harden-runner-block-action@feat/whitelist-loader
+        with:
+          org: 'lfreleng-actions'
+
       - name: 'Harden runner (block egress with whitelist)'
         if: ${{ vars.CONNECTION_WHITELIST != '' }}
         # yamllint disable-line rule:line-length

--- a/.github/workflows/release-drafter.yaml
+++ b/.github/workflows/release-drafter.yaml
@@ -29,6 +29,23 @@ jobs:
       # When the CONNECTION_WHITELIST repo/org variable is exposed
       # to this run (i.e. not a fork PR), use it to enforce a
       # block-mode egress policy.
+      # Load the egress allow-list out-of-band from
+      # lfreleng-actions/.github so harden-runner can run in 'block' mode
+      # without depending on the org-level vars.CONNECTION_WHITELIST being
+      # reachable from this workflow (it is not, for PRs raised from
+      # forks). Publishes the sanitised list as $CONNECTION_WHITELIST for
+      # downstream steps to consume in a follow-up change.
+      #
+      # Temporarily pinned to a branch in a fork because the action
+      # is still under review in
+      # lfreleng-actions/harden-runner-block-action#5. Once that PR
+      # merges and is tagged, update this 'uses:' to a tagged release
+      # in lfreleng-actions/.
+      # yamllint disable-line rule:line-length
+      - uses: ModeSevenIndustrialSolutions/harden-runner-block-action@feat/whitelist-loader
+        with:
+          org: 'lfreleng-actions'
+
       - name: 'Harden runner (block egress with whitelist)'
         if: ${{ vars.CONNECTION_WHITELIST != '' }}
         # yamllint disable-line rule:line-length


### PR DESCRIPTION
Insert a 'harden-runner-block-action' invocation immediately before each existing 'step-security/harden-runner' pair in the four workflows that gate harden-runner on the org-level vars.CONNECTION_WHITELIST variable.

The new action loads, sanitises, and exports an allowed-endpoints allow-list as $CONNECTION_WHITELIST. It fetches the list from lfreleng-actions/.github at .github/harden-runner/lfreleng-actions/ allow_list.txt via raw.githubusercontent.com, so it does NOT depend on vars.CONNECTION_WHITELIST being exposed to the workflow. Org-level GitHub variables are not reachable from workflows triggered by PRs raised from forks, so the existing 'block if var set else audit' pattern silently degrades to audit mode for fork PRs; the new action removes that limitation.

This commit is deliberately additive: the existing step-security/harden-runner pair is unchanged and still reads vars.CONNECTION_WHITELIST. A follow-up change can collapse the pair into a single block-mode invocation that reads
${{ env.CONNECTION_WHITELIST }} once this integration is validated in CI.

The 'uses:' line temporarily points at a branch in a personal fork because the action itself is still under review in lfreleng-actions/harden-runner-block-action#5. Update this to a tagged release in lfreleng-actions/ once that PR merges and is tagged.