### PR TITLE
CI: Replace legacy harden-runner pair with allow-list loader

### DIFF
--- a/.github/workflows/autolabeler.yaml
+++ b/.github/workflows/autolabeler.yaml
@@ -18,18 +18,28 @@ on:
   # manual-approval gating because:
   #
   #   1. The workflow performs no checkout of PR code
-  #      (no actions/checkout step).
+  #      (no actions/checkout step), so no PR-provided source
+  #      ever runs.
   #   2. The workflow body is loaded from the base branch
   #      (pull_request_target semantics), not from the PR head.
-  #   3. The only step is release-drafter/autolabeler, pinned to
-  #      a commit SHA, which is a pure GitHub-API consumer and
-  #      never executes PR-provided content.
+  #   3. Every step is pinned to a full commit SHA and is a
+  #      well-scoped, non-code-executing consumer:
+  #        - `lfreleng-actions/harden-runner-block-action`
+  #          fetches one allow-list file over HTTPS, sanitises
+  #          it, and publishes it as $CONNECTION_ALLOW_LIST.
+  #          No PR content is read or executed.
+  #        - `step-security/harden-runner` installs the egress
+  #          block filter from $CONNECTION_ALLOW_LIST. Pure
+  #          runner-hardening; reads no PR content.
+  #        - `release-drafter/autolabeler` makes only GitHub
+  #          API calls. No code execution, no PR content read.
   #   4. Permissions are scoped to the minimum needed:
   #      pull-requests: write and contents: read. No
   #      repository secrets are passed to the job beyond the
   #      default GITHUB_TOKEN, which the job receives with the
   #      permissions scope above and nothing more.
-  #   5. The runner is hardened with an egress block.
+  #   5. The runner is hardened with an egress block applied
+  #      before the autolabeler step runs.
   #
   # See the SECURITY block on the autolabel job below for the
   # full rationale. The zizmor `dangerous-triggers` audit is
@@ -72,29 +82,27 @@ jobs:
     runs-on: 'ubuntu-latest'
     timeout-minutes: 3
     steps:
-      # Harden the runner used by this workflow
-      # When the CONNECTION_WHITELIST repo/org variable is exposed
-      # to this run (i.e. not a fork PR), use it to enforce a
-      # block-mode egress policy.
-      - name: 'Harden runner (block egress with whitelist)'
-        if: ${{ vars.CONNECTION_WHITELIST != '' }}
+      # Load the egress allow-list out-of-band from
+      # lfreleng-actions/.github and publish it as
+      # $CONNECTION_ALLOW_LIST for the harden-runner step below
+      # to consume in 'block' mode. Loading out-of-band means
+      # the workflow no longer depends on any org-level GitHub
+      # variable being exposed at runtime (org variables are
+      # unreachable from workflows triggered by PRs raised from
+      # forks, which previously forced a fallback to audit mode).
+      # yamllint disable-line rule:line-length
+      - uses: lfreleng-actions/harden-runner-block-action@18993b53be1b9327579eb1a2ba318d8a22c39f72  # v0.1.0
+        with:
+          org: 'lfreleng-actions'
+
+      # Harden the runner with the just-loaded allow-list.
+      - name: 'Harden runner (block)'
         # yamllint disable-line rule:line-length
-        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5  # v2.19.3
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411  # v2.19.4
         with:
           egress-policy: 'block'
           allowed-endpoints: >
-            ${{ vars.CONNECTION_WHITELIST }}
-
-      # Fallback for fork PRs and other contexts where the
-      # CONNECTION_WHITELIST variable is not exposed to the
-      # workflow.  Audit-only mode logs all egress without
-      # blocking it so CI still runs.
-      - name: 'Harden runner (audit fallback, no whitelist available)'
-        if: ${{ vars.CONNECTION_WHITELIST == '' }}
-        # yamllint disable-line rule:line-length
-        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5  # v2.19.3
-        with:
-          egress-policy: 'audit'
+            ${{ env.CONNECTION_ALLOW_LIST }}
 
       # yamllint disable-line rule:line-length
-      - uses: release-drafter/release-drafter/autolabeler@c2e2804cc59f45f57076a99af580d0fedb697927  # v7.3.0
+      - uses: release-drafter/release-drafter/autolabeler@693d20e7c1ce1a81d3a41962f85914253b518449  # v7.3.1

--- a/.github/workflows/build-test-release.yaml
+++ b/.github/workflows/build-test-release.yaml
@@ -27,28 +27,27 @@ jobs:
       pull-requests: read
     timeout-minutes: 5
     steps:
-      # When the CONNECTION_WHITELIST repo/org variable is exposed
-      # to this run (i.e. not a fork PR), use it to enforce a
-      # block-mode egress policy.
-      - name: 'Harden runner (block egress with whitelist)'
-        if: ${{ vars.CONNECTION_WHITELIST != '' }}
+      # Load the egress allow-list out-of-band from
+      # lfreleng-actions/.github and publish it as
+      # $CONNECTION_ALLOW_LIST for the harden-runner step below
+      # to consume in 'block' mode. Loading out-of-band means
+      # the workflow no longer depends on any org-level GitHub
+      # variable being exposed at runtime (org variables are
+      # unreachable from workflows triggered by PRs raised from
+      # forks, which previously forced a fallback to audit mode).
+      # yamllint disable-line rule:line-length
+      - uses: lfreleng-actions/harden-runner-block-action@18993b53be1b9327579eb1a2ba318d8a22c39f72  # v0.1.0
+        with:
+          org: 'lfreleng-actions'
+
+      # Harden the runner with the just-loaded allow-list.
+      - name: 'Harden runner (block)'
         # yamllint disable-line rule:line-length
-        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5  # v2.19.3
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411  # v2.19.4
         with:
           egress-policy: 'block'
           allowed-endpoints: >
-            ${{ vars.CONNECTION_WHITELIST }}
-
-      # Fallback for fork PRs and other contexts where the
-      # CONNECTION_WHITELIST variable is not exposed to the
-      # workflow.  Audit-only mode logs all egress without
-      # blocking it so CI still runs.
-      - name: 'Harden runner (audit fallback, no whitelist available)'
-        if: ${{ vars.CONNECTION_WHITELIST == '' }}
-        # yamllint disable-line rule:line-length
-        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5  # v2.19.3
-        with:
-          egress-policy: 'audit'
+            ${{ env.CONNECTION_ALLOW_LIST }}
 
       # yamllint disable-line rule:line-length
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
@@ -75,29 +74,27 @@ jobs:
     outputs:
       tag: "${{ steps.tag-validate.outputs.tag_name }}"
     steps:
-      # Harden the runner used by this workflow
-      # When the CONNECTION_WHITELIST repo/org variable is exposed
-      # to this run (i.e. not a fork PR), use it to enforce a
-      # block-mode egress policy.
-      - name: 'Harden runner (block egress with whitelist)'
-        if: ${{ vars.CONNECTION_WHITELIST != '' }}
+      # Load the egress allow-list out-of-band from
+      # lfreleng-actions/.github and publish it as
+      # $CONNECTION_ALLOW_LIST for the harden-runner step below
+      # to consume in 'block' mode. Loading out-of-band means
+      # the workflow no longer depends on any org-level GitHub
+      # variable being exposed at runtime (org variables are
+      # unreachable from workflows triggered by PRs raised from
+      # forks, which previously forced a fallback to audit mode).
+      # yamllint disable-line rule:line-length
+      - uses: lfreleng-actions/harden-runner-block-action@18993b53be1b9327579eb1a2ba318d8a22c39f72  # v0.1.0
+        with:
+          org: 'lfreleng-actions'
+
+      # Harden the runner with the just-loaded allow-list.
+      - name: 'Harden runner (block)'
         # yamllint disable-line rule:line-length
-        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5  # v2.19.3
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411  # v2.19.4
         with:
           egress-policy: 'block'
           allowed-endpoints: >
-            ${{ vars.CONNECTION_WHITELIST }}
-
-      # Fallback for fork PRs and other contexts where the
-      # CONNECTION_WHITELIST variable is not exposed to the
-      # workflow.  Audit-only mode logs all egress without
-      # blocking it so CI still runs.
-      - name: 'Harden runner (audit fallback, no whitelist available)'
-        if: ${{ vars.CONNECTION_WHITELIST == '' }}
-        # yamllint disable-line rule:line-length
-        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5  # v2.19.3
-        with:
-          egress-policy: 'audit'
+            ${{ env.CONNECTION_ALLOW_LIST }}
 
       - name: 'Checkout repository'
         # yamllint disable-line rule:line-length
@@ -159,29 +156,27 @@ jobs:
     env:
       GH_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
     steps:
-      # Harden the runner used by this workflow
-      # When the CONNECTION_WHITELIST repo/org variable is exposed
-      # to this run (i.e. not a fork PR), use it to enforce a
-      # block-mode egress policy.
-      - name: 'Harden runner (block egress with whitelist)'
-        if: ${{ vars.CONNECTION_WHITELIST != '' }}
+      # Load the egress allow-list out-of-band from
+      # lfreleng-actions/.github and publish it as
+      # $CONNECTION_ALLOW_LIST for the harden-runner step below
+      # to consume in 'block' mode. Loading out-of-band means
+      # the workflow no longer depends on any org-level GitHub
+      # variable being exposed at runtime (org variables are
+      # unreachable from workflows triggered by PRs raised from
+      # forks, which previously forced a fallback to audit mode).
+      # yamllint disable-line rule:line-length
+      - uses: lfreleng-actions/harden-runner-block-action@18993b53be1b9327579eb1a2ba318d8a22c39f72  # v0.1.0
+        with:
+          org: 'lfreleng-actions'
+
+      # Harden the runner with the just-loaded allow-list.
+      - name: 'Harden runner (block)'
         # yamllint disable-line rule:line-length
-        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5  # v2.19.3
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411  # v2.19.4
         with:
           egress-policy: 'block'
           allowed-endpoints: >
-            ${{ vars.CONNECTION_WHITELIST }}
-
-      # Fallback for fork PRs and other contexts where the
-      # CONNECTION_WHITELIST variable is not exposed to the
-      # workflow.  Audit-only mode logs all egress without
-      # blocking it so CI still runs.
-      - name: 'Harden runner (audit fallback, no whitelist available)'
-        if: ${{ vars.CONNECTION_WHITELIST == '' }}
-        # yamllint disable-line rule:line-length
-        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5  # v2.19.3
-        with:
-          egress-policy: 'audit'
+            ${{ env.CONNECTION_ALLOW_LIST }}
 
       # yamllint disable-line rule:line-length
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
@@ -189,7 +184,7 @@ jobs:
       - name: 'Build Python project'
         id: 'python-build'
         # yamllint disable-line rule:line-length
-        uses: lfreleng-actions/python-build-action@38b9a4e7ee34e56d178f5bd248df52e41f7d496e  # v1.0.6
+        uses: lfreleng-actions/python-build-action@5f570d5d17a7315074a824a91c6a705b6fc5c7dd  # v1.1.2
         with:
           sigstore_sign: true
           attestations: true
@@ -206,29 +201,27 @@ jobs:
       contents: read
     timeout-minutes: 12
     steps:
-      # Harden the runner used by this workflow
-      # When the CONNECTION_WHITELIST repo/org variable is exposed
-      # to this run (i.e. not a fork PR), use it to enforce a
-      # block-mode egress policy.
-      - name: 'Harden runner (block egress with whitelist)'
-        if: ${{ vars.CONNECTION_WHITELIST != '' }}
+      # Load the egress allow-list out-of-band from
+      # lfreleng-actions/.github and publish it as
+      # $CONNECTION_ALLOW_LIST for the harden-runner step below
+      # to consume in 'block' mode. Loading out-of-band means
+      # the workflow no longer depends on any org-level GitHub
+      # variable being exposed at runtime (org variables are
+      # unreachable from workflows triggered by PRs raised from
+      # forks, which previously forced a fallback to audit mode).
+      # yamllint disable-line rule:line-length
+      - uses: lfreleng-actions/harden-runner-block-action@18993b53be1b9327579eb1a2ba318d8a22c39f72  # v0.1.0
+        with:
+          org: 'lfreleng-actions'
+
+      # Harden the runner with the just-loaded allow-list.
+      - name: 'Harden runner (block)'
         # yamllint disable-line rule:line-length
-        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5  # v2.19.3
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411  # v2.19.4
         with:
           egress-policy: 'block'
           allowed-endpoints: >
-            ${{ vars.CONNECTION_WHITELIST }}
-
-      # Fallback for fork PRs and other contexts where the
-      # CONNECTION_WHITELIST variable is not exposed to the
-      # workflow.  Audit-only mode logs all egress without
-      # blocking it so CI still runs.
-      - name: 'Harden runner (audit fallback, no whitelist available)'
-        if: ${{ vars.CONNECTION_WHITELIST == '' }}
-        # yamllint disable-line rule:line-length
-        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5  # v2.19.3
-        with:
-          egress-policy: 'audit'
+            ${{ env.CONNECTION_ALLOW_LIST }}
 
       # yamllint disable-line rule:line-length
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
@@ -251,36 +244,34 @@ jobs:
       contents: read
     timeout-minutes: 10
     steps:
-      # Harden the runner used by this workflow
-      # When the CONNECTION_WHITELIST repo/org variable is exposed
-      # to this run (i.e. not a fork PR), use it to enforce a
-      # block-mode egress policy.
-      - name: 'Harden runner (block egress with whitelist)'
-        if: ${{ vars.CONNECTION_WHITELIST != '' }}
+      # Load the egress allow-list out-of-band from
+      # lfreleng-actions/.github and publish it as
+      # $CONNECTION_ALLOW_LIST for the harden-runner step below
+      # to consume in 'block' mode. Loading out-of-band means
+      # the workflow no longer depends on any org-level GitHub
+      # variable being exposed at runtime (org variables are
+      # unreachable from workflows triggered by PRs raised from
+      # forks, which previously forced a fallback to audit mode).
+      # yamllint disable-line rule:line-length
+      - uses: lfreleng-actions/harden-runner-block-action@18993b53be1b9327579eb1a2ba318d8a22c39f72  # v0.1.0
+        with:
+          org: 'lfreleng-actions'
+
+      # Harden the runner with the just-loaded allow-list.
+      - name: 'Harden runner (block)'
         # yamllint disable-line rule:line-length
-        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5  # v2.19.3
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411  # v2.19.4
         with:
           egress-policy: 'block'
           allowed-endpoints: >
-            ${{ vars.CONNECTION_WHITELIST }}
-
-      # Fallback for fork PRs and other contexts where the
-      # CONNECTION_WHITELIST variable is not exposed to the
-      # workflow.  Audit-only mode logs all egress without
-      # blocking it so CI still runs.
-      - name: 'Harden runner (audit fallback, no whitelist available)'
-        if: ${{ vars.CONNECTION_WHITELIST == '' }}
-        # yamllint disable-line rule:line-length
-        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5  # v2.19.3
-        with:
-          egress-policy: 'audit'
+            ${{ env.CONNECTION_ALLOW_LIST }}
 
       # yamllint disable-line rule:line-length
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: 'Audit Python project'
         # yamllint disable-line rule:line-length
-        uses: lfreleng-actions/python-audit-action@275c85f883b03f5342c1fafd8173b6d996670a1d  # v0.2.7
+        uses: lfreleng-actions/python-audit-action@37dd0da54e2d66194f9d46b7000dbba5d62601f9  # v0.2.8
         with:
           python_version: "${{ matrix.python-version }}"
           permit_fail: "${{ vars.NO_BLOCK_AUDIT_FAIL == 'true' }}"
@@ -293,29 +284,27 @@ jobs:
     permissions:
       contents: read
     steps:
-      # Harden the runner used by this workflow
-      # When the CONNECTION_WHITELIST repo/org variable is exposed
-      # to this run (i.e. not a fork PR), use it to enforce a
-      # block-mode egress policy.
-      - name: 'Harden runner (block egress with whitelist)'
-        if: ${{ vars.CONNECTION_WHITELIST != '' }}
+      # Load the egress allow-list out-of-band from
+      # lfreleng-actions/.github and publish it as
+      # $CONNECTION_ALLOW_LIST for the harden-runner step below
+      # to consume in 'block' mode. Loading out-of-band means
+      # the workflow no longer depends on any org-level GitHub
+      # variable being exposed at runtime (org variables are
+      # unreachable from workflows triggered by PRs raised from
+      # forks, which previously forced a fallback to audit mode).
+      # yamllint disable-line rule:line-length
+      - uses: lfreleng-actions/harden-runner-block-action@18993b53be1b9327579eb1a2ba318d8a22c39f72  # v0.1.0
+        with:
+          org: 'lfreleng-actions'
+
+      # Harden the runner with the just-loaded allow-list.
+      - name: 'Harden runner (block)'
         # yamllint disable-line rule:line-length
-        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5  # v2.19.3
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411  # v2.19.4
         with:
           egress-policy: 'block'
           allowed-endpoints: >
-            ${{ vars.CONNECTION_WHITELIST }}
-
-      # Fallback for fork PRs and other contexts where the
-      # CONNECTION_WHITELIST variable is not exposed to the
-      # workflow.  Audit-only mode logs all egress without
-      # blocking it so CI still runs.
-      - name: 'Harden runner (audit fallback, no whitelist available)'
-        if: ${{ vars.CONNECTION_WHITELIST == '' }}
-        # yamllint disable-line rule:line-length
-        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5  # v2.19.3
-        with:
-          egress-policy: 'audit'
+            ${{ env.CONNECTION_ALLOW_LIST }}
 
       # yamllint disable-line rule:line-length
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
@@ -355,29 +344,27 @@ jobs:
     permissions:
       contents: read
     steps:
-      # Harden the runner used by this workflow
-      # When the CONNECTION_WHITELIST repo/org variable is exposed
-      # to this run (i.e. not a fork PR), use it to enforce a
-      # block-mode egress policy.
-      - name: 'Harden runner (block egress with whitelist)'
-        if: ${{ vars.CONNECTION_WHITELIST != '' }}
+      # Load the egress allow-list out-of-band from
+      # lfreleng-actions/.github and publish it as
+      # $CONNECTION_ALLOW_LIST for the harden-runner step below
+      # to consume in 'block' mode. Loading out-of-band means
+      # the workflow no longer depends on any org-level GitHub
+      # variable being exposed at runtime (org variables are
+      # unreachable from workflows triggered by PRs raised from
+      # forks, which previously forced a fallback to audit mode).
+      # yamllint disable-line rule:line-length
+      - uses: lfreleng-actions/harden-runner-block-action@18993b53be1b9327579eb1a2ba318d8a22c39f72  # v0.1.0
+        with:
+          org: 'lfreleng-actions'
+
+      # Harden the runner with the just-loaded allow-list.
+      - name: 'Harden runner (block)'
         # yamllint disable-line rule:line-length
-        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5  # v2.19.3
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411  # v2.19.4
         with:
           egress-policy: 'block'
           allowed-endpoints: >
-            ${{ vars.CONNECTION_WHITELIST }}
-
-      # Fallback for fork PRs and other contexts where the
-      # CONNECTION_WHITELIST variable is not exposed to the
-      # workflow.  Audit-only mode logs all egress without
-      # blocking it so CI still runs.
-      - name: 'Harden runner (audit fallback, no whitelist available)'
-        if: ${{ vars.CONNECTION_WHITELIST == '' }}
-        # yamllint disable-line rule:line-length
-        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5  # v2.19.3
-        with:
-          egress-policy: 'audit'
+            ${{ env.CONNECTION_ALLOW_LIST }}
 
       - name: "Download SBOM artefact"
         # yamllint disable-line rule:line-length
@@ -544,29 +531,27 @@ jobs:
       id-token: write  # IMPORTANT: mandatory for trusted publishing
     timeout-minutes: 5
     steps:
-      # Harden the runner used by this workflow
-      # When the CONNECTION_WHITELIST repo/org variable is exposed
-      # to this run (i.e. not a fork PR), use it to enforce a
-      # block-mode egress policy.
-      - name: 'Harden runner (block egress with whitelist)'
-        if: ${{ vars.CONNECTION_WHITELIST != '' }}
+      # Load the egress allow-list out-of-band from
+      # lfreleng-actions/.github and publish it as
+      # $CONNECTION_ALLOW_LIST for the harden-runner step below
+      # to consume in 'block' mode. Loading out-of-band means
+      # the workflow no longer depends on any org-level GitHub
+      # variable being exposed at runtime (org variables are
+      # unreachable from workflows triggered by PRs raised from
+      # forks, which previously forced a fallback to audit mode).
+      # yamllint disable-line rule:line-length
+      - uses: lfreleng-actions/harden-runner-block-action@18993b53be1b9327579eb1a2ba318d8a22c39f72  # v0.1.0
+        with:
+          org: 'lfreleng-actions'
+
+      # Harden the runner with the just-loaded allow-list.
+      - name: 'Harden runner (block)'
         # yamllint disable-line rule:line-length
-        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5  # v2.19.3
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411  # v2.19.4
         with:
           egress-policy: 'block'
           allowed-endpoints: >
-            ${{ vars.CONNECTION_WHITELIST }}
-
-      # Fallback for fork PRs and other contexts where the
-      # CONNECTION_WHITELIST variable is not exposed to the
-      # workflow.  Audit-only mode logs all egress without
-      # blocking it so CI still runs.
-      - name: 'Harden runner (audit fallback, no whitelist available)'
-        if: ${{ vars.CONNECTION_WHITELIST == '' }}
-        # yamllint disable-line rule:line-length
-        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5  # v2.19.3
-        with:
-          egress-policy: 'audit'
+            ${{ env.CONNECTION_ALLOW_LIST }}
 
       - name: 'Test PyPI publishing'
         # yamllint disable-line rule:line-length
@@ -589,29 +574,27 @@ jobs:
       id-token: write  # IMPORTANT: mandatory for trusted publishing
     timeout-minutes: 5
     steps:
-      # Harden the runner used by this workflow
-      # When the CONNECTION_WHITELIST repo/org variable is exposed
-      # to this run (i.e. not a fork PR), use it to enforce a
-      # block-mode egress policy.
-      - name: 'Harden runner (block egress with whitelist)'
-        if: ${{ vars.CONNECTION_WHITELIST != '' }}
+      # Load the egress allow-list out-of-band from
+      # lfreleng-actions/.github and publish it as
+      # $CONNECTION_ALLOW_LIST for the harden-runner step below
+      # to consume in 'block' mode. Loading out-of-band means
+      # the workflow no longer depends on any org-level GitHub
+      # variable being exposed at runtime (org variables are
+      # unreachable from workflows triggered by PRs raised from
+      # forks, which previously forced a fallback to audit mode).
+      # yamllint disable-line rule:line-length
+      - uses: lfreleng-actions/harden-runner-block-action@18993b53be1b9327579eb1a2ba318d8a22c39f72  # v0.1.0
+        with:
+          org: 'lfreleng-actions'
+
+      # Harden the runner with the just-loaded allow-list.
+      - name: 'Harden runner (block)'
         # yamllint disable-line rule:line-length
-        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5  # v2.19.3
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411  # v2.19.4
         with:
           egress-policy: 'block'
           allowed-endpoints: >
-            ${{ vars.CONNECTION_WHITELIST }}
-
-      # Fallback for fork PRs and other contexts where the
-      # CONNECTION_WHITELIST variable is not exposed to the
-      # workflow.  Audit-only mode logs all egress without
-      # blocking it so CI still runs.
-      - name: 'Harden runner (audit fallback, no whitelist available)'
-        if: ${{ vars.CONNECTION_WHITELIST == '' }}
-        # yamllint disable-line rule:line-length
-        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5  # v2.19.3
-        with:
-          egress-policy: 'audit'
+            ${{ env.CONNECTION_ALLOW_LIST }}
 
       - name: 'PyPI release'
         # yamllint disable-line rule:line-length
@@ -644,29 +627,27 @@ jobs:
     env:
       GH_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
     steps:
-      # Harden the runner used by this workflow
-      # When the CONNECTION_WHITELIST repo/org variable is exposed
-      # to this run (i.e. not a fork PR), use it to enforce a
-      # block-mode egress policy.
-      - name: 'Harden runner (block egress with whitelist)'
-        if: ${{ vars.CONNECTION_WHITELIST != '' }}
+      # Load the egress allow-list out-of-band from
+      # lfreleng-actions/.github and publish it as
+      # $CONNECTION_ALLOW_LIST for the harden-runner step below
+      # to consume in 'block' mode. Loading out-of-band means
+      # the workflow no longer depends on any org-level GitHub
+      # variable being exposed at runtime (org variables are
+      # unreachable from workflows triggered by PRs raised from
+      # forks, which previously forced a fallback to audit mode).
+      # yamllint disable-line rule:line-length
+      - uses: lfreleng-actions/harden-runner-block-action@18993b53be1b9327579eb1a2ba318d8a22c39f72  # v0.1.0
+        with:
+          org: 'lfreleng-actions'
+
+      # Harden the runner with the just-loaded allow-list.
+      - name: 'Harden runner (block)'
         # yamllint disable-line rule:line-length
-        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5  # v2.19.3
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411  # v2.19.4
         with:
           egress-policy: 'block'
           allowed-endpoints: >
-            ${{ vars.CONNECTION_WHITELIST }}
-
-      # Fallback for fork PRs and other contexts where the
-      # CONNECTION_WHITELIST variable is not exposed to the
-      # workflow.  Audit-only mode logs all egress without
-      # blocking it so CI still runs.
-      - name: 'Harden runner (audit fallback, no whitelist available)'
-        if: ${{ vars.CONNECTION_WHITELIST == '' }}
-        # yamllint disable-line rule:line-length
-        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5  # v2.19.3
-        with:
-          egress-policy: 'audit'
+            ${{ env.CONNECTION_ALLOW_LIST }}
 
       # yamllint disable-line rule:line-length
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
@@ -700,29 +681,27 @@ jobs:
       # yamllint disable-line rule:line-length
       release_url: "${{ steps.promote-release.outputs.release_url || steps.set-promoted-url.outputs.release_url }}"
     steps:
-      # Harden the runner used by this workflow
-      # When the CONNECTION_WHITELIST repo/org variable is exposed
-      # to this run (i.e. not a fork PR), use it to enforce a
-      # block-mode egress policy.
-      - name: 'Harden runner (block egress with whitelist)'
-        if: ${{ vars.CONNECTION_WHITELIST != '' }}
+      # Load the egress allow-list out-of-band from
+      # lfreleng-actions/.github and publish it as
+      # $CONNECTION_ALLOW_LIST for the harden-runner step below
+      # to consume in 'block' mode. Loading out-of-band means
+      # the workflow no longer depends on any org-level GitHub
+      # variable being exposed at runtime (org variables are
+      # unreachable from workflows triggered by PRs raised from
+      # forks, which previously forced a fallback to audit mode).
+      # yamllint disable-line rule:line-length
+      - uses: lfreleng-actions/harden-runner-block-action@18993b53be1b9327579eb1a2ba318d8a22c39f72  # v0.1.0
+        with:
+          org: 'lfreleng-actions'
+
+      # Harden the runner with the just-loaded allow-list.
+      - name: 'Harden runner (block)'
         # yamllint disable-line rule:line-length
-        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5  # v2.19.3
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411  # v2.19.4
         with:
           egress-policy: 'block'
           allowed-endpoints: >
-            ${{ vars.CONNECTION_WHITELIST }}
-
-      # Fallback for fork PRs and other contexts where the
-      # CONNECTION_WHITELIST variable is not exposed to the
-      # workflow.  Audit-only mode logs all egress without
-      # blocking it so CI still runs.
-      - name: 'Harden runner (audit fallback, no whitelist available)'
-        if: ${{ vars.CONNECTION_WHITELIST == '' }}
-        # yamllint disable-line rule:line-length
-        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5  # v2.19.3
-        with:
-          egress-policy: 'audit'
+            ${{ env.CONNECTION_ALLOW_LIST }}
 
       # yamllint disable-line rule:line-length
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -40,28 +40,27 @@ jobs:
       pull-requests: read
     timeout-minutes: 5
     steps:
-      # When the CONNECTION_WHITELIST repo/org variable is exposed
-      # to this run (i.e. not a fork PR), use it to enforce a
-      # block-mode egress policy.
-      - name: 'Harden runner (block egress with whitelist)'
-        if: ${{ vars.CONNECTION_WHITELIST != '' }}
+      # Load the egress allow-list out-of-band from
+      # lfreleng-actions/.github and publish it as
+      # $CONNECTION_ALLOW_LIST for the harden-runner step below
+      # to consume in 'block' mode. Loading out-of-band means
+      # the workflow no longer depends on any org-level GitHub
+      # variable being exposed at runtime (org variables are
+      # unreachable from workflows triggered by PRs raised from
+      # forks, which previously forced a fallback to audit mode).
+      # yamllint disable-line rule:line-length
+      - uses: lfreleng-actions/harden-runner-block-action@18993b53be1b9327579eb1a2ba318d8a22c39f72  # v0.1.0
+        with:
+          org: 'lfreleng-actions'
+
+      # Harden the runner with the just-loaded allow-list.
+      - name: 'Harden runner (block)'
         # yamllint disable-line rule:line-length
-        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5  # v2.19.3
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411  # v2.19.4
         with:
           egress-policy: 'block'
           allowed-endpoints: >
-            ${{ vars.CONNECTION_WHITELIST }}
-
-      # Fallback for fork PRs and other contexts where the
-      # CONNECTION_WHITELIST variable is not exposed to the
-      # workflow.  Audit-only mode logs all egress without
-      # blocking it so CI still runs.
-      - name: 'Harden runner (audit fallback, no whitelist available)'
-        if: ${{ vars.CONNECTION_WHITELIST == '' }}
-        # yamllint disable-line rule:line-length
-        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5  # v2.19.3
-        with:
-          egress-policy: 'audit'
+            ${{ env.CONNECTION_ALLOW_LIST }}
 
       # yamllint disable-line rule:line-length
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
@@ -92,28 +91,27 @@ jobs:
     env:
       GH_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
     steps:
-      # When the CONNECTION_WHITELIST repo/org variable is exposed
-      # to this run (i.e. not a fork PR), use it to enforce a
-      # block-mode egress policy.
-      - name: 'Harden runner (block egress with whitelist)'
-        if: ${{ vars.CONNECTION_WHITELIST != '' }}
+      # Load the egress allow-list out-of-band from
+      # lfreleng-actions/.github and publish it as
+      # $CONNECTION_ALLOW_LIST for the harden-runner step below
+      # to consume in 'block' mode. Loading out-of-band means
+      # the workflow no longer depends on any org-level GitHub
+      # variable being exposed at runtime (org variables are
+      # unreachable from workflows triggered by PRs raised from
+      # forks, which previously forced a fallback to audit mode).
+      # yamllint disable-line rule:line-length
+      - uses: lfreleng-actions/harden-runner-block-action@18993b53be1b9327579eb1a2ba318d8a22c39f72  # v0.1.0
+        with:
+          org: 'lfreleng-actions'
+
+      # Harden the runner with the just-loaded allow-list.
+      - name: 'Harden runner (block)'
         # yamllint disable-line rule:line-length
-        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5  # v2.19.3
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411  # v2.19.4
         with:
           egress-policy: 'block'
           allowed-endpoints: >
-            ${{ vars.CONNECTION_WHITELIST }}
-
-      # Fallback for fork PRs and other contexts where the
-      # CONNECTION_WHITELIST variable is not exposed to the
-      # workflow.  Audit-only mode logs all egress without
-      # blocking it so CI still runs.
-      - name: 'Harden runner (audit fallback, no whitelist available)'
-        if: ${{ vars.CONNECTION_WHITELIST == '' }}
-        # yamllint disable-line rule:line-length
-        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5  # v2.19.3
-        with:
-          egress-policy: 'audit'
+            ${{ env.CONNECTION_ALLOW_LIST }}
 
       - name: 'Clear Python dependency caches'
         env:
@@ -192,29 +190,27 @@ jobs:
       contents: read
     timeout-minutes: 12
     steps:
-      # Harden the runner used by this workflow
-      # When the CONNECTION_WHITELIST repo/org variable is exposed
-      # to this run (i.e. not a fork PR), use it to enforce a
-      # block-mode egress policy.
-      - name: 'Harden runner (block egress with whitelist)'
-        if: ${{ vars.CONNECTION_WHITELIST != '' }}
+      # Load the egress allow-list out-of-band from
+      # lfreleng-actions/.github and publish it as
+      # $CONNECTION_ALLOW_LIST for the harden-runner step below
+      # to consume in 'block' mode. Loading out-of-band means
+      # the workflow no longer depends on any org-level GitHub
+      # variable being exposed at runtime (org variables are
+      # unreachable from workflows triggered by PRs raised from
+      # forks, which previously forced a fallback to audit mode).
+      # yamllint disable-line rule:line-length
+      - uses: lfreleng-actions/harden-runner-block-action@18993b53be1b9327579eb1a2ba318d8a22c39f72  # v0.1.0
+        with:
+          org: 'lfreleng-actions'
+
+      # Harden the runner with the just-loaded allow-list.
+      - name: 'Harden runner (block)'
         # yamllint disable-line rule:line-length
-        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5  # v2.19.3
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411  # v2.19.4
         with:
           egress-policy: 'block'
           allowed-endpoints: >
-            ${{ vars.CONNECTION_WHITELIST }}
-
-      # Fallback for fork PRs and other contexts where the
-      # CONNECTION_WHITELIST variable is not exposed to the
-      # workflow.  Audit-only mode logs all egress without
-      # blocking it so CI still runs.
-      - name: 'Harden runner (audit fallback, no whitelist available)'
-        if: ${{ vars.CONNECTION_WHITELIST == '' }}
-        # yamllint disable-line rule:line-length
-        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5  # v2.19.3
-        with:
-          egress-policy: 'audit'
+            ${{ env.CONNECTION_ALLOW_LIST }}
 
       # yamllint disable-line rule:line-length
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
@@ -222,7 +218,7 @@ jobs:
       - name: 'Build Python project'
         id: python-build
         # yamllint disable-line rule:line-length
-        uses: lfreleng-actions/python-build-action@38b9a4e7ee34e56d178f5bd248df52e41f7d496e  # v1.0.6
+        uses: lfreleng-actions/python-build-action@5f570d5d17a7315074a824a91c6a705b6fc5c7dd  # v1.1.2
 
   python-tests:
     name: 'Python Tests'
@@ -237,29 +233,27 @@ jobs:
       contents: read
     timeout-minutes: 12
     steps:
-      # Harden the runner used by this workflow
-      # When the CONNECTION_WHITELIST repo/org variable is exposed
-      # to this run (i.e. not a fork PR), use it to enforce a
-      # block-mode egress policy.
-      - name: 'Harden runner (block egress with whitelist)'
-        if: ${{ vars.CONNECTION_WHITELIST != '' }}
+      # Load the egress allow-list out-of-band from
+      # lfreleng-actions/.github and publish it as
+      # $CONNECTION_ALLOW_LIST for the harden-runner step below
+      # to consume in 'block' mode. Loading out-of-band means
+      # the workflow no longer depends on any org-level GitHub
+      # variable being exposed at runtime (org variables are
+      # unreachable from workflows triggered by PRs raised from
+      # forks, which previously forced a fallback to audit mode).
+      # yamllint disable-line rule:line-length
+      - uses: lfreleng-actions/harden-runner-block-action@18993b53be1b9327579eb1a2ba318d8a22c39f72  # v0.1.0
+        with:
+          org: 'lfreleng-actions'
+
+      # Harden the runner with the just-loaded allow-list.
+      - name: 'Harden runner (block)'
         # yamllint disable-line rule:line-length
-        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5  # v2.19.3
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411  # v2.19.4
         with:
           egress-policy: 'block'
           allowed-endpoints: >
-            ${{ vars.CONNECTION_WHITELIST }}
-
-      # Fallback for fork PRs and other contexts where the
-      # CONNECTION_WHITELIST variable is not exposed to the
-      # workflow.  Audit-only mode logs all egress without
-      # blocking it so CI still runs.
-      - name: 'Harden runner (audit fallback, no whitelist available)'
-        if: ${{ vars.CONNECTION_WHITELIST == '' }}
-        # yamllint disable-line rule:line-length
-        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5  # v2.19.3
-        with:
-          egress-policy: 'audit'
+            ${{ env.CONNECTION_ALLOW_LIST }}
 
       # yamllint disable-line rule:line-length
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
@@ -283,36 +277,34 @@ jobs:
       contents: read
     timeout-minutes: 10
     steps:
-      # Harden the runner used by this workflow
-      # When the CONNECTION_WHITELIST repo/org variable is exposed
-      # to this run (i.e. not a fork PR), use it to enforce a
-      # block-mode egress policy.
-      - name: 'Harden runner (block egress with whitelist)'
-        if: ${{ vars.CONNECTION_WHITELIST != '' }}
+      # Load the egress allow-list out-of-band from
+      # lfreleng-actions/.github and publish it as
+      # $CONNECTION_ALLOW_LIST for the harden-runner step below
+      # to consume in 'block' mode. Loading out-of-band means
+      # the workflow no longer depends on any org-level GitHub
+      # variable being exposed at runtime (org variables are
+      # unreachable from workflows triggered by PRs raised from
+      # forks, which previously forced a fallback to audit mode).
+      # yamllint disable-line rule:line-length
+      - uses: lfreleng-actions/harden-runner-block-action@18993b53be1b9327579eb1a2ba318d8a22c39f72  # v0.1.0
+        with:
+          org: 'lfreleng-actions'
+
+      # Harden the runner with the just-loaded allow-list.
+      - name: 'Harden runner (block)'
         # yamllint disable-line rule:line-length
-        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5  # v2.19.3
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411  # v2.19.4
         with:
           egress-policy: 'block'
           allowed-endpoints: >
-            ${{ vars.CONNECTION_WHITELIST }}
-
-      # Fallback for fork PRs and other contexts where the
-      # CONNECTION_WHITELIST variable is not exposed to the
-      # workflow.  Audit-only mode logs all egress without
-      # blocking it so CI still runs.
-      - name: 'Harden runner (audit fallback, no whitelist available)'
-        if: ${{ vars.CONNECTION_WHITELIST == '' }}
-        # yamllint disable-line rule:line-length
-        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5  # v2.19.3
-        with:
-          egress-policy: 'audit'
+            ${{ env.CONNECTION_ALLOW_LIST }}
 
       # yamllint disable-line rule:line-length
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: "Audit dependencies ${{ matrix.python-version }}"
         # yamllint disable-line rule:line-length
-        uses: lfreleng-actions/python-audit-action@275c85f883b03f5342c1fafd8173b6d996670a1d  # v0.2.7
+        uses: lfreleng-actions/python-audit-action@37dd0da54e2d66194f9d46b7000dbba5d62601f9  # v0.2.8
         with:
           python_version: "${{ matrix.python-version }}"
           permit_fail: "${{ vars.NO_BLOCK_AUDIT_FAIL == 'true' }}"
@@ -326,29 +318,27 @@ jobs:
     permissions:
       contents: read
     steps:
-      # Harden the runner used by this workflow
-      # When the CONNECTION_WHITELIST repo/org variable is exposed
-      # to this run (i.e. not a fork PR), use it to enforce a
-      # block-mode egress policy.
-      - name: 'Harden runner (block egress with whitelist)'
-        if: ${{ vars.CONNECTION_WHITELIST != '' }}
+      # Load the egress allow-list out-of-band from
+      # lfreleng-actions/.github and publish it as
+      # $CONNECTION_ALLOW_LIST for the harden-runner step below
+      # to consume in 'block' mode. Loading out-of-band means
+      # the workflow no longer depends on any org-level GitHub
+      # variable being exposed at runtime (org variables are
+      # unreachable from workflows triggered by PRs raised from
+      # forks, which previously forced a fallback to audit mode).
+      # yamllint disable-line rule:line-length
+      - uses: lfreleng-actions/harden-runner-block-action@18993b53be1b9327579eb1a2ba318d8a22c39f72  # v0.1.0
+        with:
+          org: 'lfreleng-actions'
+
+      # Harden the runner with the just-loaded allow-list.
+      - name: 'Harden runner (block)'
         # yamllint disable-line rule:line-length
-        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5  # v2.19.3
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411  # v2.19.4
         with:
           egress-policy: 'block'
           allowed-endpoints: >
-            ${{ vars.CONNECTION_WHITELIST }}
-
-      # Fallback for fork PRs and other contexts where the
-      # CONNECTION_WHITELIST variable is not exposed to the
-      # workflow.  Audit-only mode logs all egress without
-      # blocking it so CI still runs.
-      - name: 'Harden runner (audit fallback, no whitelist available)'
-        if: ${{ vars.CONNECTION_WHITELIST == '' }}
-        # yamllint disable-line rule:line-length
-        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5  # v2.19.3
-        with:
-          egress-policy: 'audit'
+            ${{ env.CONNECTION_ALLOW_LIST }}
 
       # yamllint disable-line rule:line-length
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
@@ -389,29 +379,27 @@ jobs:
     permissions:
       contents: read
     steps:
-      # Harden the runner used by this workflow
-      # When the CONNECTION_WHITELIST repo/org variable is exposed
-      # to this run (i.e. not a fork PR), use it to enforce a
-      # block-mode egress policy.
-      - name: 'Harden runner (block egress with whitelist)'
-        if: ${{ vars.CONNECTION_WHITELIST != '' }}
+      # Load the egress allow-list out-of-band from
+      # lfreleng-actions/.github and publish it as
+      # $CONNECTION_ALLOW_LIST for the harden-runner step below
+      # to consume in 'block' mode. Loading out-of-band means
+      # the workflow no longer depends on any org-level GitHub
+      # variable being exposed at runtime (org variables are
+      # unreachable from workflows triggered by PRs raised from
+      # forks, which previously forced a fallback to audit mode).
+      # yamllint disable-line rule:line-length
+      - uses: lfreleng-actions/harden-runner-block-action@18993b53be1b9327579eb1a2ba318d8a22c39f72  # v0.1.0
+        with:
+          org: 'lfreleng-actions'
+
+      # Harden the runner with the just-loaded allow-list.
+      - name: 'Harden runner (block)'
         # yamllint disable-line rule:line-length
-        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5  # v2.19.3
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411  # v2.19.4
         with:
           egress-policy: 'block'
           allowed-endpoints: >
-            ${{ vars.CONNECTION_WHITELIST }}
-
-      # Fallback for fork PRs and other contexts where the
-      # CONNECTION_WHITELIST variable is not exposed to the
-      # workflow.  Audit-only mode logs all egress without
-      # blocking it so CI still runs.
-      - name: 'Harden runner (audit fallback, no whitelist available)'
-        if: ${{ vars.CONNECTION_WHITELIST == '' }}
-        # yamllint disable-line rule:line-length
-        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5  # v2.19.3
-        with:
-          egress-policy: 'audit'
+            ${{ env.CONNECTION_ALLOW_LIST }}
 
       - name: "Download SBOM artefact"
         # yamllint disable-line rule:line-length

--- a/.github/workflows/release-drafter.yaml
+++ b/.github/workflows/release-drafter.yaml
@@ -25,29 +25,27 @@ jobs:
     runs-on: 'ubuntu-latest'
     timeout-minutes: 3
     steps:
-      # Harden the runner used by this workflow
-      # When the CONNECTION_WHITELIST repo/org variable is exposed
-      # to this run (i.e. not a fork PR), use it to enforce a
-      # block-mode egress policy.
-      - name: 'Harden runner (block egress with whitelist)'
-        if: ${{ vars.CONNECTION_WHITELIST != '' }}
+      # Load the egress allow-list out-of-band from
+      # lfreleng-actions/.github and publish it as
+      # $CONNECTION_ALLOW_LIST for the harden-runner step below
+      # to consume in 'block' mode. Loading out-of-band means
+      # the workflow no longer depends on any org-level GitHub
+      # variable being exposed at runtime (org variables are
+      # unreachable from workflows triggered by PRs raised from
+      # forks, which previously forced a fallback to audit mode).
+      # yamllint disable-line rule:line-length
+      - uses: lfreleng-actions/harden-runner-block-action@18993b53be1b9327579eb1a2ba318d8a22c39f72  # v0.1.0
+        with:
+          org: 'lfreleng-actions'
+
+      # Harden the runner with the just-loaded allow-list.
+      - name: 'Harden runner (block)'
         # yamllint disable-line rule:line-length
-        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5  # v2.19.3
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411  # v2.19.4
         with:
           egress-policy: 'block'
           allowed-endpoints: >
-            ${{ vars.CONNECTION_WHITELIST }}
-
-      # Fallback for fork PRs and other contexts where the
-      # CONNECTION_WHITELIST variable is not exposed to the
-      # workflow.  Audit-only mode logs all egress without
-      # blocking it so CI still runs.
-      - name: 'Harden runner (audit fallback, no whitelist available)'
-        if: ${{ vars.CONNECTION_WHITELIST == '' }}
-        # yamllint disable-line rule:line-length
-        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5  # v2.19.3
-        with:
-          egress-policy: 'audit'
+            ${{ env.CONNECTION_ALLOW_LIST }}
 
       # yamllint disable-line rule:line-length
-      - uses: release-drafter/release-drafter@c2e2804cc59f45f57076a99af580d0fedb697927  # v7.3.0
+      - uses: release-drafter/release-drafter@693d20e7c1ce1a81d3a41962f85914253b518449  # v7.3.1

--- a/.github/workflows/zizmor.yaml
+++ b/.github/workflows/zizmor.yaml
@@ -66,7 +66,7 @@ jobs:
     steps:
       # Harden the runner used by this workflow.
       # yamllint disable-line rule:line-length
-      - uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5  # v2.19.3
+      - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411  # v2.19.4
         with:
           egress-policy: 'audit'
 
@@ -486,7 +486,7 @@ jobs:
     steps:
       # Harden the runner used by this workflow.
       # yamllint disable-line rule:line-length
-      - uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5  # v2.19.3
+      - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411  # v2.19.4
         with:
           egress-policy: 'audit'
 
@@ -510,7 +510,7 @@ jobs:
         # block other required checks on the calling repository.
         continue-on-error: true
         # yamllint disable-line rule:line-length
-        uses: github/codeql-action/upload-sarif@9e0d7b8d25671d64c341c19c0152d693099fb5ba  # v4.35.5
+        uses: github/codeql-action/upload-sarif@7211b7c8077ea37d8641b6271f6a365a22a5fbfa  # v4.36.0
         with:
           sarif_file: 'zizmor.sarif'
           category: 'zizmor'


### PR DESCRIPTION
## Summary

Replace every existing `step-security/harden-runner` block/audit
pair (previously gated on an org-level GitHub variable holding the
egress allow-list) with a two-step sequence:

1. **`lfreleng-actions/harden-runner-block-action`** loads the
   allow-list out-of-band from
   `lfreleng-actions/.github/.github/harden-runner/lfreleng-actions/allow_list.txt`
   and publishes it as the `CONNECTION_ALLOW_LIST` environment
   variable.

2. **`step-security/harden-runner`** runs in `egress-policy: block`
   and consumes `${{ env.CONNECTION_ALLOW_LIST }}` as its
   `allowed-endpoints` input.

20 replacement sites across four workflows:
`autolabeler.yaml` (1), `release-drafter.yaml` (1),
`build-test.yaml` (7), `build-test-release.yaml` (11).
`zizmor.yaml` is unchanged in terms of the harden-runner pattern
(its single audit-only step was never part of the block/audit pair).

## Why

Org-level GitHub variables are not exposed to workflows triggered
by PRs raised from forks — they behave like secrets in that
context. The previous variable-gated pattern detected this case
and silently degraded to audit mode for every fork PR, which
broke the "block everywhere" security goal. Loading the
allow-list out-of-band over HTTPS removes that limitation:
**block mode now applies uniformly across same-repo PRs, fork
PRs, push events, and release runs**.

## Legacy org-level variable

The org-level variable that previously held the allow-list has
already been removed at the org level. This PR replaces the last
remaining workflow code that referenced it; once merged there are
no further references to it anywhere in this repository.

## Pin

The `uses:` lines pin the loader to the upstream tagged release:

```
uses: lfreleng-actions/harden-runner-block-action@18993b53be1b9327579eb1a2ba318d8a22c39f72  # v0.1.0
```

## Action SHA refresh

Also refreshes all other pinned action commit SHAs to the latest
tagged releases as of 2026-05-28:

| Action | From | To |
|---|---|---|
| `step-security/harden-runner` | v2.19.3 | v2.19.4 |
| `release-drafter/release-drafter` (+ `/autolabeler`) | v7.3.0 | v7.3.1 |
| `lfreleng-actions/python-build-action` | v1.0.6 | v1.1.2 |
| `lfreleng-actions/python-audit-action` | v0.2.7 | v0.2.8 |
| `github/codeql-action/upload-sarif` | v4.35.5 | v4.36.0 |

## Documentation

The `autolabeler.yaml` `pull_request_target` SECURITY rationale
comment is refreshed to describe the three pinned steps actually
present in the job (allow-list loader, block-mode harden-runner,
release-drafter autolabeler) and the safety property of each. No
behavioural change; comment-only.

## Validation

End-to-end testing in [`modeseven-lfit/dependamerge`](https://github.com/modeseven-lfit/dependamerge) confirmed the
pre-hook architecture works against live block-mode `harden-runner`
(initial run [26510979035](https://github.com/modeseven-lfit/dependamerge/actions/runs/26510979035) used the in-development branch; the
fork's `main` branch now mirrors this PR pinned to
`harden-runner-block-action@v0.1.0` for an independent confirmation
of the tagged-release path before merging here).

## Known non-blocking CI failure on this PR

The `Autolabel PR` check on this PR will fail until this PR
itself merges. Reason: `pull_request_target` runs the autolabeler
workflow from the BASE branch (`lfit/dependamerge:main`), which
still has the legacy conditional `harden-runner` pair. With the
org-level variable now removed, GitHub Actions still fires both
`harden-runner` `pre:` hooks (the runner evaluates every step's
`pre:` upfront, before step-level `if:` is applied to main
steps), so the block-mode `pre:` runs with an empty
`allowed-endpoints` and blocks all egress for the job. This is
precisely the silent-failure mode this PR fixes; the check will
go green again on the very next PR after this one merges.