### PR TITLE
Docs: Update repository URLs for org migration

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -102,9 +102,9 @@ version-resolver:
   default: patch
 # yamllint disable rule:line-length
 template: |
-  [![Downloads for this release](https://img.shields.io/github/downloads/lfit/dependamerge/v$RESOLVED_VERSION/total.svg)](https://github.com/lfit/dependamerge/releases/v$RESOLVED_VERSION)
+  [![Downloads for this release](https://img.shields.io/github/downloads/lfreleng-actions/dependamerge/v$RESOLVED_VERSION/total.svg)](https://github.com/lfreleng-actions/dependamerge/releases/v$RESOLVED_VERSION)
 
   $CHANGES
 
   ## Links
-  - [Submit bugs/feature requests](https://github.com/lfit/dependamerge/issues)
+  - [Submit bugs/feature requests](https://github.com/lfreleng-actions/dependamerge/issues)

--- a/README.md
+++ b/README.md
@@ -5,6 +5,17 @@ SPDX-FileCopyrightText: 2025 The Linux Foundation
 
 # Dependamerge
 
+<!-- markdownlint-disable MD013 -->
+
+[![Source Code](https://img.shields.io/badge/Source_Code-GitHub?logo=github&logoColor=white&color=blue)](https://github.com/lfreleng-actions/dependamerge)
+[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/lfreleng-actions/dependamerge/badge)](https://scorecard.dev/viewer/?uri=github.com/lfreleng-actions/dependamerge)
+[![License: Apache-2.0](https://img.shields.io/badge/License-Apache--2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
+[![PyPI](https://img.shields.io/pypi/v/dependamerge.svg?label=PyPI)](https://pypi.org/project/dependamerge/)
+[![TestPyPI](https://img.shields.io/pypi/v/dependamerge.svg?label=TestPyPI&pypiBaseUrl=https://test.pypi.org)](https://test.pypi.org/project/dependamerge/)
+[![CodeQL](https://github.com/lfreleng-actions/dependamerge/actions/workflows/codeql.yml/badge.svg)](https://github.com/lfreleng-actions/dependamerge/actions/workflows/codeql.yml)
+
+<!-- markdownlint-enable MD013 -->
+
 Command-line tool for the management of pull requests in a GitHub organization
 and changes on Gerrit Code Review servers.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,12 +42,12 @@ dependencies = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/lfit/dependamerge"
-Repository = "https://github.com/lfit/dependamerge"
-Downloads = "https://github.com/lfit/dependamerge/releases"
-"Bug Tracker" = "https://github.com/lfit/dependamerge/issues"
-Documentation = "https://github.com/lfit/dependamerge/tree/main/docs"
-"Source Code" = "https://github.com/lfit/dependamerge"
+Homepage = "https://github.com/lfreleng-actions/dependamerge"
+Repository = "https://github.com/lfreleng-actions/dependamerge"
+Downloads = "https://github.com/lfreleng-actions/dependamerge/releases"
+"Bug Tracker" = "https://github.com/lfreleng-actions/dependamerge/issues"
+Documentation = "https://github.com/lfreleng-actions/dependamerge/tree/main/docs"
+"Source Code" = "https://github.com/lfreleng-actions/dependamerge"
 
 [project.optional-dependencies]
 dev = [


### PR DESCRIPTION
## What

Two documentation updates following the `dependamerge` repository's move
from the **`lfit`** GitHub organisation to **`lfreleng-actions`**:

1. Updates the repository/documentation links that still pointed at
   `github.com/lfit/dependamerge`.
2. Adds a status badge row to the README header.

## 1. Repository / documentation links

- **`pyproject.toml`** `[project.urls]` (6): `Homepage`, `Repository`,
  `Downloads`, `Bug Tracker`, `Documentation`, `Source Code`.
- **`.github/release-drafter.yml`** (2): the release download badge and
  the "Submit bugs/feature requests" link in the release-notes template.

## 2. README badges

Adds a badge row to the README header, modelled on
`lfreleng-actions/lftools-uv` and adapted for this project: **Source
Code**, **OpenSSF Scorecard**, **License (Apache-2.0)**, **PyPI**,
**TestPyPI**, and **CodeQL**. All links target
`lfreleng-actions/dependamerge` and the `dependamerge` package.

## Deliberately left unchanged

These `lfit` references are unrelated to this repository's move:

- `uses: lfit/releng-reusable-workflows/...` pins in `codeql.yml` /
  `openssf-scorecard.yaml` — a **separate** repository that has not
  moved.
- The Gerrit host-detection logic in `src/dependamerge/merge_manager.py`
  (`lfit` → LF Gerrit) — **functional code**, not a doc link.
- `lfit`-org **test fixtures** in `tests/` — intentional test data.

## Validation

`pre-commit` (yamllint, markdownlint, reuse, write-good, codespell,
etc.) passes. Both commits are GPG-signed with DCO `Signed-off-by`
lines.