### PR TITLE
Fix(zizmor): Guard Dependabot pip pin against lockfile error

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -37,3 +37,12 @@ updates:
     open-pull-requests-limit: 5
     cooldown:
       default-days: 7
+    # Restrict to direct dependencies. The pin file declares only
+    # `zizmor` itself; the workflow never runs `pip install -r` against
+    # it (it greps the version and feeds it to `uvx --from`), so there
+    # is no lockfile and no place for Dependabot to express transitive
+    # updates. Without this filter Dependabot's resolver errors with
+    # "can't update vulnerable dependencies without a lockfile" whenever
+    # a transitive of zizmor carries a security advisory.
+    allow:
+      - dependency-type: "direct"

--- a/.github/workflows/autolabeler.yaml
+++ b/.github/workflows/autolabeler.yaml
@@ -72,29 +72,32 @@ jobs:
     runs-on: 'ubuntu-latest'
     timeout-minutes: 3
     steps:
-      # Harden the runner used by this workflow
-      # When the CONNECTION_WHITELIST repo/org variable is exposed
-      # to this run (i.e. not a fork PR), use it to enforce a
-      # block-mode egress policy.
-      - name: 'Harden runner (block egress with whitelist)'
-        if: ${{ vars.CONNECTION_WHITELIST != '' }}
+      # Load the egress allow-list out-of-band from
+      # lfreleng-actions/.github and publish it as
+      # $CONNECTION_ALLOW_LIST for the harden-runner step below
+      # to consume in 'block' mode. Loading out-of-band means
+      # the workflow no longer depends on any org-level GitHub
+      # variable being exposed at runtime (org variables are
+      # unreachable from workflows triggered by PRs raised from
+      # forks, which previously forced a fallback to audit mode).
+      #
+      # Temporarily pinned to a branch in a personal fork while
+      # lfreleng-actions/harden-runner-block-action#5 is in
+      # review; update to a tagged release in lfreleng-actions/
+      # once that PR merges.
+      # yamllint disable-line rule:line-length
+      - uses: modeseven-lfreleng-actions/harden-runner-block-action@feat/whitelist-loader
+        with:
+          org: 'lfreleng-actions'
+
+      # Harden the runner with the just-loaded allow-list.
+      - name: 'Harden runner (block)'
         # yamllint disable-line rule:line-length
         uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5  # v2.19.3
         with:
           egress-policy: 'block'
           allowed-endpoints: >
-            ${{ vars.CONNECTION_WHITELIST }}
-
-      # Fallback for fork PRs and other contexts where the
-      # CONNECTION_WHITELIST variable is not exposed to the
-      # workflow.  Audit-only mode logs all egress without
-      # blocking it so CI still runs.
-      - name: 'Harden runner (audit fallback, no whitelist available)'
-        if: ${{ vars.CONNECTION_WHITELIST == '' }}
-        # yamllint disable-line rule:line-length
-        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5  # v2.19.3
-        with:
-          egress-policy: 'audit'
+            ${{ env.CONNECTION_ALLOW_LIST }}
 
       # yamllint disable-line rule:line-length
       - uses: release-drafter/release-drafter/autolabeler@c2e2804cc59f45f57076a99af580d0fedb697927  # v7.3.0

--- a/.github/workflows/autolabeler.yaml
+++ b/.github/workflows/autolabeler.yaml
@@ -82,11 +82,11 @@ jobs:
       # forks, which previously forced a fallback to audit mode).
       #
       # Temporarily pinned to a branch in a personal fork while
-      # lfreleng-actions/harden-runner-block-action#5 is in
+      # lfreleng-actions/harden-runner-block-action#7 is in
       # review; update to a tagged release in lfreleng-actions/
       # once that PR merges.
       # yamllint disable-line rule:line-length
-      - uses: modeseven-lfreleng-actions/harden-runner-block-action@feat/whitelist-loader
+      - uses: modeseven-lfreleng-actions/harden-runner-block-action@feat/allow-list-loader
         with:
           org: 'lfreleng-actions'
 

--- a/.github/workflows/autolabeler.yaml
+++ b/.github/workflows/autolabeler.yaml
@@ -18,18 +18,28 @@ on:
   # manual-approval gating because:
   #
   #   1. The workflow performs no checkout of PR code
-  #      (no actions/checkout step).
+  #      (no actions/checkout step), so no PR-provided source
+  #      ever runs.
   #   2. The workflow body is loaded from the base branch
   #      (pull_request_target semantics), not from the PR head.
-  #   3. The only step is release-drafter/autolabeler, pinned to
-  #      a commit SHA, which is a pure GitHub-API consumer and
-  #      never executes PR-provided content.
+  #   3. Every step is pinned to a full commit SHA and is a
+  #      well-scoped, non-code-executing consumer:
+  #        - `lfreleng-actions/harden-runner-block-action`
+  #          fetches one allow-list file over HTTPS, sanitises
+  #          it, and publishes it as $CONNECTION_ALLOW_LIST.
+  #          No PR content is read or executed.
+  #        - `step-security/harden-runner` installs the egress
+  #          block filter from $CONNECTION_ALLOW_LIST. Pure
+  #          runner-hardening; reads no PR content.
+  #        - `release-drafter/autolabeler` makes only GitHub
+  #          API calls. No code execution, no PR content read.
   #   4. Permissions are scoped to the minimum needed:
   #      pull-requests: write and contents: read. No
   #      repository secrets are passed to the job beyond the
   #      default GITHUB_TOKEN, which the job receives with the
   #      permissions scope above and nothing more.
-  #   5. The runner is hardened with an egress block.
+  #   5. The runner is hardened with an egress block applied
+  #      before the autolabeler step runs.
   #
   # See the SECURITY block on the autolabel job below for the
   # full rationale. The zizmor `dangerous-triggers` audit is

--- a/.github/workflows/autolabeler.yaml
+++ b/.github/workflows/autolabeler.yaml
@@ -80,24 +80,19 @@ jobs:
       # variable being exposed at runtime (org variables are
       # unreachable from workflows triggered by PRs raised from
       # forks, which previously forced a fallback to audit mode).
-      #
-      # Temporarily pinned to a branch in a personal fork while
-      # lfreleng-actions/harden-runner-block-action#7 is in
-      # review; update to a tagged release in lfreleng-actions/
-      # once that PR merges.
       # yamllint disable-line rule:line-length
-      - uses: modeseven-lfreleng-actions/harden-runner-block-action@feat/allow-list-loader
+      - uses: lfreleng-actions/harden-runner-block-action@18993b53be1b9327579eb1a2ba318d8a22c39f72  # v0.1.0
         with:
           org: 'lfreleng-actions'
 
       # Harden the runner with the just-loaded allow-list.
       - name: 'Harden runner (block)'
         # yamllint disable-line rule:line-length
-        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5  # v2.19.3
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411  # v2.19.4
         with:
           egress-policy: 'block'
           allowed-endpoints: >
             ${{ env.CONNECTION_ALLOW_LIST }}
 
       # yamllint disable-line rule:line-length
-      - uses: release-drafter/release-drafter/autolabeler@c2e2804cc59f45f57076a99af580d0fedb697927  # v7.3.0
+      - uses: release-drafter/release-drafter/autolabeler@693d20e7c1ce1a81d3a41962f85914253b518449  # v7.3.1

--- a/.github/workflows/build-test-release.yaml
+++ b/.github/workflows/build-test-release.yaml
@@ -37,11 +37,11 @@ jobs:
       # forks, which previously forced a fallback to audit mode).
       #
       # Temporarily pinned to a branch in a personal fork while
-      # lfreleng-actions/harden-runner-block-action#5 is in
+      # lfreleng-actions/harden-runner-block-action#7 is in
       # review; update to a tagged release in lfreleng-actions/
       # once that PR merges.
       # yamllint disable-line rule:line-length
-      - uses: modeseven-lfreleng-actions/harden-runner-block-action@feat/whitelist-loader
+      - uses: modeseven-lfreleng-actions/harden-runner-block-action@feat/allow-list-loader
         with:
           org: 'lfreleng-actions'
 
@@ -89,11 +89,11 @@ jobs:
       # forks, which previously forced a fallback to audit mode).
       #
       # Temporarily pinned to a branch in a personal fork while
-      # lfreleng-actions/harden-runner-block-action#5 is in
+      # lfreleng-actions/harden-runner-block-action#7 is in
       # review; update to a tagged release in lfreleng-actions/
       # once that PR merges.
       # yamllint disable-line rule:line-length
-      - uses: modeseven-lfreleng-actions/harden-runner-block-action@feat/whitelist-loader
+      - uses: modeseven-lfreleng-actions/harden-runner-block-action@feat/allow-list-loader
         with:
           org: 'lfreleng-actions'
 
@@ -176,11 +176,11 @@ jobs:
       # forks, which previously forced a fallback to audit mode).
       #
       # Temporarily pinned to a branch in a personal fork while
-      # lfreleng-actions/harden-runner-block-action#5 is in
+      # lfreleng-actions/harden-runner-block-action#7 is in
       # review; update to a tagged release in lfreleng-actions/
       # once that PR merges.
       # yamllint disable-line rule:line-length
-      - uses: modeseven-lfreleng-actions/harden-runner-block-action@feat/whitelist-loader
+      - uses: modeseven-lfreleng-actions/harden-runner-block-action@feat/allow-list-loader
         with:
           org: 'lfreleng-actions'
 
@@ -226,11 +226,11 @@ jobs:
       # forks, which previously forced a fallback to audit mode).
       #
       # Temporarily pinned to a branch in a personal fork while
-      # lfreleng-actions/harden-runner-block-action#5 is in
+      # lfreleng-actions/harden-runner-block-action#7 is in
       # review; update to a tagged release in lfreleng-actions/
       # once that PR merges.
       # yamllint disable-line rule:line-length
-      - uses: modeseven-lfreleng-actions/harden-runner-block-action@feat/whitelist-loader
+      - uses: modeseven-lfreleng-actions/harden-runner-block-action@feat/allow-list-loader
         with:
           org: 'lfreleng-actions'
 
@@ -274,11 +274,11 @@ jobs:
       # forks, which previously forced a fallback to audit mode).
       #
       # Temporarily pinned to a branch in a personal fork while
-      # lfreleng-actions/harden-runner-block-action#5 is in
+      # lfreleng-actions/harden-runner-block-action#7 is in
       # review; update to a tagged release in lfreleng-actions/
       # once that PR merges.
       # yamllint disable-line rule:line-length
-      - uses: modeseven-lfreleng-actions/harden-runner-block-action@feat/whitelist-loader
+      - uses: modeseven-lfreleng-actions/harden-runner-block-action@feat/allow-list-loader
         with:
           org: 'lfreleng-actions'
 
@@ -319,11 +319,11 @@ jobs:
       # forks, which previously forced a fallback to audit mode).
       #
       # Temporarily pinned to a branch in a personal fork while
-      # lfreleng-actions/harden-runner-block-action#5 is in
+      # lfreleng-actions/harden-runner-block-action#7 is in
       # review; update to a tagged release in lfreleng-actions/
       # once that PR merges.
       # yamllint disable-line rule:line-length
-      - uses: modeseven-lfreleng-actions/harden-runner-block-action@feat/whitelist-loader
+      - uses: modeseven-lfreleng-actions/harden-runner-block-action@feat/allow-list-loader
         with:
           org: 'lfreleng-actions'
 
@@ -384,11 +384,11 @@ jobs:
       # forks, which previously forced a fallback to audit mode).
       #
       # Temporarily pinned to a branch in a personal fork while
-      # lfreleng-actions/harden-runner-block-action#5 is in
+      # lfreleng-actions/harden-runner-block-action#7 is in
       # review; update to a tagged release in lfreleng-actions/
       # once that PR merges.
       # yamllint disable-line rule:line-length
-      - uses: modeseven-lfreleng-actions/harden-runner-block-action@feat/whitelist-loader
+      - uses: modeseven-lfreleng-actions/harden-runner-block-action@feat/allow-list-loader
         with:
           org: 'lfreleng-actions'
 
@@ -576,11 +576,11 @@ jobs:
       # forks, which previously forced a fallback to audit mode).
       #
       # Temporarily pinned to a branch in a personal fork while
-      # lfreleng-actions/harden-runner-block-action#5 is in
+      # lfreleng-actions/harden-runner-block-action#7 is in
       # review; update to a tagged release in lfreleng-actions/
       # once that PR merges.
       # yamllint disable-line rule:line-length
-      - uses: modeseven-lfreleng-actions/harden-runner-block-action@feat/whitelist-loader
+      - uses: modeseven-lfreleng-actions/harden-runner-block-action@feat/allow-list-loader
         with:
           org: 'lfreleng-actions'
 
@@ -624,11 +624,11 @@ jobs:
       # forks, which previously forced a fallback to audit mode).
       #
       # Temporarily pinned to a branch in a personal fork while
-      # lfreleng-actions/harden-runner-block-action#5 is in
+      # lfreleng-actions/harden-runner-block-action#7 is in
       # review; update to a tagged release in lfreleng-actions/
       # once that PR merges.
       # yamllint disable-line rule:line-length
-      - uses: modeseven-lfreleng-actions/harden-runner-block-action@feat/whitelist-loader
+      - uses: modeseven-lfreleng-actions/harden-runner-block-action@feat/allow-list-loader
         with:
           org: 'lfreleng-actions'
 
@@ -682,11 +682,11 @@ jobs:
       # forks, which previously forced a fallback to audit mode).
       #
       # Temporarily pinned to a branch in a personal fork while
-      # lfreleng-actions/harden-runner-block-action#5 is in
+      # lfreleng-actions/harden-runner-block-action#7 is in
       # review; update to a tagged release in lfreleng-actions/
       # once that PR merges.
       # yamllint disable-line rule:line-length
-      - uses: modeseven-lfreleng-actions/harden-runner-block-action@feat/whitelist-loader
+      - uses: modeseven-lfreleng-actions/harden-runner-block-action@feat/allow-list-loader
         with:
           org: 'lfreleng-actions'
 
@@ -741,11 +741,11 @@ jobs:
       # forks, which previously forced a fallback to audit mode).
       #
       # Temporarily pinned to a branch in a personal fork while
-      # lfreleng-actions/harden-runner-block-action#5 is in
+      # lfreleng-actions/harden-runner-block-action#7 is in
       # review; update to a tagged release in lfreleng-actions/
       # once that PR merges.
       # yamllint disable-line rule:line-length
-      - uses: modeseven-lfreleng-actions/harden-runner-block-action@feat/whitelist-loader
+      - uses: modeseven-lfreleng-actions/harden-runner-block-action@feat/allow-list-loader
         with:
           org: 'lfreleng-actions'
 

--- a/.github/workflows/build-test-release.yaml
+++ b/.github/workflows/build-test-release.yaml
@@ -35,20 +35,15 @@ jobs:
       # variable being exposed at runtime (org variables are
       # unreachable from workflows triggered by PRs raised from
       # forks, which previously forced a fallback to audit mode).
-      #
-      # Temporarily pinned to a branch in a personal fork while
-      # lfreleng-actions/harden-runner-block-action#7 is in
-      # review; update to a tagged release in lfreleng-actions/
-      # once that PR merges.
       # yamllint disable-line rule:line-length
-      - uses: modeseven-lfreleng-actions/harden-runner-block-action@feat/allow-list-loader
+      - uses: lfreleng-actions/harden-runner-block-action@18993b53be1b9327579eb1a2ba318d8a22c39f72  # v0.1.0
         with:
           org: 'lfreleng-actions'
 
       # Harden the runner with the just-loaded allow-list.
       - name: 'Harden runner (block)'
         # yamllint disable-line rule:line-length
-        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5  # v2.19.3
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411  # v2.19.4
         with:
           egress-policy: 'block'
           allowed-endpoints: >
@@ -87,20 +82,15 @@ jobs:
       # variable being exposed at runtime (org variables are
       # unreachable from workflows triggered by PRs raised from
       # forks, which previously forced a fallback to audit mode).
-      #
-      # Temporarily pinned to a branch in a personal fork while
-      # lfreleng-actions/harden-runner-block-action#7 is in
-      # review; update to a tagged release in lfreleng-actions/
-      # once that PR merges.
       # yamllint disable-line rule:line-length
-      - uses: modeseven-lfreleng-actions/harden-runner-block-action@feat/allow-list-loader
+      - uses: lfreleng-actions/harden-runner-block-action@18993b53be1b9327579eb1a2ba318d8a22c39f72  # v0.1.0
         with:
           org: 'lfreleng-actions'
 
       # Harden the runner with the just-loaded allow-list.
       - name: 'Harden runner (block)'
         # yamllint disable-line rule:line-length
-        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5  # v2.19.3
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411  # v2.19.4
         with:
           egress-policy: 'block'
           allowed-endpoints: >
@@ -174,20 +164,15 @@ jobs:
       # variable being exposed at runtime (org variables are
       # unreachable from workflows triggered by PRs raised from
       # forks, which previously forced a fallback to audit mode).
-      #
-      # Temporarily pinned to a branch in a personal fork while
-      # lfreleng-actions/harden-runner-block-action#7 is in
-      # review; update to a tagged release in lfreleng-actions/
-      # once that PR merges.
       # yamllint disable-line rule:line-length
-      - uses: modeseven-lfreleng-actions/harden-runner-block-action@feat/allow-list-loader
+      - uses: lfreleng-actions/harden-runner-block-action@18993b53be1b9327579eb1a2ba318d8a22c39f72  # v0.1.0
         with:
           org: 'lfreleng-actions'
 
       # Harden the runner with the just-loaded allow-list.
       - name: 'Harden runner (block)'
         # yamllint disable-line rule:line-length
-        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5  # v2.19.3
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411  # v2.19.4
         with:
           egress-policy: 'block'
           allowed-endpoints: >
@@ -199,7 +184,7 @@ jobs:
       - name: 'Build Python project'
         id: 'python-build'
         # yamllint disable-line rule:line-length
-        uses: lfreleng-actions/python-build-action@38b9a4e7ee34e56d178f5bd248df52e41f7d496e  # v1.0.6
+        uses: lfreleng-actions/python-build-action@5f570d5d17a7315074a824a91c6a705b6fc5c7dd  # v1.1.2
         with:
           sigstore_sign: true
           attestations: true
@@ -224,20 +209,15 @@ jobs:
       # variable being exposed at runtime (org variables are
       # unreachable from workflows triggered by PRs raised from
       # forks, which previously forced a fallback to audit mode).
-      #
-      # Temporarily pinned to a branch in a personal fork while
-      # lfreleng-actions/harden-runner-block-action#7 is in
-      # review; update to a tagged release in lfreleng-actions/
-      # once that PR merges.
       # yamllint disable-line rule:line-length
-      - uses: modeseven-lfreleng-actions/harden-runner-block-action@feat/allow-list-loader
+      - uses: lfreleng-actions/harden-runner-block-action@18993b53be1b9327579eb1a2ba318d8a22c39f72  # v0.1.0
         with:
           org: 'lfreleng-actions'
 
       # Harden the runner with the just-loaded allow-list.
       - name: 'Harden runner (block)'
         # yamllint disable-line rule:line-length
-        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5  # v2.19.3
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411  # v2.19.4
         with:
           egress-policy: 'block'
           allowed-endpoints: >
@@ -272,20 +252,15 @@ jobs:
       # variable being exposed at runtime (org variables are
       # unreachable from workflows triggered by PRs raised from
       # forks, which previously forced a fallback to audit mode).
-      #
-      # Temporarily pinned to a branch in a personal fork while
-      # lfreleng-actions/harden-runner-block-action#7 is in
-      # review; update to a tagged release in lfreleng-actions/
-      # once that PR merges.
       # yamllint disable-line rule:line-length
-      - uses: modeseven-lfreleng-actions/harden-runner-block-action@feat/allow-list-loader
+      - uses: lfreleng-actions/harden-runner-block-action@18993b53be1b9327579eb1a2ba318d8a22c39f72  # v0.1.0
         with:
           org: 'lfreleng-actions'
 
       # Harden the runner with the just-loaded allow-list.
       - name: 'Harden runner (block)'
         # yamllint disable-line rule:line-length
-        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5  # v2.19.3
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411  # v2.19.4
         with:
           egress-policy: 'block'
           allowed-endpoints: >
@@ -296,7 +271,7 @@ jobs:
 
       - name: 'Audit Python project'
         # yamllint disable-line rule:line-length
-        uses: lfreleng-actions/python-audit-action@275c85f883b03f5342c1fafd8173b6d996670a1d  # v0.2.7
+        uses: lfreleng-actions/python-audit-action@37dd0da54e2d66194f9d46b7000dbba5d62601f9  # v0.2.8
         with:
           python_version: "${{ matrix.python-version }}"
           permit_fail: "${{ vars.NO_BLOCK_AUDIT_FAIL == 'true' }}"
@@ -317,20 +292,15 @@ jobs:
       # variable being exposed at runtime (org variables are
       # unreachable from workflows triggered by PRs raised from
       # forks, which previously forced a fallback to audit mode).
-      #
-      # Temporarily pinned to a branch in a personal fork while
-      # lfreleng-actions/harden-runner-block-action#7 is in
-      # review; update to a tagged release in lfreleng-actions/
-      # once that PR merges.
       # yamllint disable-line rule:line-length
-      - uses: modeseven-lfreleng-actions/harden-runner-block-action@feat/allow-list-loader
+      - uses: lfreleng-actions/harden-runner-block-action@18993b53be1b9327579eb1a2ba318d8a22c39f72  # v0.1.0
         with:
           org: 'lfreleng-actions'
 
       # Harden the runner with the just-loaded allow-list.
       - name: 'Harden runner (block)'
         # yamllint disable-line rule:line-length
-        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5  # v2.19.3
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411  # v2.19.4
         with:
           egress-policy: 'block'
           allowed-endpoints: >
@@ -382,20 +352,15 @@ jobs:
       # variable being exposed at runtime (org variables are
       # unreachable from workflows triggered by PRs raised from
       # forks, which previously forced a fallback to audit mode).
-      #
-      # Temporarily pinned to a branch in a personal fork while
-      # lfreleng-actions/harden-runner-block-action#7 is in
-      # review; update to a tagged release in lfreleng-actions/
-      # once that PR merges.
       # yamllint disable-line rule:line-length
-      - uses: modeseven-lfreleng-actions/harden-runner-block-action@feat/allow-list-loader
+      - uses: lfreleng-actions/harden-runner-block-action@18993b53be1b9327579eb1a2ba318d8a22c39f72  # v0.1.0
         with:
           org: 'lfreleng-actions'
 
       # Harden the runner with the just-loaded allow-list.
       - name: 'Harden runner (block)'
         # yamllint disable-line rule:line-length
-        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5  # v2.19.3
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411  # v2.19.4
         with:
           egress-policy: 'block'
           allowed-endpoints: >
@@ -574,20 +539,15 @@ jobs:
       # variable being exposed at runtime (org variables are
       # unreachable from workflows triggered by PRs raised from
       # forks, which previously forced a fallback to audit mode).
-      #
-      # Temporarily pinned to a branch in a personal fork while
-      # lfreleng-actions/harden-runner-block-action#7 is in
-      # review; update to a tagged release in lfreleng-actions/
-      # once that PR merges.
       # yamllint disable-line rule:line-length
-      - uses: modeseven-lfreleng-actions/harden-runner-block-action@feat/allow-list-loader
+      - uses: lfreleng-actions/harden-runner-block-action@18993b53be1b9327579eb1a2ba318d8a22c39f72  # v0.1.0
         with:
           org: 'lfreleng-actions'
 
       # Harden the runner with the just-loaded allow-list.
       - name: 'Harden runner (block)'
         # yamllint disable-line rule:line-length
-        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5  # v2.19.3
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411  # v2.19.4
         with:
           egress-policy: 'block'
           allowed-endpoints: >
@@ -622,20 +582,15 @@ jobs:
       # variable being exposed at runtime (org variables are
       # unreachable from workflows triggered by PRs raised from
       # forks, which previously forced a fallback to audit mode).
-      #
-      # Temporarily pinned to a branch in a personal fork while
-      # lfreleng-actions/harden-runner-block-action#7 is in
-      # review; update to a tagged release in lfreleng-actions/
-      # once that PR merges.
       # yamllint disable-line rule:line-length
-      - uses: modeseven-lfreleng-actions/harden-runner-block-action@feat/allow-list-loader
+      - uses: lfreleng-actions/harden-runner-block-action@18993b53be1b9327579eb1a2ba318d8a22c39f72  # v0.1.0
         with:
           org: 'lfreleng-actions'
 
       # Harden the runner with the just-loaded allow-list.
       - name: 'Harden runner (block)'
         # yamllint disable-line rule:line-length
-        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5  # v2.19.3
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411  # v2.19.4
         with:
           egress-policy: 'block'
           allowed-endpoints: >
@@ -680,20 +635,15 @@ jobs:
       # variable being exposed at runtime (org variables are
       # unreachable from workflows triggered by PRs raised from
       # forks, which previously forced a fallback to audit mode).
-      #
-      # Temporarily pinned to a branch in a personal fork while
-      # lfreleng-actions/harden-runner-block-action#7 is in
-      # review; update to a tagged release in lfreleng-actions/
-      # once that PR merges.
       # yamllint disable-line rule:line-length
-      - uses: modeseven-lfreleng-actions/harden-runner-block-action@feat/allow-list-loader
+      - uses: lfreleng-actions/harden-runner-block-action@18993b53be1b9327579eb1a2ba318d8a22c39f72  # v0.1.0
         with:
           org: 'lfreleng-actions'
 
       # Harden the runner with the just-loaded allow-list.
       - name: 'Harden runner (block)'
         # yamllint disable-line rule:line-length
-        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5  # v2.19.3
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411  # v2.19.4
         with:
           egress-policy: 'block'
           allowed-endpoints: >
@@ -739,20 +689,15 @@ jobs:
       # variable being exposed at runtime (org variables are
       # unreachable from workflows triggered by PRs raised from
       # forks, which previously forced a fallback to audit mode).
-      #
-      # Temporarily pinned to a branch in a personal fork while
-      # lfreleng-actions/harden-runner-block-action#7 is in
-      # review; update to a tagged release in lfreleng-actions/
-      # once that PR merges.
       # yamllint disable-line rule:line-length
-      - uses: modeseven-lfreleng-actions/harden-runner-block-action@feat/allow-list-loader
+      - uses: lfreleng-actions/harden-runner-block-action@18993b53be1b9327579eb1a2ba318d8a22c39f72  # v0.1.0
         with:
           org: 'lfreleng-actions'
 
       # Harden the runner with the just-loaded allow-list.
       - name: 'Harden runner (block)'
         # yamllint disable-line rule:line-length
-        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5  # v2.19.3
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411  # v2.19.4
         with:
           egress-policy: 'block'
           allowed-endpoints: >

--- a/.github/workflows/build-test-release.yaml
+++ b/.github/workflows/build-test-release.yaml
@@ -27,28 +27,32 @@ jobs:
       pull-requests: read
     timeout-minutes: 5
     steps:
-      # When the CONNECTION_WHITELIST repo/org variable is exposed
-      # to this run (i.e. not a fork PR), use it to enforce a
-      # block-mode egress policy.
-      - name: 'Harden runner (block egress with whitelist)'
-        if: ${{ vars.CONNECTION_WHITELIST != '' }}
+      # Load the egress allow-list out-of-band from
+      # lfreleng-actions/.github and publish it as
+      # $CONNECTION_ALLOW_LIST for the harden-runner step below
+      # to consume in 'block' mode. Loading out-of-band means
+      # the workflow no longer depends on any org-level GitHub
+      # variable being exposed at runtime (org variables are
+      # unreachable from workflows triggered by PRs raised from
+      # forks, which previously forced a fallback to audit mode).
+      #
+      # Temporarily pinned to a branch in a personal fork while
+      # lfreleng-actions/harden-runner-block-action#5 is in
+      # review; update to a tagged release in lfreleng-actions/
+      # once that PR merges.
+      # yamllint disable-line rule:line-length
+      - uses: modeseven-lfreleng-actions/harden-runner-block-action@feat/whitelist-loader
+        with:
+          org: 'lfreleng-actions'
+
+      # Harden the runner with the just-loaded allow-list.
+      - name: 'Harden runner (block)'
         # yamllint disable-line rule:line-length
         uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5  # v2.19.3
         with:
           egress-policy: 'block'
           allowed-endpoints: >
-            ${{ vars.CONNECTION_WHITELIST }}
-
-      # Fallback for fork PRs and other contexts where the
-      # CONNECTION_WHITELIST variable is not exposed to the
-      # workflow.  Audit-only mode logs all egress without
-      # blocking it so CI still runs.
-      - name: 'Harden runner (audit fallback, no whitelist available)'
-        if: ${{ vars.CONNECTION_WHITELIST == '' }}
-        # yamllint disable-line rule:line-length
-        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5  # v2.19.3
-        with:
-          egress-policy: 'audit'
+            ${{ env.CONNECTION_ALLOW_LIST }}
 
       # yamllint disable-line rule:line-length
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
@@ -75,29 +79,32 @@ jobs:
     outputs:
       tag: "${{ steps.tag-validate.outputs.tag_name }}"
     steps:
-      # Harden the runner used by this workflow
-      # When the CONNECTION_WHITELIST repo/org variable is exposed
-      # to this run (i.e. not a fork PR), use it to enforce a
-      # block-mode egress policy.
-      - name: 'Harden runner (block egress with whitelist)'
-        if: ${{ vars.CONNECTION_WHITELIST != '' }}
+      # Load the egress allow-list out-of-band from
+      # lfreleng-actions/.github and publish it as
+      # $CONNECTION_ALLOW_LIST for the harden-runner step below
+      # to consume in 'block' mode. Loading out-of-band means
+      # the workflow no longer depends on any org-level GitHub
+      # variable being exposed at runtime (org variables are
+      # unreachable from workflows triggered by PRs raised from
+      # forks, which previously forced a fallback to audit mode).
+      #
+      # Temporarily pinned to a branch in a personal fork while
+      # lfreleng-actions/harden-runner-block-action#5 is in
+      # review; update to a tagged release in lfreleng-actions/
+      # once that PR merges.
+      # yamllint disable-line rule:line-length
+      - uses: modeseven-lfreleng-actions/harden-runner-block-action@feat/whitelist-loader
+        with:
+          org: 'lfreleng-actions'
+
+      # Harden the runner with the just-loaded allow-list.
+      - name: 'Harden runner (block)'
         # yamllint disable-line rule:line-length
         uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5  # v2.19.3
         with:
           egress-policy: 'block'
           allowed-endpoints: >
-            ${{ vars.CONNECTION_WHITELIST }}
-
-      # Fallback for fork PRs and other contexts where the
-      # CONNECTION_WHITELIST variable is not exposed to the
-      # workflow.  Audit-only mode logs all egress without
-      # blocking it so CI still runs.
-      - name: 'Harden runner (audit fallback, no whitelist available)'
-        if: ${{ vars.CONNECTION_WHITELIST == '' }}
-        # yamllint disable-line rule:line-length
-        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5  # v2.19.3
-        with:
-          egress-policy: 'audit'
+            ${{ env.CONNECTION_ALLOW_LIST }}
 
       - name: 'Checkout repository'
         # yamllint disable-line rule:line-length
@@ -159,29 +166,32 @@ jobs:
     env:
       GH_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
     steps:
-      # Harden the runner used by this workflow
-      # When the CONNECTION_WHITELIST repo/org variable is exposed
-      # to this run (i.e. not a fork PR), use it to enforce a
-      # block-mode egress policy.
-      - name: 'Harden runner (block egress with whitelist)'
-        if: ${{ vars.CONNECTION_WHITELIST != '' }}
+      # Load the egress allow-list out-of-band from
+      # lfreleng-actions/.github and publish it as
+      # $CONNECTION_ALLOW_LIST for the harden-runner step below
+      # to consume in 'block' mode. Loading out-of-band means
+      # the workflow no longer depends on any org-level GitHub
+      # variable being exposed at runtime (org variables are
+      # unreachable from workflows triggered by PRs raised from
+      # forks, which previously forced a fallback to audit mode).
+      #
+      # Temporarily pinned to a branch in a personal fork while
+      # lfreleng-actions/harden-runner-block-action#5 is in
+      # review; update to a tagged release in lfreleng-actions/
+      # once that PR merges.
+      # yamllint disable-line rule:line-length
+      - uses: modeseven-lfreleng-actions/harden-runner-block-action@feat/whitelist-loader
+        with:
+          org: 'lfreleng-actions'
+
+      # Harden the runner with the just-loaded allow-list.
+      - name: 'Harden runner (block)'
         # yamllint disable-line rule:line-length
         uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5  # v2.19.3
         with:
           egress-policy: 'block'
           allowed-endpoints: >
-            ${{ vars.CONNECTION_WHITELIST }}
-
-      # Fallback for fork PRs and other contexts where the
-      # CONNECTION_WHITELIST variable is not exposed to the
-      # workflow.  Audit-only mode logs all egress without
-      # blocking it so CI still runs.
-      - name: 'Harden runner (audit fallback, no whitelist available)'
-        if: ${{ vars.CONNECTION_WHITELIST == '' }}
-        # yamllint disable-line rule:line-length
-        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5  # v2.19.3
-        with:
-          egress-policy: 'audit'
+            ${{ env.CONNECTION_ALLOW_LIST }}
 
       # yamllint disable-line rule:line-length
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
@@ -206,29 +216,32 @@ jobs:
       contents: read
     timeout-minutes: 12
     steps:
-      # Harden the runner used by this workflow
-      # When the CONNECTION_WHITELIST repo/org variable is exposed
-      # to this run (i.e. not a fork PR), use it to enforce a
-      # block-mode egress policy.
-      - name: 'Harden runner (block egress with whitelist)'
-        if: ${{ vars.CONNECTION_WHITELIST != '' }}
+      # Load the egress allow-list out-of-band from
+      # lfreleng-actions/.github and publish it as
+      # $CONNECTION_ALLOW_LIST for the harden-runner step below
+      # to consume in 'block' mode. Loading out-of-band means
+      # the workflow no longer depends on any org-level GitHub
+      # variable being exposed at runtime (org variables are
+      # unreachable from workflows triggered by PRs raised from
+      # forks, which previously forced a fallback to audit mode).
+      #
+      # Temporarily pinned to a branch in a personal fork while
+      # lfreleng-actions/harden-runner-block-action#5 is in
+      # review; update to a tagged release in lfreleng-actions/
+      # once that PR merges.
+      # yamllint disable-line rule:line-length
+      - uses: modeseven-lfreleng-actions/harden-runner-block-action@feat/whitelist-loader
+        with:
+          org: 'lfreleng-actions'
+
+      # Harden the runner with the just-loaded allow-list.
+      - name: 'Harden runner (block)'
         # yamllint disable-line rule:line-length
         uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5  # v2.19.3
         with:
           egress-policy: 'block'
           allowed-endpoints: >
-            ${{ vars.CONNECTION_WHITELIST }}
-
-      # Fallback for fork PRs and other contexts where the
-      # CONNECTION_WHITELIST variable is not exposed to the
-      # workflow.  Audit-only mode logs all egress without
-      # blocking it so CI still runs.
-      - name: 'Harden runner (audit fallback, no whitelist available)'
-        if: ${{ vars.CONNECTION_WHITELIST == '' }}
-        # yamllint disable-line rule:line-length
-        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5  # v2.19.3
-        with:
-          egress-policy: 'audit'
+            ${{ env.CONNECTION_ALLOW_LIST }}
 
       # yamllint disable-line rule:line-length
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
@@ -251,29 +264,32 @@ jobs:
       contents: read
     timeout-minutes: 10
     steps:
-      # Harden the runner used by this workflow
-      # When the CONNECTION_WHITELIST repo/org variable is exposed
-      # to this run (i.e. not a fork PR), use it to enforce a
-      # block-mode egress policy.
-      - name: 'Harden runner (block egress with whitelist)'
-        if: ${{ vars.CONNECTION_WHITELIST != '' }}
+      # Load the egress allow-list out-of-band from
+      # lfreleng-actions/.github and publish it as
+      # $CONNECTION_ALLOW_LIST for the harden-runner step below
+      # to consume in 'block' mode. Loading out-of-band means
+      # the workflow no longer depends on any org-level GitHub
+      # variable being exposed at runtime (org variables are
+      # unreachable from workflows triggered by PRs raised from
+      # forks, which previously forced a fallback to audit mode).
+      #
+      # Temporarily pinned to a branch in a personal fork while
+      # lfreleng-actions/harden-runner-block-action#5 is in
+      # review; update to a tagged release in lfreleng-actions/
+      # once that PR merges.
+      # yamllint disable-line rule:line-length
+      - uses: modeseven-lfreleng-actions/harden-runner-block-action@feat/whitelist-loader
+        with:
+          org: 'lfreleng-actions'
+
+      # Harden the runner with the just-loaded allow-list.
+      - name: 'Harden runner (block)'
         # yamllint disable-line rule:line-length
         uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5  # v2.19.3
         with:
           egress-policy: 'block'
           allowed-endpoints: >
-            ${{ vars.CONNECTION_WHITELIST }}
-
-      # Fallback for fork PRs and other contexts where the
-      # CONNECTION_WHITELIST variable is not exposed to the
-      # workflow.  Audit-only mode logs all egress without
-      # blocking it so CI still runs.
-      - name: 'Harden runner (audit fallback, no whitelist available)'
-        if: ${{ vars.CONNECTION_WHITELIST == '' }}
-        # yamllint disable-line rule:line-length
-        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5  # v2.19.3
-        with:
-          egress-policy: 'audit'
+            ${{ env.CONNECTION_ALLOW_LIST }}
 
       # yamllint disable-line rule:line-length
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
@@ -293,29 +309,32 @@ jobs:
     permissions:
       contents: read
     steps:
-      # Harden the runner used by this workflow
-      # When the CONNECTION_WHITELIST repo/org variable is exposed
-      # to this run (i.e. not a fork PR), use it to enforce a
-      # block-mode egress policy.
-      - name: 'Harden runner (block egress with whitelist)'
-        if: ${{ vars.CONNECTION_WHITELIST != '' }}
+      # Load the egress allow-list out-of-band from
+      # lfreleng-actions/.github and publish it as
+      # $CONNECTION_ALLOW_LIST for the harden-runner step below
+      # to consume in 'block' mode. Loading out-of-band means
+      # the workflow no longer depends on any org-level GitHub
+      # variable being exposed at runtime (org variables are
+      # unreachable from workflows triggered by PRs raised from
+      # forks, which previously forced a fallback to audit mode).
+      #
+      # Temporarily pinned to a branch in a personal fork while
+      # lfreleng-actions/harden-runner-block-action#5 is in
+      # review; update to a tagged release in lfreleng-actions/
+      # once that PR merges.
+      # yamllint disable-line rule:line-length
+      - uses: modeseven-lfreleng-actions/harden-runner-block-action@feat/whitelist-loader
+        with:
+          org: 'lfreleng-actions'
+
+      # Harden the runner with the just-loaded allow-list.
+      - name: 'Harden runner (block)'
         # yamllint disable-line rule:line-length
         uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5  # v2.19.3
         with:
           egress-policy: 'block'
           allowed-endpoints: >
-            ${{ vars.CONNECTION_WHITELIST }}
-
-      # Fallback for fork PRs and other contexts where the
-      # CONNECTION_WHITELIST variable is not exposed to the
-      # workflow.  Audit-only mode logs all egress without
-      # blocking it so CI still runs.
-      - name: 'Harden runner (audit fallback, no whitelist available)'
-        if: ${{ vars.CONNECTION_WHITELIST == '' }}
-        # yamllint disable-line rule:line-length
-        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5  # v2.19.3
-        with:
-          egress-policy: 'audit'
+            ${{ env.CONNECTION_ALLOW_LIST }}
 
       # yamllint disable-line rule:line-length
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
@@ -355,29 +374,32 @@ jobs:
     permissions:
       contents: read
     steps:
-      # Harden the runner used by this workflow
-      # When the CONNECTION_WHITELIST repo/org variable is exposed
-      # to this run (i.e. not a fork PR), use it to enforce a
-      # block-mode egress policy.
-      - name: 'Harden runner (block egress with whitelist)'
-        if: ${{ vars.CONNECTION_WHITELIST != '' }}
+      # Load the egress allow-list out-of-band from
+      # lfreleng-actions/.github and publish it as
+      # $CONNECTION_ALLOW_LIST for the harden-runner step below
+      # to consume in 'block' mode. Loading out-of-band means
+      # the workflow no longer depends on any org-level GitHub
+      # variable being exposed at runtime (org variables are
+      # unreachable from workflows triggered by PRs raised from
+      # forks, which previously forced a fallback to audit mode).
+      #
+      # Temporarily pinned to a branch in a personal fork while
+      # lfreleng-actions/harden-runner-block-action#5 is in
+      # review; update to a tagged release in lfreleng-actions/
+      # once that PR merges.
+      # yamllint disable-line rule:line-length
+      - uses: modeseven-lfreleng-actions/harden-runner-block-action@feat/whitelist-loader
+        with:
+          org: 'lfreleng-actions'
+
+      # Harden the runner with the just-loaded allow-list.
+      - name: 'Harden runner (block)'
         # yamllint disable-line rule:line-length
         uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5  # v2.19.3
         with:
           egress-policy: 'block'
           allowed-endpoints: >
-            ${{ vars.CONNECTION_WHITELIST }}
-
-      # Fallback for fork PRs and other contexts where the
-      # CONNECTION_WHITELIST variable is not exposed to the
-      # workflow.  Audit-only mode logs all egress without
-      # blocking it so CI still runs.
-      - name: 'Harden runner (audit fallback, no whitelist available)'
-        if: ${{ vars.CONNECTION_WHITELIST == '' }}
-        # yamllint disable-line rule:line-length
-        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5  # v2.19.3
-        with:
-          egress-policy: 'audit'
+            ${{ env.CONNECTION_ALLOW_LIST }}
 
       - name: "Download SBOM artefact"
         # yamllint disable-line rule:line-length
@@ -544,29 +566,32 @@ jobs:
       id-token: write  # IMPORTANT: mandatory for trusted publishing
     timeout-minutes: 5
     steps:
-      # Harden the runner used by this workflow
-      # When the CONNECTION_WHITELIST repo/org variable is exposed
-      # to this run (i.e. not a fork PR), use it to enforce a
-      # block-mode egress policy.
-      - name: 'Harden runner (block egress with whitelist)'
-        if: ${{ vars.CONNECTION_WHITELIST != '' }}
+      # Load the egress allow-list out-of-band from
+      # lfreleng-actions/.github and publish it as
+      # $CONNECTION_ALLOW_LIST for the harden-runner step below
+      # to consume in 'block' mode. Loading out-of-band means
+      # the workflow no longer depends on any org-level GitHub
+      # variable being exposed at runtime (org variables are
+      # unreachable from workflows triggered by PRs raised from
+      # forks, which previously forced a fallback to audit mode).
+      #
+      # Temporarily pinned to a branch in a personal fork while
+      # lfreleng-actions/harden-runner-block-action#5 is in
+      # review; update to a tagged release in lfreleng-actions/
+      # once that PR merges.
+      # yamllint disable-line rule:line-length
+      - uses: modeseven-lfreleng-actions/harden-runner-block-action@feat/whitelist-loader
+        with:
+          org: 'lfreleng-actions'
+
+      # Harden the runner with the just-loaded allow-list.
+      - name: 'Harden runner (block)'
         # yamllint disable-line rule:line-length
         uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5  # v2.19.3
         with:
           egress-policy: 'block'
           allowed-endpoints: >
-            ${{ vars.CONNECTION_WHITELIST }}
-
-      # Fallback for fork PRs and other contexts where the
-      # CONNECTION_WHITELIST variable is not exposed to the
-      # workflow.  Audit-only mode logs all egress without
-      # blocking it so CI still runs.
-      - name: 'Harden runner (audit fallback, no whitelist available)'
-        if: ${{ vars.CONNECTION_WHITELIST == '' }}
-        # yamllint disable-line rule:line-length
-        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5  # v2.19.3
-        with:
-          egress-policy: 'audit'
+            ${{ env.CONNECTION_ALLOW_LIST }}
 
       - name: 'Test PyPI publishing'
         # yamllint disable-line rule:line-length
@@ -589,29 +614,32 @@ jobs:
       id-token: write  # IMPORTANT: mandatory for trusted publishing
     timeout-minutes: 5
     steps:
-      # Harden the runner used by this workflow
-      # When the CONNECTION_WHITELIST repo/org variable is exposed
-      # to this run (i.e. not a fork PR), use it to enforce a
-      # block-mode egress policy.
-      - name: 'Harden runner (block egress with whitelist)'
-        if: ${{ vars.CONNECTION_WHITELIST != '' }}
+      # Load the egress allow-list out-of-band from
+      # lfreleng-actions/.github and publish it as
+      # $CONNECTION_ALLOW_LIST for the harden-runner step below
+      # to consume in 'block' mode. Loading out-of-band means
+      # the workflow no longer depends on any org-level GitHub
+      # variable being exposed at runtime (org variables are
+      # unreachable from workflows triggered by PRs raised from
+      # forks, which previously forced a fallback to audit mode).
+      #
+      # Temporarily pinned to a branch in a personal fork while
+      # lfreleng-actions/harden-runner-block-action#5 is in
+      # review; update to a tagged release in lfreleng-actions/
+      # once that PR merges.
+      # yamllint disable-line rule:line-length
+      - uses: modeseven-lfreleng-actions/harden-runner-block-action@feat/whitelist-loader
+        with:
+          org: 'lfreleng-actions'
+
+      # Harden the runner with the just-loaded allow-list.
+      - name: 'Harden runner (block)'
         # yamllint disable-line rule:line-length
         uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5  # v2.19.3
         with:
           egress-policy: 'block'
           allowed-endpoints: >
-            ${{ vars.CONNECTION_WHITELIST }}
-
-      # Fallback for fork PRs and other contexts where the
-      # CONNECTION_WHITELIST variable is not exposed to the
-      # workflow.  Audit-only mode logs all egress without
-      # blocking it so CI still runs.
-      - name: 'Harden runner (audit fallback, no whitelist available)'
-        if: ${{ vars.CONNECTION_WHITELIST == '' }}
-        # yamllint disable-line rule:line-length
-        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5  # v2.19.3
-        with:
-          egress-policy: 'audit'
+            ${{ env.CONNECTION_ALLOW_LIST }}
 
       - name: 'PyPI release'
         # yamllint disable-line rule:line-length
@@ -644,29 +672,32 @@ jobs:
     env:
       GH_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
     steps:
-      # Harden the runner used by this workflow
-      # When the CONNECTION_WHITELIST repo/org variable is exposed
-      # to this run (i.e. not a fork PR), use it to enforce a
-      # block-mode egress policy.
-      - name: 'Harden runner (block egress with whitelist)'
-        if: ${{ vars.CONNECTION_WHITELIST != '' }}
+      # Load the egress allow-list out-of-band from
+      # lfreleng-actions/.github and publish it as
+      # $CONNECTION_ALLOW_LIST for the harden-runner step below
+      # to consume in 'block' mode. Loading out-of-band means
+      # the workflow no longer depends on any org-level GitHub
+      # variable being exposed at runtime (org variables are
+      # unreachable from workflows triggered by PRs raised from
+      # forks, which previously forced a fallback to audit mode).
+      #
+      # Temporarily pinned to a branch in a personal fork while
+      # lfreleng-actions/harden-runner-block-action#5 is in
+      # review; update to a tagged release in lfreleng-actions/
+      # once that PR merges.
+      # yamllint disable-line rule:line-length
+      - uses: modeseven-lfreleng-actions/harden-runner-block-action@feat/whitelist-loader
+        with:
+          org: 'lfreleng-actions'
+
+      # Harden the runner with the just-loaded allow-list.
+      - name: 'Harden runner (block)'
         # yamllint disable-line rule:line-length
         uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5  # v2.19.3
         with:
           egress-policy: 'block'
           allowed-endpoints: >
-            ${{ vars.CONNECTION_WHITELIST }}
-
-      # Fallback for fork PRs and other contexts where the
-      # CONNECTION_WHITELIST variable is not exposed to the
-      # workflow.  Audit-only mode logs all egress without
-      # blocking it so CI still runs.
-      - name: 'Harden runner (audit fallback, no whitelist available)'
-        if: ${{ vars.CONNECTION_WHITELIST == '' }}
-        # yamllint disable-line rule:line-length
-        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5  # v2.19.3
-        with:
-          egress-policy: 'audit'
+            ${{ env.CONNECTION_ALLOW_LIST }}
 
       # yamllint disable-line rule:line-length
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
@@ -700,29 +731,32 @@ jobs:
       # yamllint disable-line rule:line-length
       release_url: "${{ steps.promote-release.outputs.release_url || steps.set-promoted-url.outputs.release_url }}"
     steps:
-      # Harden the runner used by this workflow
-      # When the CONNECTION_WHITELIST repo/org variable is exposed
-      # to this run (i.e. not a fork PR), use it to enforce a
-      # block-mode egress policy.
-      - name: 'Harden runner (block egress with whitelist)'
-        if: ${{ vars.CONNECTION_WHITELIST != '' }}
+      # Load the egress allow-list out-of-band from
+      # lfreleng-actions/.github and publish it as
+      # $CONNECTION_ALLOW_LIST for the harden-runner step below
+      # to consume in 'block' mode. Loading out-of-band means
+      # the workflow no longer depends on any org-level GitHub
+      # variable being exposed at runtime (org variables are
+      # unreachable from workflows triggered by PRs raised from
+      # forks, which previously forced a fallback to audit mode).
+      #
+      # Temporarily pinned to a branch in a personal fork while
+      # lfreleng-actions/harden-runner-block-action#5 is in
+      # review; update to a tagged release in lfreleng-actions/
+      # once that PR merges.
+      # yamllint disable-line rule:line-length
+      - uses: modeseven-lfreleng-actions/harden-runner-block-action@feat/whitelist-loader
+        with:
+          org: 'lfreleng-actions'
+
+      # Harden the runner with the just-loaded allow-list.
+      - name: 'Harden runner (block)'
         # yamllint disable-line rule:line-length
         uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5  # v2.19.3
         with:
           egress-policy: 'block'
           allowed-endpoints: >
-            ${{ vars.CONNECTION_WHITELIST }}
-
-      # Fallback for fork PRs and other contexts where the
-      # CONNECTION_WHITELIST variable is not exposed to the
-      # workflow.  Audit-only mode logs all egress without
-      # blocking it so CI still runs.
-      - name: 'Harden runner (audit fallback, no whitelist available)'
-        if: ${{ vars.CONNECTION_WHITELIST == '' }}
-        # yamllint disable-line rule:line-length
-        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5  # v2.19.3
-        with:
-          egress-policy: 'audit'
+            ${{ env.CONNECTION_ALLOW_LIST }}
 
       # yamllint disable-line rule:line-length
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -48,20 +48,15 @@ jobs:
       # variable being exposed at runtime (org variables are
       # unreachable from workflows triggered by PRs raised from
       # forks, which previously forced a fallback to audit mode).
-      #
-      # Temporarily pinned to a branch in a personal fork while
-      # lfreleng-actions/harden-runner-block-action#7 is in
-      # review; update to a tagged release in lfreleng-actions/
-      # once that PR merges.
       # yamllint disable-line rule:line-length
-      - uses: modeseven-lfreleng-actions/harden-runner-block-action@feat/allow-list-loader
+      - uses: lfreleng-actions/harden-runner-block-action@18993b53be1b9327579eb1a2ba318d8a22c39f72  # v0.1.0
         with:
           org: 'lfreleng-actions'
 
       # Harden the runner with the just-loaded allow-list.
       - name: 'Harden runner (block)'
         # yamllint disable-line rule:line-length
-        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5  # v2.19.3
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411  # v2.19.4
         with:
           egress-policy: 'block'
           allowed-endpoints: >
@@ -104,20 +99,15 @@ jobs:
       # variable being exposed at runtime (org variables are
       # unreachable from workflows triggered by PRs raised from
       # forks, which previously forced a fallback to audit mode).
-      #
-      # Temporarily pinned to a branch in a personal fork while
-      # lfreleng-actions/harden-runner-block-action#7 is in
-      # review; update to a tagged release in lfreleng-actions/
-      # once that PR merges.
       # yamllint disable-line rule:line-length
-      - uses: modeseven-lfreleng-actions/harden-runner-block-action@feat/allow-list-loader
+      - uses: lfreleng-actions/harden-runner-block-action@18993b53be1b9327579eb1a2ba318d8a22c39f72  # v0.1.0
         with:
           org: 'lfreleng-actions'
 
       # Harden the runner with the just-loaded allow-list.
       - name: 'Harden runner (block)'
         # yamllint disable-line rule:line-length
-        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5  # v2.19.3
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411  # v2.19.4
         with:
           egress-policy: 'block'
           allowed-endpoints: >
@@ -208,20 +198,15 @@ jobs:
       # variable being exposed at runtime (org variables are
       # unreachable from workflows triggered by PRs raised from
       # forks, which previously forced a fallback to audit mode).
-      #
-      # Temporarily pinned to a branch in a personal fork while
-      # lfreleng-actions/harden-runner-block-action#7 is in
-      # review; update to a tagged release in lfreleng-actions/
-      # once that PR merges.
       # yamllint disable-line rule:line-length
-      - uses: modeseven-lfreleng-actions/harden-runner-block-action@feat/allow-list-loader
+      - uses: lfreleng-actions/harden-runner-block-action@18993b53be1b9327579eb1a2ba318d8a22c39f72  # v0.1.0
         with:
           org: 'lfreleng-actions'
 
       # Harden the runner with the just-loaded allow-list.
       - name: 'Harden runner (block)'
         # yamllint disable-line rule:line-length
-        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5  # v2.19.3
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411  # v2.19.4
         with:
           egress-policy: 'block'
           allowed-endpoints: >
@@ -233,7 +218,7 @@ jobs:
       - name: 'Build Python project'
         id: python-build
         # yamllint disable-line rule:line-length
-        uses: lfreleng-actions/python-build-action@38b9a4e7ee34e56d178f5bd248df52e41f7d496e  # v1.0.6
+        uses: lfreleng-actions/python-build-action@5f570d5d17a7315074a824a91c6a705b6fc5c7dd  # v1.1.2
 
   python-tests:
     name: 'Python Tests'
@@ -256,20 +241,15 @@ jobs:
       # variable being exposed at runtime (org variables are
       # unreachable from workflows triggered by PRs raised from
       # forks, which previously forced a fallback to audit mode).
-      #
-      # Temporarily pinned to a branch in a personal fork while
-      # lfreleng-actions/harden-runner-block-action#7 is in
-      # review; update to a tagged release in lfreleng-actions/
-      # once that PR merges.
       # yamllint disable-line rule:line-length
-      - uses: modeseven-lfreleng-actions/harden-runner-block-action@feat/allow-list-loader
+      - uses: lfreleng-actions/harden-runner-block-action@18993b53be1b9327579eb1a2ba318d8a22c39f72  # v0.1.0
         with:
           org: 'lfreleng-actions'
 
       # Harden the runner with the just-loaded allow-list.
       - name: 'Harden runner (block)'
         # yamllint disable-line rule:line-length
-        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5  # v2.19.3
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411  # v2.19.4
         with:
           egress-policy: 'block'
           allowed-endpoints: >
@@ -305,20 +285,15 @@ jobs:
       # variable being exposed at runtime (org variables are
       # unreachable from workflows triggered by PRs raised from
       # forks, which previously forced a fallback to audit mode).
-      #
-      # Temporarily pinned to a branch in a personal fork while
-      # lfreleng-actions/harden-runner-block-action#7 is in
-      # review; update to a tagged release in lfreleng-actions/
-      # once that PR merges.
       # yamllint disable-line rule:line-length
-      - uses: modeseven-lfreleng-actions/harden-runner-block-action@feat/allow-list-loader
+      - uses: lfreleng-actions/harden-runner-block-action@18993b53be1b9327579eb1a2ba318d8a22c39f72  # v0.1.0
         with:
           org: 'lfreleng-actions'
 
       # Harden the runner with the just-loaded allow-list.
       - name: 'Harden runner (block)'
         # yamllint disable-line rule:line-length
-        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5  # v2.19.3
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411  # v2.19.4
         with:
           egress-policy: 'block'
           allowed-endpoints: >
@@ -329,7 +304,7 @@ jobs:
 
       - name: "Audit dependencies ${{ matrix.python-version }}"
         # yamllint disable-line rule:line-length
-        uses: lfreleng-actions/python-audit-action@275c85f883b03f5342c1fafd8173b6d996670a1d  # v0.2.7
+        uses: lfreleng-actions/python-audit-action@37dd0da54e2d66194f9d46b7000dbba5d62601f9  # v0.2.8
         with:
           python_version: "${{ matrix.python-version }}"
           permit_fail: "${{ vars.NO_BLOCK_AUDIT_FAIL == 'true' }}"
@@ -351,20 +326,15 @@ jobs:
       # variable being exposed at runtime (org variables are
       # unreachable from workflows triggered by PRs raised from
       # forks, which previously forced a fallback to audit mode).
-      #
-      # Temporarily pinned to a branch in a personal fork while
-      # lfreleng-actions/harden-runner-block-action#7 is in
-      # review; update to a tagged release in lfreleng-actions/
-      # once that PR merges.
       # yamllint disable-line rule:line-length
-      - uses: modeseven-lfreleng-actions/harden-runner-block-action@feat/allow-list-loader
+      - uses: lfreleng-actions/harden-runner-block-action@18993b53be1b9327579eb1a2ba318d8a22c39f72  # v0.1.0
         with:
           org: 'lfreleng-actions'
 
       # Harden the runner with the just-loaded allow-list.
       - name: 'Harden runner (block)'
         # yamllint disable-line rule:line-length
-        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5  # v2.19.3
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411  # v2.19.4
         with:
           egress-policy: 'block'
           allowed-endpoints: >
@@ -417,20 +387,15 @@ jobs:
       # variable being exposed at runtime (org variables are
       # unreachable from workflows triggered by PRs raised from
       # forks, which previously forced a fallback to audit mode).
-      #
-      # Temporarily pinned to a branch in a personal fork while
-      # lfreleng-actions/harden-runner-block-action#7 is in
-      # review; update to a tagged release in lfreleng-actions/
-      # once that PR merges.
       # yamllint disable-line rule:line-length
-      - uses: modeseven-lfreleng-actions/harden-runner-block-action@feat/allow-list-loader
+      - uses: lfreleng-actions/harden-runner-block-action@18993b53be1b9327579eb1a2ba318d8a22c39f72  # v0.1.0
         with:
           org: 'lfreleng-actions'
 
       # Harden the runner with the just-loaded allow-list.
       - name: 'Harden runner (block)'
         # yamllint disable-line rule:line-length
-        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5  # v2.19.3
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411  # v2.19.4
         with:
           egress-policy: 'block'
           allowed-endpoints: >

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -40,28 +40,32 @@ jobs:
       pull-requests: read
     timeout-minutes: 5
     steps:
-      # When the CONNECTION_WHITELIST repo/org variable is exposed
-      # to this run (i.e. not a fork PR), use it to enforce a
-      # block-mode egress policy.
-      - name: 'Harden runner (block egress with whitelist)'
-        if: ${{ vars.CONNECTION_WHITELIST != '' }}
+      # Load the egress allow-list out-of-band from
+      # lfreleng-actions/.github and publish it as
+      # $CONNECTION_ALLOW_LIST for the harden-runner step below
+      # to consume in 'block' mode. Loading out-of-band means
+      # the workflow no longer depends on any org-level GitHub
+      # variable being exposed at runtime (org variables are
+      # unreachable from workflows triggered by PRs raised from
+      # forks, which previously forced a fallback to audit mode).
+      #
+      # Temporarily pinned to a branch in a personal fork while
+      # lfreleng-actions/harden-runner-block-action#5 is in
+      # review; update to a tagged release in lfreleng-actions/
+      # once that PR merges.
+      # yamllint disable-line rule:line-length
+      - uses: modeseven-lfreleng-actions/harden-runner-block-action@feat/whitelist-loader
+        with:
+          org: 'lfreleng-actions'
+
+      # Harden the runner with the just-loaded allow-list.
+      - name: 'Harden runner (block)'
         # yamllint disable-line rule:line-length
         uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5  # v2.19.3
         with:
           egress-policy: 'block'
           allowed-endpoints: >
-            ${{ vars.CONNECTION_WHITELIST }}
-
-      # Fallback for fork PRs and other contexts where the
-      # CONNECTION_WHITELIST variable is not exposed to the
-      # workflow.  Audit-only mode logs all egress without
-      # blocking it so CI still runs.
-      - name: 'Harden runner (audit fallback, no whitelist available)'
-        if: ${{ vars.CONNECTION_WHITELIST == '' }}
-        # yamllint disable-line rule:line-length
-        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5  # v2.19.3
-        with:
-          egress-policy: 'audit'
+            ${{ env.CONNECTION_ALLOW_LIST }}
 
       # yamllint disable-line rule:line-length
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
@@ -92,28 +96,32 @@ jobs:
     env:
       GH_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
     steps:
-      # When the CONNECTION_WHITELIST repo/org variable is exposed
-      # to this run (i.e. not a fork PR), use it to enforce a
-      # block-mode egress policy.
-      - name: 'Harden runner (block egress with whitelist)'
-        if: ${{ vars.CONNECTION_WHITELIST != '' }}
+      # Load the egress allow-list out-of-band from
+      # lfreleng-actions/.github and publish it as
+      # $CONNECTION_ALLOW_LIST for the harden-runner step below
+      # to consume in 'block' mode. Loading out-of-band means
+      # the workflow no longer depends on any org-level GitHub
+      # variable being exposed at runtime (org variables are
+      # unreachable from workflows triggered by PRs raised from
+      # forks, which previously forced a fallback to audit mode).
+      #
+      # Temporarily pinned to a branch in a personal fork while
+      # lfreleng-actions/harden-runner-block-action#5 is in
+      # review; update to a tagged release in lfreleng-actions/
+      # once that PR merges.
+      # yamllint disable-line rule:line-length
+      - uses: modeseven-lfreleng-actions/harden-runner-block-action@feat/whitelist-loader
+        with:
+          org: 'lfreleng-actions'
+
+      # Harden the runner with the just-loaded allow-list.
+      - name: 'Harden runner (block)'
         # yamllint disable-line rule:line-length
         uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5  # v2.19.3
         with:
           egress-policy: 'block'
           allowed-endpoints: >
-            ${{ vars.CONNECTION_WHITELIST }}
-
-      # Fallback for fork PRs and other contexts where the
-      # CONNECTION_WHITELIST variable is not exposed to the
-      # workflow.  Audit-only mode logs all egress without
-      # blocking it so CI still runs.
-      - name: 'Harden runner (audit fallback, no whitelist available)'
-        if: ${{ vars.CONNECTION_WHITELIST == '' }}
-        # yamllint disable-line rule:line-length
-        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5  # v2.19.3
-        with:
-          egress-policy: 'audit'
+            ${{ env.CONNECTION_ALLOW_LIST }}
 
       - name: 'Clear Python dependency caches'
         env:
@@ -192,29 +200,32 @@ jobs:
       contents: read
     timeout-minutes: 12
     steps:
-      # Harden the runner used by this workflow
-      # When the CONNECTION_WHITELIST repo/org variable is exposed
-      # to this run (i.e. not a fork PR), use it to enforce a
-      # block-mode egress policy.
-      - name: 'Harden runner (block egress with whitelist)'
-        if: ${{ vars.CONNECTION_WHITELIST != '' }}
+      # Load the egress allow-list out-of-band from
+      # lfreleng-actions/.github and publish it as
+      # $CONNECTION_ALLOW_LIST for the harden-runner step below
+      # to consume in 'block' mode. Loading out-of-band means
+      # the workflow no longer depends on any org-level GitHub
+      # variable being exposed at runtime (org variables are
+      # unreachable from workflows triggered by PRs raised from
+      # forks, which previously forced a fallback to audit mode).
+      #
+      # Temporarily pinned to a branch in a personal fork while
+      # lfreleng-actions/harden-runner-block-action#5 is in
+      # review; update to a tagged release in lfreleng-actions/
+      # once that PR merges.
+      # yamllint disable-line rule:line-length
+      - uses: modeseven-lfreleng-actions/harden-runner-block-action@feat/whitelist-loader
+        with:
+          org: 'lfreleng-actions'
+
+      # Harden the runner with the just-loaded allow-list.
+      - name: 'Harden runner (block)'
         # yamllint disable-line rule:line-length
         uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5  # v2.19.3
         with:
           egress-policy: 'block'
           allowed-endpoints: >
-            ${{ vars.CONNECTION_WHITELIST }}
-
-      # Fallback for fork PRs and other contexts where the
-      # CONNECTION_WHITELIST variable is not exposed to the
-      # workflow.  Audit-only mode logs all egress without
-      # blocking it so CI still runs.
-      - name: 'Harden runner (audit fallback, no whitelist available)'
-        if: ${{ vars.CONNECTION_WHITELIST == '' }}
-        # yamllint disable-line rule:line-length
-        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5  # v2.19.3
-        with:
-          egress-policy: 'audit'
+            ${{ env.CONNECTION_ALLOW_LIST }}
 
       # yamllint disable-line rule:line-length
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
@@ -237,29 +248,32 @@ jobs:
       contents: read
     timeout-minutes: 12
     steps:
-      # Harden the runner used by this workflow
-      # When the CONNECTION_WHITELIST repo/org variable is exposed
-      # to this run (i.e. not a fork PR), use it to enforce a
-      # block-mode egress policy.
-      - name: 'Harden runner (block egress with whitelist)'
-        if: ${{ vars.CONNECTION_WHITELIST != '' }}
+      # Load the egress allow-list out-of-band from
+      # lfreleng-actions/.github and publish it as
+      # $CONNECTION_ALLOW_LIST for the harden-runner step below
+      # to consume in 'block' mode. Loading out-of-band means
+      # the workflow no longer depends on any org-level GitHub
+      # variable being exposed at runtime (org variables are
+      # unreachable from workflows triggered by PRs raised from
+      # forks, which previously forced a fallback to audit mode).
+      #
+      # Temporarily pinned to a branch in a personal fork while
+      # lfreleng-actions/harden-runner-block-action#5 is in
+      # review; update to a tagged release in lfreleng-actions/
+      # once that PR merges.
+      # yamllint disable-line rule:line-length
+      - uses: modeseven-lfreleng-actions/harden-runner-block-action@feat/whitelist-loader
+        with:
+          org: 'lfreleng-actions'
+
+      # Harden the runner with the just-loaded allow-list.
+      - name: 'Harden runner (block)'
         # yamllint disable-line rule:line-length
         uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5  # v2.19.3
         with:
           egress-policy: 'block'
           allowed-endpoints: >
-            ${{ vars.CONNECTION_WHITELIST }}
-
-      # Fallback for fork PRs and other contexts where the
-      # CONNECTION_WHITELIST variable is not exposed to the
-      # workflow.  Audit-only mode logs all egress without
-      # blocking it so CI still runs.
-      - name: 'Harden runner (audit fallback, no whitelist available)'
-        if: ${{ vars.CONNECTION_WHITELIST == '' }}
-        # yamllint disable-line rule:line-length
-        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5  # v2.19.3
-        with:
-          egress-policy: 'audit'
+            ${{ env.CONNECTION_ALLOW_LIST }}
 
       # yamllint disable-line rule:line-length
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
@@ -283,29 +297,32 @@ jobs:
       contents: read
     timeout-minutes: 10
     steps:
-      # Harden the runner used by this workflow
-      # When the CONNECTION_WHITELIST repo/org variable is exposed
-      # to this run (i.e. not a fork PR), use it to enforce a
-      # block-mode egress policy.
-      - name: 'Harden runner (block egress with whitelist)'
-        if: ${{ vars.CONNECTION_WHITELIST != '' }}
+      # Load the egress allow-list out-of-band from
+      # lfreleng-actions/.github and publish it as
+      # $CONNECTION_ALLOW_LIST for the harden-runner step below
+      # to consume in 'block' mode. Loading out-of-band means
+      # the workflow no longer depends on any org-level GitHub
+      # variable being exposed at runtime (org variables are
+      # unreachable from workflows triggered by PRs raised from
+      # forks, which previously forced a fallback to audit mode).
+      #
+      # Temporarily pinned to a branch in a personal fork while
+      # lfreleng-actions/harden-runner-block-action#5 is in
+      # review; update to a tagged release in lfreleng-actions/
+      # once that PR merges.
+      # yamllint disable-line rule:line-length
+      - uses: modeseven-lfreleng-actions/harden-runner-block-action@feat/whitelist-loader
+        with:
+          org: 'lfreleng-actions'
+
+      # Harden the runner with the just-loaded allow-list.
+      - name: 'Harden runner (block)'
         # yamllint disable-line rule:line-length
         uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5  # v2.19.3
         with:
           egress-policy: 'block'
           allowed-endpoints: >
-            ${{ vars.CONNECTION_WHITELIST }}
-
-      # Fallback for fork PRs and other contexts where the
-      # CONNECTION_WHITELIST variable is not exposed to the
-      # workflow.  Audit-only mode logs all egress without
-      # blocking it so CI still runs.
-      - name: 'Harden runner (audit fallback, no whitelist available)'
-        if: ${{ vars.CONNECTION_WHITELIST == '' }}
-        # yamllint disable-line rule:line-length
-        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5  # v2.19.3
-        with:
-          egress-policy: 'audit'
+            ${{ env.CONNECTION_ALLOW_LIST }}
 
       # yamllint disable-line rule:line-length
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
@@ -326,29 +343,32 @@ jobs:
     permissions:
       contents: read
     steps:
-      # Harden the runner used by this workflow
-      # When the CONNECTION_WHITELIST repo/org variable is exposed
-      # to this run (i.e. not a fork PR), use it to enforce a
-      # block-mode egress policy.
-      - name: 'Harden runner (block egress with whitelist)'
-        if: ${{ vars.CONNECTION_WHITELIST != '' }}
+      # Load the egress allow-list out-of-band from
+      # lfreleng-actions/.github and publish it as
+      # $CONNECTION_ALLOW_LIST for the harden-runner step below
+      # to consume in 'block' mode. Loading out-of-band means
+      # the workflow no longer depends on any org-level GitHub
+      # variable being exposed at runtime (org variables are
+      # unreachable from workflows triggered by PRs raised from
+      # forks, which previously forced a fallback to audit mode).
+      #
+      # Temporarily pinned to a branch in a personal fork while
+      # lfreleng-actions/harden-runner-block-action#5 is in
+      # review; update to a tagged release in lfreleng-actions/
+      # once that PR merges.
+      # yamllint disable-line rule:line-length
+      - uses: modeseven-lfreleng-actions/harden-runner-block-action@feat/whitelist-loader
+        with:
+          org: 'lfreleng-actions'
+
+      # Harden the runner with the just-loaded allow-list.
+      - name: 'Harden runner (block)'
         # yamllint disable-line rule:line-length
         uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5  # v2.19.3
         with:
           egress-policy: 'block'
           allowed-endpoints: >
-            ${{ vars.CONNECTION_WHITELIST }}
-
-      # Fallback for fork PRs and other contexts where the
-      # CONNECTION_WHITELIST variable is not exposed to the
-      # workflow.  Audit-only mode logs all egress without
-      # blocking it so CI still runs.
-      - name: 'Harden runner (audit fallback, no whitelist available)'
-        if: ${{ vars.CONNECTION_WHITELIST == '' }}
-        # yamllint disable-line rule:line-length
-        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5  # v2.19.3
-        with:
-          egress-policy: 'audit'
+            ${{ env.CONNECTION_ALLOW_LIST }}
 
       # yamllint disable-line rule:line-length
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
@@ -389,29 +409,32 @@ jobs:
     permissions:
       contents: read
     steps:
-      # Harden the runner used by this workflow
-      # When the CONNECTION_WHITELIST repo/org variable is exposed
-      # to this run (i.e. not a fork PR), use it to enforce a
-      # block-mode egress policy.
-      - name: 'Harden runner (block egress with whitelist)'
-        if: ${{ vars.CONNECTION_WHITELIST != '' }}
+      # Load the egress allow-list out-of-band from
+      # lfreleng-actions/.github and publish it as
+      # $CONNECTION_ALLOW_LIST for the harden-runner step below
+      # to consume in 'block' mode. Loading out-of-band means
+      # the workflow no longer depends on any org-level GitHub
+      # variable being exposed at runtime (org variables are
+      # unreachable from workflows triggered by PRs raised from
+      # forks, which previously forced a fallback to audit mode).
+      #
+      # Temporarily pinned to a branch in a personal fork while
+      # lfreleng-actions/harden-runner-block-action#5 is in
+      # review; update to a tagged release in lfreleng-actions/
+      # once that PR merges.
+      # yamllint disable-line rule:line-length
+      - uses: modeseven-lfreleng-actions/harden-runner-block-action@feat/whitelist-loader
+        with:
+          org: 'lfreleng-actions'
+
+      # Harden the runner with the just-loaded allow-list.
+      - name: 'Harden runner (block)'
         # yamllint disable-line rule:line-length
         uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5  # v2.19.3
         with:
           egress-policy: 'block'
           allowed-endpoints: >
-            ${{ vars.CONNECTION_WHITELIST }}
-
-      # Fallback for fork PRs and other contexts where the
-      # CONNECTION_WHITELIST variable is not exposed to the
-      # workflow.  Audit-only mode logs all egress without
-      # blocking it so CI still runs.
-      - name: 'Harden runner (audit fallback, no whitelist available)'
-        if: ${{ vars.CONNECTION_WHITELIST == '' }}
-        # yamllint disable-line rule:line-length
-        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5  # v2.19.3
-        with:
-          egress-policy: 'audit'
+            ${{ env.CONNECTION_ALLOW_LIST }}
 
       - name: "Download SBOM artefact"
         # yamllint disable-line rule:line-length

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -50,11 +50,11 @@ jobs:
       # forks, which previously forced a fallback to audit mode).
       #
       # Temporarily pinned to a branch in a personal fork while
-      # lfreleng-actions/harden-runner-block-action#5 is in
+      # lfreleng-actions/harden-runner-block-action#7 is in
       # review; update to a tagged release in lfreleng-actions/
       # once that PR merges.
       # yamllint disable-line rule:line-length
-      - uses: modeseven-lfreleng-actions/harden-runner-block-action@feat/whitelist-loader
+      - uses: modeseven-lfreleng-actions/harden-runner-block-action@feat/allow-list-loader
         with:
           org: 'lfreleng-actions'
 
@@ -106,11 +106,11 @@ jobs:
       # forks, which previously forced a fallback to audit mode).
       #
       # Temporarily pinned to a branch in a personal fork while
-      # lfreleng-actions/harden-runner-block-action#5 is in
+      # lfreleng-actions/harden-runner-block-action#7 is in
       # review; update to a tagged release in lfreleng-actions/
       # once that PR merges.
       # yamllint disable-line rule:line-length
-      - uses: modeseven-lfreleng-actions/harden-runner-block-action@feat/whitelist-loader
+      - uses: modeseven-lfreleng-actions/harden-runner-block-action@feat/allow-list-loader
         with:
           org: 'lfreleng-actions'
 
@@ -210,11 +210,11 @@ jobs:
       # forks, which previously forced a fallback to audit mode).
       #
       # Temporarily pinned to a branch in a personal fork while
-      # lfreleng-actions/harden-runner-block-action#5 is in
+      # lfreleng-actions/harden-runner-block-action#7 is in
       # review; update to a tagged release in lfreleng-actions/
       # once that PR merges.
       # yamllint disable-line rule:line-length
-      - uses: modeseven-lfreleng-actions/harden-runner-block-action@feat/whitelist-loader
+      - uses: modeseven-lfreleng-actions/harden-runner-block-action@feat/allow-list-loader
         with:
           org: 'lfreleng-actions'
 
@@ -258,11 +258,11 @@ jobs:
       # forks, which previously forced a fallback to audit mode).
       #
       # Temporarily pinned to a branch in a personal fork while
-      # lfreleng-actions/harden-runner-block-action#5 is in
+      # lfreleng-actions/harden-runner-block-action#7 is in
       # review; update to a tagged release in lfreleng-actions/
       # once that PR merges.
       # yamllint disable-line rule:line-length
-      - uses: modeseven-lfreleng-actions/harden-runner-block-action@feat/whitelist-loader
+      - uses: modeseven-lfreleng-actions/harden-runner-block-action@feat/allow-list-loader
         with:
           org: 'lfreleng-actions'
 
@@ -307,11 +307,11 @@ jobs:
       # forks, which previously forced a fallback to audit mode).
       #
       # Temporarily pinned to a branch in a personal fork while
-      # lfreleng-actions/harden-runner-block-action#5 is in
+      # lfreleng-actions/harden-runner-block-action#7 is in
       # review; update to a tagged release in lfreleng-actions/
       # once that PR merges.
       # yamllint disable-line rule:line-length
-      - uses: modeseven-lfreleng-actions/harden-runner-block-action@feat/whitelist-loader
+      - uses: modeseven-lfreleng-actions/harden-runner-block-action@feat/allow-list-loader
         with:
           org: 'lfreleng-actions'
 
@@ -353,11 +353,11 @@ jobs:
       # forks, which previously forced a fallback to audit mode).
       #
       # Temporarily pinned to a branch in a personal fork while
-      # lfreleng-actions/harden-runner-block-action#5 is in
+      # lfreleng-actions/harden-runner-block-action#7 is in
       # review; update to a tagged release in lfreleng-actions/
       # once that PR merges.
       # yamllint disable-line rule:line-length
-      - uses: modeseven-lfreleng-actions/harden-runner-block-action@feat/whitelist-loader
+      - uses: modeseven-lfreleng-actions/harden-runner-block-action@feat/allow-list-loader
         with:
           org: 'lfreleng-actions'
 
@@ -419,11 +419,11 @@ jobs:
       # forks, which previously forced a fallback to audit mode).
       #
       # Temporarily pinned to a branch in a personal fork while
-      # lfreleng-actions/harden-runner-block-action#5 is in
+      # lfreleng-actions/harden-runner-block-action#7 is in
       # review; update to a tagged release in lfreleng-actions/
       # once that PR merges.
       # yamllint disable-line rule:line-length
-      - uses: modeseven-lfreleng-actions/harden-runner-block-action@feat/whitelist-loader
+      - uses: modeseven-lfreleng-actions/harden-runner-block-action@feat/allow-list-loader
         with:
           org: 'lfreleng-actions'
 

--- a/.github/workflows/release-drafter.yaml
+++ b/.github/workflows/release-drafter.yaml
@@ -25,29 +25,32 @@ jobs:
     runs-on: 'ubuntu-latest'
     timeout-minutes: 3
     steps:
-      # Harden the runner used by this workflow
-      # When the CONNECTION_WHITELIST repo/org variable is exposed
-      # to this run (i.e. not a fork PR), use it to enforce a
-      # block-mode egress policy.
-      - name: 'Harden runner (block egress with whitelist)'
-        if: ${{ vars.CONNECTION_WHITELIST != '' }}
+      # Load the egress allow-list out-of-band from
+      # lfreleng-actions/.github and publish it as
+      # $CONNECTION_ALLOW_LIST for the harden-runner step below
+      # to consume in 'block' mode. Loading out-of-band means
+      # the workflow no longer depends on any org-level GitHub
+      # variable being exposed at runtime (org variables are
+      # unreachable from workflows triggered by PRs raised from
+      # forks, which previously forced a fallback to audit mode).
+      #
+      # Temporarily pinned to a branch in a personal fork while
+      # lfreleng-actions/harden-runner-block-action#5 is in
+      # review; update to a tagged release in lfreleng-actions/
+      # once that PR merges.
+      # yamllint disable-line rule:line-length
+      - uses: modeseven-lfreleng-actions/harden-runner-block-action@feat/whitelist-loader
+        with:
+          org: 'lfreleng-actions'
+
+      # Harden the runner with the just-loaded allow-list.
+      - name: 'Harden runner (block)'
         # yamllint disable-line rule:line-length
         uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5  # v2.19.3
         with:
           egress-policy: 'block'
           allowed-endpoints: >
-            ${{ vars.CONNECTION_WHITELIST }}
-
-      # Fallback for fork PRs and other contexts where the
-      # CONNECTION_WHITELIST variable is not exposed to the
-      # workflow.  Audit-only mode logs all egress without
-      # blocking it so CI still runs.
-      - name: 'Harden runner (audit fallback, no whitelist available)'
-        if: ${{ vars.CONNECTION_WHITELIST == '' }}
-        # yamllint disable-line rule:line-length
-        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5  # v2.19.3
-        with:
-          egress-policy: 'audit'
+            ${{ env.CONNECTION_ALLOW_LIST }}
 
       # yamllint disable-line rule:line-length
       - uses: release-drafter/release-drafter@c2e2804cc59f45f57076a99af580d0fedb697927  # v7.3.0

--- a/.github/workflows/release-drafter.yaml
+++ b/.github/workflows/release-drafter.yaml
@@ -35,11 +35,11 @@ jobs:
       # forks, which previously forced a fallback to audit mode).
       #
       # Temporarily pinned to a branch in a personal fork while
-      # lfreleng-actions/harden-runner-block-action#5 is in
+      # lfreleng-actions/harden-runner-block-action#7 is in
       # review; update to a tagged release in lfreleng-actions/
       # once that PR merges.
       # yamllint disable-line rule:line-length
-      - uses: modeseven-lfreleng-actions/harden-runner-block-action@feat/whitelist-loader
+      - uses: modeseven-lfreleng-actions/harden-runner-block-action@feat/allow-list-loader
         with:
           org: 'lfreleng-actions'
 

--- a/.github/workflows/release-drafter.yaml
+++ b/.github/workflows/release-drafter.yaml
@@ -33,24 +33,19 @@ jobs:
       # variable being exposed at runtime (org variables are
       # unreachable from workflows triggered by PRs raised from
       # forks, which previously forced a fallback to audit mode).
-      #
-      # Temporarily pinned to a branch in a personal fork while
-      # lfreleng-actions/harden-runner-block-action#7 is in
-      # review; update to a tagged release in lfreleng-actions/
-      # once that PR merges.
       # yamllint disable-line rule:line-length
-      - uses: modeseven-lfreleng-actions/harden-runner-block-action@feat/allow-list-loader
+      - uses: lfreleng-actions/harden-runner-block-action@18993b53be1b9327579eb1a2ba318d8a22c39f72  # v0.1.0
         with:
           org: 'lfreleng-actions'
 
       # Harden the runner with the just-loaded allow-list.
       - name: 'Harden runner (block)'
         # yamllint disable-line rule:line-length
-        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5  # v2.19.3
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411  # v2.19.4
         with:
           egress-policy: 'block'
           allowed-endpoints: >
             ${{ env.CONNECTION_ALLOW_LIST }}
 
       # yamllint disable-line rule:line-length
-      - uses: release-drafter/release-drafter@c2e2804cc59f45f57076a99af580d0fedb697927  # v7.3.0
+      - uses: release-drafter/release-drafter@693d20e7c1ce1a81d3a41962f85914253b518449  # v7.3.1

--- a/.github/workflows/zizmor.yaml
+++ b/.github/workflows/zizmor.yaml
@@ -66,7 +66,7 @@ jobs:
     steps:
       # Harden the runner used by this workflow.
       # yamllint disable-line rule:line-length
-      - uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5  # v2.19.3
+      - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411  # v2.19.4
         with:
           egress-policy: 'audit'
 
@@ -486,7 +486,7 @@ jobs:
     steps:
       # Harden the runner used by this workflow.
       # yamllint disable-line rule:line-length
-      - uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5  # v2.19.3
+      - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411  # v2.19.4
         with:
           egress-policy: 'audit'
 
@@ -510,7 +510,7 @@ jobs:
         # block other required checks on the calling repository.
         continue-on-error: true
         # yamllint disable-line rule:line-length
-        uses: github/codeql-action/upload-sarif@9e0d7b8d25671d64c341c19c0152d693099fb5ba  # v4.35.5
+        uses: github/codeql-action/upload-sarif@7211b7c8077ea37d8641b6271f6a365a22a5fbfa  # v4.36.0
         with:
           sarif_file: 'zizmor.sarif'
           category: 'zizmor'


### PR DESCRIPTION
## Summary

The `pip` ecosystem entry in `dependabot.yml` that keeps the zizmor
pin (`.github/dependabot/zizmor-requirements.txt`) current had no
`allow` filter. The pin file is read by the zizmor workflow with grep
at run-time and is never installed, so there is no lockfile. When a
transitive of zizmor picks up a security advisory, Dependabot's
resolver fails the pip update job with *"can't update vulnerable
dependencies without a lockfile"* — a failure only visible in the
Dependabot UI.

## Fix

Add the standard guard to the pip entry:

```yaml
allow:
  - dependency-type: 'direct'
```

Since `zizmor-requirements.txt` declares only `zizmor` itself, this
restricts Dependabot to the one direct dependency it can actually bump
and sidesteps the missing-lockfile path entirely.

Config only; no behaviour change. Matches the guard being rolled out
across the other repos that carry the zizmor workflow.