### PR TITLE
Fix(merge): Recover from conflicts and unblock stuck merges

### DIFF
--- a/src/dependamerge/cli.py
+++ b/src/dependamerge/cli.py
@@ -727,6 +727,7 @@ def _run_parallel_merge(
     preview: bool,
     concurrency: int = 10,
     leading_blank: bool = True,
+    repo_scoped: bool = False,
 ) -> list[MergeResult]:
     """Execute a parallel merge (preview or real) and return results.
 
@@ -747,6 +748,11 @@ def _run_parallel_merge(
             preceding similar-PR list.  Callers pass False when no
             list was printed (e.g. no similar PRs were found) so the
             output stays compact.
+        repo_scoped: When True, all PRs target a single repository, so
+            each worker refreshes its PR's live merge state just before
+            dispatching the merge (a sibling merge can make a PR
+            ``dirty`` / ``behind`` mid-batch).  Left False for org-wide
+            runs.  See ``AsyncMergeManager._refresh_pr_mergeability``.
     """
 
     async def _do_merge():
@@ -765,6 +771,7 @@ def _run_parallel_merge(
             no_netrc=ctx.no_netrc,
             netrc_file=ctx.netrc_file,
             rebase_local=ctx.rebase_local,
+            repo_scoped=repo_scoped,
         ) as merge_manager:
             if not preview:
                 prefix = "\n" if leading_blank else ""
@@ -1100,6 +1107,10 @@ def _handle_repo_merge(
             # PRs in the batch.  Cap by PR count so we don't spawn
             # more workers than there is work.
             concurrency=min(5, len(all_prs_to_merge)) or 1,
+            # All PRs target the same repo, so a sibling merge can make
+            # a queued PR ``dirty`` / ``behind`` mid-batch; refresh
+            # live state before each merge dispatch.
+            repo_scoped=True,
         )
     finally:
         if ctx.show_progress and ctx.progress_tracker:
@@ -1199,6 +1210,9 @@ def _execute_repo_confirmed_merge(
             # Per-repo merge dispatch lock makes parallel workers
             # safe; cap by PR count.
             concurrency=min(5, len(mergeable_prs)) or 1,
+            # Single-repo batch — refresh live merge state before each
+            # dispatch (a sibling merge can introduce a conflict).
+            repo_scoped=True,
         )
     finally:
         if ctx.show_progress and ctx.progress_tracker:

--- a/src/dependamerge/cli.py
+++ b/src/dependamerge/cli.py
@@ -783,6 +783,34 @@ def _run_parallel_merge(
     return asyncio.run(_do_merge())
 
 
+def _restart_merge_progress_tracker(ctx: _MergeContext, total_prs: int) -> None:
+    """Stand up a fresh, started progress tracker for the merge phase.
+
+    The org-wide scan (``_scan_and_find_similar``) calls ``stop()`` on
+    the tracker it used, tearing down its Rich ``Live`` and leaving
+    ``ctx.progress_tracker`` in a stopped state.  Reusing that stopped
+    tracker for the real merge means the background wait-status ticker
+    pushes ``update_operation`` calls into a dead ``Live`` — silently
+    dropped by ``ProgressTracker._refresh_display`` — so the user sees
+    no countdown while PRs sit in the Step 5.5 auto-merge wait.
+
+    Mirror the repo-scoped path (``_handle_repo_merge`` /
+    ``_execute_repo_confirmed_merge``) by replacing the tracker with a
+    fresh one dedicated to the merge phase and starting it.  No-op when
+    progress display is disabled (``--no-progress``), where the plain
+    text ticker already provides feedback.
+    """
+    if not ctx.show_progress:
+        return
+    ctx.progress_tracker = MergeProgressTracker(
+        ctx.owner,
+        operation_label="Merging PRs",
+        operation_icon="🔀",
+    )
+    ctx.progress_tracker.set_total_prs(total_prs)
+    ctx.progress_tracker.start()
+
+
 def _handle_preview_confirmation(
     ctx: _MergeContext,
     merge_results: list[MergeResult],
@@ -847,7 +875,12 @@ def _execute_confirmed_merge(
     merged_count = len(mergeable_prs)
     console.print(f"\n🔨 Merging {merged_count} mergeable pull requests...")
 
-    real_results = _run_parallel_merge(ctx, mergeable_prs, preview=False)
+    _restart_merge_progress_tracker(ctx, merged_count)
+    try:
+        real_results = _run_parallel_merge(ctx, mergeable_prs, preview=False)
+    finally:
+        if ctx.show_progress and ctx.progress_tracker:
+            ctx.progress_tracker.stop()
 
     final_merged = sum(1 for r in real_results if r.status.value == "merged")
     final_failed = sum(1 for r in real_results if r.status.value == "failed")
@@ -917,9 +950,7 @@ def _print_failed_pr_details(
     for r in failed:
         url = getattr(r.pr_info, "html_url", "<unknown>")
         reason = r.error or "no reason reported"
-        body = "\n".join(
-            f"     {line}" for line in _format_failure_reason(reason)
-        )
+        body = "\n".join(f"     {line}" for line in _format_failure_reason(reason))
         # markup=False so bracketed reasons are not eaten by Rich.
         console.print(f"   • {url}\n{body}", markup=False)
 
@@ -1855,14 +1886,25 @@ def merge(
             *ctx.all_similar_prs,
             source_entry,
         ]
-        merge_results = _run_parallel_merge(
-            ctx,
-            all_prs_to_merge,
-            preview=not ctx.no_confirm,
-            # No similar-PR list was printed when none were found, so
-            # skip the blank line before the merge banner.
-            leading_blank=bool(ctx.all_similar_prs),
-        )
+        # For the real merge (``--no-confirm``) the scan has already
+        # stopped the progress tracker; stand up a fresh one so the
+        # background wait-status ticker has a live display to update
+        # while PRs sit in the Step 5.5 auto-merge wait.  Preview runs
+        # keep the stopped tracker (one line per PR, no wait loop).
+        if ctx.no_confirm:
+            _restart_merge_progress_tracker(ctx, len(all_prs_to_merge))
+        try:
+            merge_results = _run_parallel_merge(
+                ctx,
+                all_prs_to_merge,
+                preview=not ctx.no_confirm,
+                # No similar-PR list was printed when none were found, so
+                # skip the blank line before the merge banner.
+                leading_blank=bool(ctx.all_similar_prs),
+            )
+        finally:
+            if ctx.no_confirm and ctx.show_progress and ctx.progress_tracker:
+                ctx.progress_tracker.stop()
 
         # Process and display results
         if not merge_results:

--- a/src/dependamerge/cli.py
+++ b/src/dependamerge/cli.py
@@ -805,7 +805,7 @@ def _restart_merge_progress_tracker(ctx: _MergeContext, total_prs: int) -> None:
     ctx.progress_tracker = MergeProgressTracker(
         ctx.owner,
         operation_label="Merging PRs",
-        operation_icon="🔀",
+        operation_icon="▶️",
     )
     ctx.progress_tracker.set_total_prs(total_prs)
     ctx.progress_tracker.start()
@@ -1146,7 +1146,7 @@ def _handle_repo_merge(
         ctx.progress_tracker = MergeProgressTracker(
             f"{ctx.owner}/{ctx.repo_name}",
             operation_label="Merging PRs",
-            operation_icon="🔀",
+            operation_icon="▶️",
         )
         ctx.progress_tracker.set_total_prs(len(all_prs_to_merge))
         ctx.progress_tracker.start()
@@ -1259,7 +1259,7 @@ def _execute_repo_confirmed_merge(
         ctx.progress_tracker = MergeProgressTracker(
             f"{ctx.owner}/{ctx.repo_name}",
             operation_label="Merging PRs",
-            operation_icon="🔀",
+            operation_icon="▶️",
         )
         ctx.progress_tracker.set_total_prs(len(mergeable_prs))
         ctx.progress_tracker.start()

--- a/src/dependamerge/cli.py
+++ b/src/dependamerge/cli.py
@@ -5,6 +5,7 @@ import asyncio
 import hashlib
 import logging
 import os
+import re
 import sys
 from collections import OrderedDict
 from dataclasses import dataclass, field
@@ -907,28 +908,49 @@ def _execute_confirmed_merge(
 
 
 def _format_failure_reason(reason: str) -> list[str]:
-    """Expand a failure reason into display lines.
+    """Expand a failure reason into consistent display lines.
 
-    A repository-ruleset "required workflows" violation is rendered as
-    a header plus a bulleted list of the offending workflows (the raw
-    GitHub message crams them into one long quoted, comma-separated
-    string).  Every other reason is returned unchanged as a single
-    line.
+    Failures are rendered in a consistent shape so the final summary is
+    actionable at a glance:
+
+      1. the failed PR URL (prepended by the caller),
+      2. a single **failure-type** line whose parts are joined with
+         `` / `` and carry no trailing colon, e.g.
+         ``Repository rule violations found / Required workflows failed``,
+      3. one bullet (``• ``) per individual failing condition.
+
+    Repository-ruleset violations arrive from GitHub as one long string
+    that crams the offending workflow / status-check names into a
+    quoted, comma-separated clause.  We split that into the type line
+    plus a bullet per name for both the ``Required workflows`` and
+    ``Required status check(s)`` variants.  Reasons we do not recognise
+    are returned unchanged as a single line.
     """
-    marker = "Required workflows "
-    if "Repository rule violations found" in reason and marker in reason:
-        after_marker = reason.split(marker, 1)[1]
-        if "'" in after_marker:
-            # ``'A, B, C' are not satisfied`` -> names, then verb.
-            _, _, after_first = after_marker.partition("'")
-            quoted, _, rest = after_first.partition("'")
-            workflows = [w.strip() for w in quoted.split(",") if w.strip()]
-            verb = "failed:" if "fail" in rest.lower() else "not satisfied:"
-            if workflows:
+    ruleset = "Repository rule violations found"
+    if ruleset in reason:
+        # Required workflows: ``Required workflows 'A, B' are not satisfied``
+        wf_marker = "Required workflows "
+        if wf_marker in reason:
+            after_marker = reason.split(wf_marker, 1)[1]
+            if "'" in after_marker:
+                # ``'A, B, C' are not satisfied`` -> names, then verb.
+                _, _, after_first = after_marker.partition("'")
+                quoted, _, rest = after_first.partition("'")
+                workflows = [w.strip() for w in quoted.split(",") if w.strip()]
+                verb = "failed" if "fail" in rest.lower() else "not satisfied"
+                if workflows:
+                    return [
+                        f"{ruleset} / Required workflows {verb}",
+                        *(f"• {name}" for name in workflows),
+                    ]
+        # Required status check(s): ``Required status check "X" is failing.``
+        if "Required status check" in reason:
+            checks = [c.strip() for c in re.findall(r'"([^"]+)"', reason) if c.strip()]
+            verb = "failed" if "fail" in reason.lower() else "not satisfied"
+            if checks:
                 return [
-                    "Repository rule violations found",
-                    f"Required workflows {verb}",
-                    *(f"• {name}" for name in workflows),
+                    f"{ruleset} / Required status checks {verb}",
+                    *(f"• {name}" for name in checks),
                 ]
     return [reason]
 

--- a/src/dependamerge/cli.py
+++ b/src/dependamerge/cli.py
@@ -873,6 +873,33 @@ def _execute_confirmed_merge(
     _print_failed_pr_details(real_results)
 
 
+def _format_failure_reason(reason: str) -> list[str]:
+    """Expand a failure reason into display lines.
+
+    A repository-ruleset "required workflows" violation is rendered as
+    a header plus a bulleted list of the offending workflows (the raw
+    GitHub message crams them into one long quoted, comma-separated
+    string).  Every other reason is returned unchanged as a single
+    line.
+    """
+    marker = "Required workflows "
+    if "Repository rule violations found" in reason and marker in reason:
+        after_marker = reason.split(marker, 1)[1]
+        if "'" in after_marker:
+            # ``'A, B, C' are not satisfied`` -> names, then verb.
+            _, _, after_first = after_marker.partition("'")
+            quoted, _, rest = after_first.partition("'")
+            workflows = [w.strip() for w in quoted.split(",") if w.strip()]
+            verb = "failed:" if "fail" in rest.lower() else "not satisfied:"
+            if workflows:
+                return [
+                    "Repository rule violations found",
+                    f"Required workflows {verb}",
+                    *(f"• {name}" for name in workflows),
+                ]
+    return [reason]
+
+
 def _print_failed_pr_details(
     merge_results: list[MergeResult],
 ) -> None:
@@ -890,7 +917,11 @@ def _print_failed_pr_details(
     for r in failed:
         url = getattr(r.pr_info, "html_url", "<unknown>")
         reason = r.error or "no reason reported"
-        console.print(f"   • {url}\n     {reason}")
+        body = "\n".join(
+            f"     {line}" for line in _format_failure_reason(reason)
+        )
+        # markup=False so bracketed reasons are not eaten by Rich.
+        console.print(f"   • {url}\n{body}", markup=False)
 
 
 def _display_merge_results(

--- a/src/dependamerge/github_async.py
+++ b/src/dependamerge/github_async.py
@@ -841,13 +841,21 @@ class GitHubAsync:
 
                 raise Exception(error_msg) from e
             except Exception as inner_e:
-                # If we can't get PR details, just re-raise the original error
-                if isinstance(inner_e, Exception) and "Failed to merge PR" in str(
-                    inner_e
-                ):
+                # The enhanced-error path raised successfully (the
+                # message starts with "Failed to merge PR") — propagate
+                # it unchanged.
+                if "Failed to merge PR" in str(inner_e):
                     raise inner_e from e
-                else:
-                    raise e from inner_e
+                # Otherwise the PR-state re-fetch itself failed.  Still
+                # surface GitHub's response body (the actionable reason)
+                # when we captured it, rather than dropping back to the
+                # bare status-line ``HTTPStatusError``.
+                if github_detail:
+                    raise Exception(
+                        f"Failed to merge PR #{number} in {owner}/{repo}. "
+                        f"GitHub: {github_detail}"
+                    ) from e
+                raise e from inner_e
 
 
     async def enable_auto_merge(

--- a/src/dependamerge/github_async.py
+++ b/src/dependamerge/github_async.py
@@ -812,14 +812,20 @@ class GitHubAsync:
                     )
                     return True
 
-                # Enhanced error message: lead with GitHub's own
-                # explanation (the actionable part) and add PR-state
-                # context.
-                error_msg = f"Failed to merge PR #{number} in {owner}/{repo}."
+                # Enhanced error message.  Always keep the original
+                # error text — it carries the HTTP status line (e.g.
+                # "405 Method Not Allowed") that ``_merge_pr_with_retry``
+                # string-matches to classify retryable vs terminal
+                # failures; dropping it made every blocked/ruleset 405
+                # fall through to the generic retry path (3 attempts +
+                # sleeps).  Then *add* GitHub's response body (the
+                # actionable reason) when we captured it.
+                error_msg = (
+                    f"Failed to merge PR #{number} in {owner}/{repo}. "
+                    f"Error: {str(e)}."
+                )
                 if github_detail:
                     error_msg += f" GitHub: {github_detail}"
-                else:
-                    error_msg += f" Error: {str(e)}"
                 error_msg += (
                     f" (PR state: {state}, mergeable: {mergeable}, "
                     f"mergeable_state: {mergeable_state})"
@@ -853,7 +859,7 @@ class GitHubAsync:
                 if github_detail:
                     raise Exception(
                         f"Failed to merge PR #{number} in {owner}/{repo}. "
-                        f"GitHub: {github_detail}"
+                        f"Error: {str(e)}. GitHub: {github_detail}"
                     ) from e
                 raise e from inner_e
 

--- a/src/dependamerge/github_async.py
+++ b/src/dependamerge/github_async.py
@@ -754,15 +754,41 @@ class GitHubAsync:
             self.log.debug(
                 f"Merge API error for PR #{number} in {owner}/{repo}: {error_type}: {error_msg}"
             )
-            raise
-            # Try to extract response body if available (for HTTPStatusError)
-            if hasattr(e, "response") and hasattr(e.response, "text"):
+
+            # Extract the response body.  GitHub puts the *actual*
+            # reason here — ruleset violations, "Required workflows ...
+            # are not satisfied", required-check names, etc.  The
+            # ``HTTPStatusError`` text only carries the status line
+            # (e.g. "405 Method Not Allowed"), so without this the real
+            # cause is silently lost.  Whitespace/newlines are
+            # collapsed so the reason fits on a single status line.
+            github_detail = ""
+            response = getattr(e, "response", None)
+            if response is not None:
                 try:
-                    response_text = e.response.text
-                    self.log.debug(f"GitHub API response body: {response_text}")
+                    body = response.json()
+                    if isinstance(body, dict) and isinstance(
+                        body.get("message"), str
+                    ):
+                        github_detail = " ".join(body["message"].split())
                 except Exception:
-                    pass
-            # Get PR details to check if the merge actually succeeded despite the exception
+                    github_detail = ""
+                if not github_detail:
+                    try:
+                        raw = getattr(response, "text", "") or ""
+                        github_detail = " ".join(raw.split())[:500]
+                    except Exception:
+                        github_detail = ""
+            if github_detail:
+                self.log.debug(
+                    f"GitHub merge API response body for #{number}: {github_detail}"
+                )
+
+            # Re-check PR state: the merge may have actually succeeded
+            # despite the exception (a race where the API call lands
+            # but we still see an error from rate-limiting, network, or
+            # JSON parsing), and the state adds context to the error we
+            # raise.
             try:
                 pr_data_response = await self.get(
                     f"/repos/{owner}/{repo}/pulls/{number}"
@@ -786,26 +812,32 @@ class GitHubAsync:
                     )
                     return True
 
-                # Enhanced error message with PR state context
-                error_msg = (
-                    f"Failed to merge PR #{number} in {owner}/{repo}. "
-                    f"PR state: {state}, mergeable: {mergeable}, mergeable_state: {mergeable_state}. "
-                    f"Error: {str(e)}"
+                # Enhanced error message: lead with GitHub's own
+                # explanation (the actionable part) and add PR-state
+                # context.
+                error_msg = f"Failed to merge PR #{number} in {owner}/{repo}."
+                if github_detail:
+                    error_msg += f" GitHub: {github_detail}"
+                else:
+                    error_msg += f" Error: {str(e)}"
+                error_msg += (
+                    f" (PR state: {state}, mergeable: {mergeable}, "
+                    f"mergeable_state: {mergeable_state})"
                 )
 
-                # Check for common issues that cause 405 errors
+                # Note common state-based causes for 405-style errors.
                 if mergeable_state == "blocked":
-                    error_msg += " (Likely blocked by branch protection rules or required status checks)"
+                    error_msg += " [blocked by branch protection / required checks]"
                 elif mergeable_state == "behind":
-                    error_msg += " (PR branch is behind base branch)"
+                    error_msg += " [PR branch is behind base branch]"
                 elif mergeable_state == "dirty":
-                    error_msg += " (PR has merge conflicts)"
+                    error_msg += " [PR has merge conflicts]"
                 elif draft:
-                    error_msg += " (Cannot merge draft PR)"
+                    error_msg += " [cannot merge draft PR]"
                 elif state == "closed" and not merged:
-                    error_msg += " (PR was closed without merging)"
+                    error_msg += " [PR was closed without merging]"
                 elif state != "open":
-                    error_msg += f" (PR is not open, state: {state})"
+                    error_msg += f" [PR is not open, state: {state}]"
 
                 raise Exception(error_msg) from e
             except Exception as inner_e:

--- a/src/dependamerge/merge_manager.py
+++ b/src/dependamerge/merge_manager.py
@@ -999,6 +999,22 @@ class AsyncMergeManager:
                 self._console.print(f"🛑 Failed: {pr_info.html_url} [already closed]")
                 return result
 
+            # A merge conflict (``dirty``) has no merge path of its
+            # own: route it to the conflict handler (dependabot →
+            # ``@dependabot rebase`` + wait; other authors → report
+            # and fail fast) rather than the generic not-mergeable
+            # skip below.  Skipped in preview (no side effects) and
+            # under ``force=all`` (which intentionally attempts the
+            # merge regardless of state).
+            if (
+                pr_info.mergeable_state == "dirty"
+                and not self.preview_mode
+                and self.force_level != "all"
+            ):
+                return await self._handle_merge_conflict(
+                    pr_info, repo_owner, repo_name, result
+                )
+
             if not self._is_pr_mergeable(pr_info):
                 # Get detailed status for a more informative skip message
                 # Use async method to avoid event loop conflicts
@@ -1516,6 +1532,7 @@ class AsyncMergeManager:
                     dispatch_lock = await self._get_merge_dispatch_lock(
                         repo_owner, repo_name
                     )
+                    conflict_detected = False
                     async with dispatch_lock:
                         # In a repo-scoped batch, an earlier merge in
                         # this repo (or a concurrent dependamerge run)
@@ -1530,17 +1547,22 @@ class AsyncMergeManager:
                                 pr_info, repo_owner, repo_name
                             )
                         if pr_info.mergeable_state == "dirty":
-                            # A real merge conflict the merge API
-                            # cannot resolve.  Skip the doomed attempt
-                            # so the failure path reports the accurate
-                            # cause ("merge conflicts") instead of
-                            # "Failed to merge after all retry
-                            # attempts".
+                            # A real merge conflict (a sibling merged
+                            # first).  Defer recovery until *after* we
+                            # release the dispatch lock: the conflict
+                            # handler can wait for the full
+                            # ``merge_timeout`` and must not block other
+                            # PRs' merges on this repo.
+                            conflict_detected = True
                             merged = False
                         else:
                             merged = await self._merge_pr_with_retry(
                                 pr_info, repo_owner, repo_name
                             )
+                    if conflict_detected:
+                        return await self._handle_merge_conflict(
+                            pr_info, repo_owner, repo_name, result
+                        )
 
                 if merged is None:
                     # Auto-merge is active — PR will merge asynchronously.
@@ -3666,6 +3688,7 @@ class AsyncMergeManager:
         *,
         continue_states: tuple[str, ...],
         deadline: float | None = None,
+        stop_on_clean: bool = True,
     ) -> tuple[bool, bool]:
         """Poll a PR until it merges, closes, settles, or times out.
 
@@ -3673,8 +3696,11 @@ class AsyncMergeManager:
         progress ticker can render an aggregate countdown, then polls
         every ``_merge_recheck_interval`` seconds until one of:
 
-          * ``mergeable_state`` becomes ``clean`` (a mergeable PR;
-            auto-merge will fire / the caller can merge),
+          * ``mergeable_state`` becomes ``clean`` (only when
+            ``stop_on_clean`` is True — the default; callers that have
+            enabled auto-merge and want to observe the PR actually
+            close set it False and include ``"clean"`` in
+            ``continue_states`` instead),
           * the PR closes (capturing the ``merged`` flag so the caller
             can tell auto-merge success from closed-without-merge),
           * ``mergeable_state`` leaves ``continue_states`` (the caller
@@ -3715,7 +3741,7 @@ class AsyncMergeManager:
         merged_during_wait = False
         try:
             while loop.time() < deadline:
-                if pr_info.mergeable_state == "clean":
+                if stop_on_clean and pr_info.mergeable_state == "clean":
                     break
                 # Sleep no longer than the time remaining so we don't
                 # overshoot the deadline.  Clamp to non-negative: the
@@ -3774,6 +3800,230 @@ class AsyncMergeManager:
                 self._waiting_prs.pop(pr_key, None)
 
         return closed_during_wait, merged_during_wait
+
+    async def _request_dependabot_rebase(
+        self, pr_info: PullRequestInfo, owner: str, repo: str
+    ) -> bool:
+        """Post ``@dependabot rebase`` on a conflicted dependabot PR.
+
+        Dependabot responds by rebasing the PR branch onto the latest
+        base, regenerating any lockfiles and re-signing the commit —
+        the reliable way to clear a ``uv.lock`` / dependency conflict
+        that a plain ``git rebase`` cannot resolve.
+
+        Guards against duplicate comments: when a ``@dependabot
+        rebase`` is already present the request is treated as
+        in-flight and ``True`` is returned (the caller proceeds to
+        wait).  Returns ``False`` only when the comment could not be
+        posted.
+        """
+        if self._github_client is None:
+            return False
+
+        # Duplicate guard — don't stack rebase requests if one is
+        # already pending from a previous run / trigger.
+        try:
+            comments = await self._github_client.get(
+                f"/repos/{owner}/{repo}/issues/{pr_info.number}/comments"
+                f"?per_page=100&direction=desc"
+            )
+            if isinstance(comments, list):
+                for c in comments:
+                    if not isinstance(c, dict):
+                        continue
+                    body = c.get("body")
+                    if isinstance(body, str) and "@dependabot rebase" in body:
+                        self.log.info(
+                            "Existing @dependabot rebase comment on %s#%s; "
+                            "treating rebase as already requested.",
+                            pr_info.repository_full_name,
+                            pr_info.number,
+                        )
+                        return True
+        except Exception as exc:
+            # If we can't list comments, fall through and post anyway:
+            # a duplicate rebase request is harmless (dependabot just
+            # rebases again) and is better than skipping recovery.
+            self.log.debug(
+                "Could not list comments for %s#%s before rebase request: %s",
+                pr_info.repository_full_name,
+                pr_info.number,
+                exc,
+            )
+
+        try:
+            await self._github_client.post_issue_comment(
+                owner, repo, pr_info.number, "@dependabot rebase"
+            )
+            return True
+        except Exception as exc:
+            self.log.warning(
+                "Failed to post @dependabot rebase on %s#%s: %s",
+                pr_info.repository_full_name,
+                pr_info.number,
+                exc,
+            )
+            return False
+
+    def _finish_conflict_close(
+        self, pr_info: PullRequestInfo, result: MergeResult, merged: bool
+    ) -> MergeResult:
+        """Finalise a conflict-recovery result when the PR closed mid-wait.
+
+        ``merged`` distinguishes auto-merge success (the rebase landed
+        and GitHub merged the PR) from closed-without-merge (a human
+        closed it, dependabot superseded it, etc.).
+        """
+        if merged:
+            result.status = MergeStatus.MERGED
+            if self.progress_tracker:
+                self.progress_tracker.merge_success()
+            log_and_print(
+                self.log,
+                self._console,
+                f"✅ Merged (auto-merge): {pr_info.html_url}",
+                level="debug",
+            )
+        else:
+            result.status = MergeStatus.FAILED
+            result.error = "PR closed without merging during conflict rebase"
+            if self.progress_tracker:
+                self.progress_tracker.merge_failure()
+            self._console.print(
+                f"🛑 Closed without merging: {pr_info.html_url}"
+            )
+        return result
+
+    async def _handle_merge_conflict(
+        self,
+        pr_info: PullRequestInfo,
+        owner: str,
+        repo: str,
+        result: MergeResult,
+    ) -> MergeResult:
+        """Recover from (or report) a PR with a real merge conflict.
+
+        A ``dirty`` PR has no merge path of its own.  For a dependabot
+        PR we ask dependabot to rebase — which regenerates lockfiles
+        and re-signs the commit — then wait (bounded by
+        ``merge_timeout``) for the rebase and required checks to land,
+        approving the *rebased* commit and enabling auto-merge so
+        GitHub completes the merge.  For any other author there is no
+        automated way to resolve a content conflict, so we report it
+        and fail fast (no wait).
+
+        Must be called *outside* the per-repo dispatch lock: the wait
+        can run for the full ``merge_timeout`` and must not block
+        sibling merges.  Sets ``result`` and returns it.
+        """
+        # Non-dependabot authors: no comment macro regenerates a
+        # conflicted lockfile, and a blind force-push would only break
+        # the approval chain (this org forbids self-merge of pushed
+        # commits).  Report the conflict and fail fast.
+        if pr_info.author != "dependabot[bot]":
+            log_and_print(
+                self.log,
+                self._console,
+                f"🔀 Merge conflict: {pr_info.html_url}",
+                level="info",
+            )
+            self._console.print(f"❌ Failed: {pr_info.html_url} [merge conflicts]")
+            result.status = MergeStatus.FAILED
+            result.error = "merge conflicts"
+            if self.progress_tracker:
+                self.progress_tracker.merge_failure()
+            return result
+
+        # Dependabot: request a rebase (regenerates the lockfile +
+        # signs the commit).
+        log_and_print(
+            self.log,
+            self._console,
+            f"🔄 Requesting dependabot rebase: {pr_info.html_url}",
+            level="info",
+        )
+        if not await self._request_dependabot_rebase(pr_info, owner, repo):
+            self._console.print(f"❌ Failed: {pr_info.html_url} [merge conflicts]")
+            result.status = MergeStatus.FAILED
+            result.error = "merge conflicts"
+            if self.progress_tracker:
+                self.progress_tracker.merge_failure()
+            return result
+
+        # Share a single ``merge_timeout`` budget across both wait
+        # phases (waiting for the rebase, then for checks).
+        deadline = asyncio.get_running_loop().time() + self._merge_timeout
+
+        # Phase 1: wait for dependabot's rebase to clear the conflict.
+        # Keep waiting while still ``dirty`` or while GitHub recomputes
+        # mergeability (a transient null is preserved as the prior
+        # ``dirty`` by ``_wait_for_auto_merge``).
+        closed, merged = await self._wait_for_auto_merge(
+            pr_info,
+            owner,
+            repo,
+            continue_states=("dirty", "unknown", ""),
+            deadline=deadline,
+        )
+        if closed:
+            return self._finish_conflict_close(pr_info, result, merged)
+        if pr_info.mergeable_state == "dirty":
+            # Timed out still conflicting — the rebase did not happen
+            # or could not resolve the conflict.
+            self._console.print(f"❌ Failed: {pr_info.html_url} [merge conflicts]")
+            result.status = MergeStatus.FAILED
+            result.error = "merge conflicts"
+            if self.progress_tracker:
+                self.progress_tracker.merge_failure()
+            return result
+
+        # Conflict cleared.  Approve the rebased commit *now* (not
+        # before — approving the pre-rebase head would just be
+        # dismissed by dependabot's force-push, producing the
+        # duplicate approvals we want to avoid) and enable auto-merge.
+        await self._approve_pr(owner, repo, pr_info.number)
+        if await self._enable_auto_merge_for_pr(pr_info, owner, repo):
+            log_and_print(
+                self.log,
+                self._console,
+                f"🤖 Auto-merge: {pr_info.html_url}",
+                level="debug",
+            )
+
+        # Phase 2: wait (sharing the deadline) for required checks and
+        # auto-merge to complete.  ``stop_on_clean=False`` keeps us
+        # waiting once the PR goes ``clean`` so we observe auto-merge
+        # actually close the PR (reporting MERGED) rather than exiting
+        # the moment it becomes mergeable.
+        closed, merged = await self._wait_for_auto_merge(
+            pr_info,
+            owner,
+            repo,
+            continue_states=(
+                "clean",
+                "blocked",
+                "behind",
+                "unstable",
+                "unknown",
+                "",
+            ),
+            deadline=deadline,
+            stop_on_clean=False,
+        )
+        if closed:
+            return self._finish_conflict_close(pr_info, result, merged)
+
+        # Not merged within the window, but the rebase landed and
+        # auto-merge is armed: GitHub will complete the merge once the
+        # required checks pass (often after our run ends).
+        result.status = MergeStatus.AUTO_MERGE_PENDING
+        log_and_print(
+            self.log,
+            self._console,
+            f"⏳ Waiting: {pr_info.html_url} [auto-merge after rebase]",
+            level="debug",
+        )
+        return result
 
     def _get_failure_summary(self, pr_info: PullRequestInfo) -> str:
         """

--- a/src/dependamerge/merge_manager.py
+++ b/src/dependamerge/merge_manager.py
@@ -4199,14 +4199,12 @@ class AsyncMergeManager:
             result.error = failure_reason or "Failed to merge after all retry attempts"
         if self.progress_tracker:
             self.progress_tracker.merge_failure()
-        # The ``⚠️ Stuck check`` line above is the cause for stuck PRs;
-        # only emit the generic failure line otherwise.  ``markup=False``
-        # keeps Rich from swallowing the bracketed reason.
+        # Keep the live line terse: the full (often long) reason is
+        # shown in the end-of-run summary via ``result.error``, so
+        # repeating it inline only duplicates it.  The ``⚠️ Stuck
+        # check`` line above already carries the cause for stuck PRs.
         if not stuck_reported:
-            self._console.print(
-                f"❌ Failed: {pr_info.html_url} [{failure_reason}]",
-                markup=False,
-            )
+            self._console.print(f"❌ Failed: {pr_info.html_url}", markup=False)
         return result
 
     def _get_failure_summary(self, pr_info: PullRequestInfo) -> str:

--- a/src/dependamerge/merge_manager.py
+++ b/src/dependamerge/merge_manager.py
@@ -1768,12 +1768,12 @@ class AsyncMergeManager:
                                 "[recreated PR merge failed]"
                             )
                     else:
-                        result.status = MergeStatus.FAILED
-                        result.error = "Failed to merge after all retry attempts"
-                        if self.progress_tracker:
-                            self.progress_tracker.merge_failure()
-                        self._console.print(
-                            f"❌ Failed: {pr_info.html_url} [{failure_reason}]"
+                        await self._report_merge_failure(
+                            pr_info,
+                            repo_owner,
+                            repo_name,
+                            result,
+                            failure_reason,
                         )
 
         except GitHubPermissionError as e:
@@ -4077,6 +4077,71 @@ class AsyncMergeManager:
             f"⏳ Waiting: {pr_info.html_url} [auto-merge after rebase]",
             level="debug",
         )
+        return result
+
+    async def _report_merge_failure(
+        self,
+        pr_info: PullRequestInfo,
+        owner: str,
+        repo: str,
+        result: MergeResult,
+        failure_reason: str,
+    ) -> MergeResult:
+        """Report a failed merge, upgrading to a stuck-check cause if found.
+
+        Called when ``_merge_pr_with_retry`` failed and no dependabot
+        recreate produced a replacement PR.  For a non-dependabot PR
+        we check whether a required check is stuck (Option A): if so,
+        print ``⚠️ Stuck check`` and arm auto-merge (when the PR is
+        otherwise mergeable) so it lands once the check is
+        re-triggered, without a force-push that would break this org's
+        self-merge rule.  Otherwise emit the generic failure line.
+
+        Sets ``result`` to ``FAILED`` and returns it.
+        """
+        stuck_reported = False
+        if pr_info.author != "dependabot[bot]" and not self.preview_mode:
+            try:
+                (
+                    is_stuck,
+                    stuck_check,
+                    _stuck_age,
+                ) = await self._detect_stuck_required_check(pr_info)
+            except Exception as exc:
+                self.log.debug(
+                    "_detect_stuck_required_check failed for %s#%s: %s",
+                    pr_info.repository_full_name,
+                    pr_info.number,
+                    exc,
+                )
+                is_stuck = False
+                stuck_check = None
+            if is_stuck:
+                # markup=False: a check name may contain characters
+                # Rich would otherwise treat as markup.
+                self._console.print(
+                    f"⚠️ Stuck check: {pr_info.html_url} [{stuck_check}]",
+                    markup=False,
+                )
+                # Arm auto-merge when the PR is otherwise mergeable
+                # (not dirty) so it lands automatically once the stuck
+                # check is re-triggered, without a second review round.
+                if pr_info.mergeable_state != "dirty":
+                    await self._enable_auto_merge_for_pr(pr_info, owner, repo)
+                result.error = f"stuck check: {stuck_check}"
+                stuck_reported = True
+
+        result.status = MergeStatus.FAILED
+        if not stuck_reported:
+            result.error = "Failed to merge after all retry attempts"
+        if self.progress_tracker:
+            self.progress_tracker.merge_failure()
+        # The ``⚠️ Stuck check`` line above is the cause for stuck PRs;
+        # only emit the generic failure line otherwise.
+        if not stuck_reported:
+            self._console.print(
+                f"❌ Failed: {pr_info.html_url} [{failure_reason}]"
+            )
         return result
 
     def _get_failure_summary(self, pr_info: PullRequestInfo) -> str:

--- a/src/dependamerge/merge_manager.py
+++ b/src/dependamerge/merge_manager.py
@@ -1329,128 +1329,19 @@ class AsyncMergeManager:
                             level="debug",
                         )
 
-                # Drive the wait loop directly off a monotonic
-                # deadline so the total wait is bounded by
-                # ``merge_timeout`` even if a single iteration
-                # over-sleeps slightly.
-                wait_deadline = asyncio.get_running_loop().time() + self._merge_timeout
-                # Local alias so the type checker can narrow
-                # ``self._github_client`` across the await boundary.
-                wait_client = self._github_client
-                assert wait_client is not None
-                async with self._waiting_lock:
-                    self._waiting_prs[pr_key_for_wait] = wait_deadline
-                # Track whether the PR was closed during the wait
-                # and, if so, whether it was actually merged. The
-                # REST PR payload includes a ``merged`` boolean that
-                # distinguishes auto-merge success from
-                # closed-without-merge (the user closed the PR
-                # while we were waiting, dependabot superseded it,
-                # etc.).
-                closed_during_wait = False
-                merged_during_wait = False
-                try:
-                    while asyncio.get_running_loop().time() < wait_deadline:
-                        if pr_info.mergeable_state == "clean":
-                            break
-                        # Sleep no longer than the time remaining
-                        # so we don't overshoot ``wait_deadline``.
-                        # Clamp to a non-negative value: the loop's
-                        # ``while ... < wait_deadline`` check and the
-                        # ``time()`` call here are not atomic, so a
-                        # near-deadline crossing can produce a tiny
-                        # negative ``remaining`` which would raise
-                        # ``ValueError`` from ``asyncio.sleep``.
-                        remaining = max(
-                            0.0,
-                            wait_deadline - asyncio.get_running_loop().time(),
-                        )
-                        await asyncio.sleep(
-                            min(self._merge_recheck_interval, remaining)
-                        )
-                        try:
-                            refreshed_wait = await wait_client.get(
-                                f"/repos/{repo_owner}/{repo_name}/pulls/"
-                                f"{pr_info.number}"
-                            )
-                        except Exception as wait_exc:
-                            self.log.debug(
-                                "Failed to refresh PR state during auto-merge "
-                                "wait for %s/%s#%s: %s",
-                                repo_owner,
-                                repo_name,
-                                pr_info.number,
-                                wait_exc,
-                            )
-                            continue
-                        if isinstance(refreshed_wait, dict):
-                            # Only overwrite when the keys are present, so a
-                            # partial/empty API response does not blank out
-                            # the existing state. Additionally, preserve the
-                            # previous non-None ``mergeable`` value when the
-                            # refresh returns ``null`` — GitHub returns null
-                            # while still computing the value. The Step 6
-                            # skip gate accepts ``True`` and ``None`` (only
-                            # ``False`` falls through to the manual merge
-                            # attempt), but preserving the prior known
-                            # ``True`` keeps the post-wait state
-                            # informative for downstream logging and any
-                            # future tightening of that predicate.
-                            if "mergeable" in refreshed_wait:
-                                refreshed_mergeable = refreshed_wait.get("mergeable")
-                                if refreshed_mergeable is not None:
-                                    pr_info.mergeable = refreshed_mergeable
-                            if "mergeable_state" in refreshed_wait:
-                                # Preserve the previous non-None
-                                # ``mergeable_state`` for the same
-                                # reason as ``mergeable`` above. The
-                                # subsequent ``not in ("blocked",
-                                # "behind", "unstable")`` check would
-                                # otherwise break the wait loop early
-                                # on a transient ``null`` returned
-                                # while GitHub is still computing.
-                                refreshed_state = refreshed_wait.get("mergeable_state")
-                                if refreshed_state is not None:
-                                    pr_info.mergeable_state = refreshed_state
-                            # Capture the current head SHA so any
-                            # subsequent analyze_block_reason()
-                            # call queries the right commit. The
-                            # head can change while we wait
-                            # (rebase, dependabot force-push, etc.).
-                            refreshed_head = (refreshed_wait.get("head") or {}).get(
-                                "sha"
-                            )
-                            if refreshed_head:
-                                pr_info.head_sha = refreshed_head
-                            if refreshed_wait.get("state") == "closed":
-                                # PR was closed during the wait —
-                                # capture the ``merged`` boolean so
-                                # we can distinguish auto-merge
-                                # success from closed-without-merge.
-                                closed_during_wait = True
-                                merged_during_wait = bool(
-                                    refreshed_wait.get("merged", False)
-                                )
-                                pr_info.state = "closed"
-                                break
-                        # Continue waiting only while the PR is in a
-                        # state that auto-merge can still rescue. The
-                        # set must mirror the ``base_should_wait``
-                        # entry condition above (blocked / behind /
-                        # unstable); any other value means the PR has
-                        # either become mergeable, has been closed,
-                        # or has hit a state Step 5.5 cannot help
-                        # with, so we should exit the wait loop and
-                        # let downstream steps decide.
-                        if pr_info.mergeable_state not in (
-                            "blocked",
-                            "behind",
-                            "unstable",
-                        ):
-                            break
-                finally:
-                    async with self._waiting_lock:
-                        self._waiting_prs.pop(pr_key_for_wait, None)
+                # Wait (bounded by ``merge_timeout``) for required
+                # checks to complete and auto-merge to fire.  The
+                # continue-states mirror the ``base_should_wait`` entry
+                # condition above (blocked / behind / unstable).
+                (
+                    closed_during_wait,
+                    merged_during_wait,
+                ) = await self._wait_for_auto_merge(
+                    pr_info,
+                    repo_owner,
+                    repo_name,
+                    continue_states=("blocked", "behind", "unstable"),
+                )
 
                 # If the wait revealed the PR is already closed,
                 # short-circuit before attempting a manual merge.
@@ -3766,6 +3657,123 @@ class AsyncMergeManager:
                 return
 
             await asyncio.sleep(min(poll_interval, deadline - now))
+
+    async def _wait_for_auto_merge(
+        self,
+        pr_info: PullRequestInfo,
+        owner: str,
+        repo: str,
+        *,
+        continue_states: tuple[str, ...],
+        deadline: float | None = None,
+    ) -> tuple[bool, bool]:
+        """Poll a PR until it merges, closes, settles, or times out.
+
+        Registers ``owner/repo#N`` in ``_waiting_prs`` so the parallel
+        progress ticker can render an aggregate countdown, then polls
+        every ``_merge_recheck_interval`` seconds until one of:
+
+          * ``mergeable_state`` becomes ``clean`` (a mergeable PR;
+            auto-merge will fire / the caller can merge),
+          * the PR closes (capturing the ``merged`` flag so the caller
+            can tell auto-merge success from closed-without-merge),
+          * ``mergeable_state`` leaves ``continue_states`` (the caller
+            decides what the new state means), or
+          * the deadline passes.
+
+        The total wait is bounded by ``merge_timeout`` unless an
+        explicit ``deadline`` is supplied — used to share a single
+        budget across sequential waits (e.g. the rebase-then-checks
+        phases of conflict recovery).
+
+        Mutates ``pr_info`` in place (``mergeable``,
+        ``mergeable_state``, ``head_sha``, ``state``).  Returns
+        ``(closed_during_wait, merged_during_wait)``.
+        """
+        if self._github_client is None:
+            return False, False
+
+        pr_key = f"{owner}/{repo}#{pr_info.number}"
+        loop = asyncio.get_running_loop()
+        # Drive the wait off a monotonic deadline so the total is
+        # bounded even if a single iteration over-sleeps slightly.
+        if deadline is None:
+            deadline = loop.time() + self._merge_timeout
+        # Local alias so the type checker can narrow
+        # ``self._github_client`` across the await boundary.
+        wait_client = self._github_client
+
+        async with self._waiting_lock:
+            self._waiting_prs[pr_key] = deadline
+
+        # Track whether the PR was closed during the wait and, if so,
+        # whether it was actually merged.  The REST payload's
+        # ``merged`` boolean distinguishes auto-merge success from
+        # closed-without-merge (a human closed it, dependabot
+        # superseded it, etc.).
+        closed_during_wait = False
+        merged_during_wait = False
+        try:
+            while loop.time() < deadline:
+                if pr_info.mergeable_state == "clean":
+                    break
+                # Sleep no longer than the time remaining so we don't
+                # overshoot the deadline.  Clamp to non-negative: the
+                # ``while`` check and this ``time()`` call are not
+                # atomic, so a near-deadline crossing could otherwise
+                # pass ``asyncio.sleep`` a tiny negative value.
+                remaining = max(0.0, deadline - loop.time())
+                await asyncio.sleep(min(self._merge_recheck_interval, remaining))
+                try:
+                    refreshed_wait = await wait_client.get(
+                        f"/repos/{owner}/{repo}/pulls/{pr_info.number}"
+                    )
+                except Exception as wait_exc:
+                    self.log.debug(
+                        "Failed to refresh PR state during auto-merge "
+                        "wait for %s: %s",
+                        pr_key,
+                        wait_exc,
+                    )
+                    continue
+                if isinstance(refreshed_wait, dict):
+                    # Only overwrite when present, and preserve the
+                    # previous non-None value when GitHub returns null
+                    # (it does so while recomputing) so the
+                    # ``continue_states`` check below does not break the
+                    # loop early on a transient null.
+                    if "mergeable" in refreshed_wait:
+                        refreshed_mergeable = refreshed_wait.get("mergeable")
+                        if refreshed_mergeable is not None:
+                            pr_info.mergeable = refreshed_mergeable
+                    if "mergeable_state" in refreshed_wait:
+                        refreshed_state = refreshed_wait.get("mergeable_state")
+                        if refreshed_state is not None:
+                            pr_info.mergeable_state = refreshed_state
+                    # The head can change while we wait (rebase,
+                    # force-push); keep it current so any later
+                    # block-reason analysis queries the right commit.
+                    refreshed_head = (refreshed_wait.get("head") or {}).get("sha")
+                    if refreshed_head:
+                        pr_info.head_sha = refreshed_head
+                    if refreshed_wait.get("state") == "closed":
+                        closed_during_wait = True
+                        merged_during_wait = bool(
+                            refreshed_wait.get("merged", False)
+                        )
+                        pr_info.state = "closed"
+                        break
+                # Continue waiting only while the PR is in a state the
+                # caller still considers rescuable; any other value
+                # means it became mergeable, closed, or hit a terminal
+                # state, so exit and let the caller decide.
+                if pr_info.mergeable_state not in continue_states:
+                    break
+        finally:
+            async with self._waiting_lock:
+                self._waiting_prs.pop(pr_key, None)
+
+        return closed_during_wait, merged_during_wait
 
     def _get_failure_summary(self, pr_info: PullRequestInfo) -> str:
         """

--- a/src/dependamerge/merge_manager.py
+++ b/src/dependamerge/merge_manager.py
@@ -53,6 +53,16 @@ from .progress_tracker import MergeProgressTracker
 DEFAULT_MERGE_TIMEOUT: float = 300.0  # seconds (5 minutes)
 DEFAULT_MERGE_RECHECK_INTERVAL: float = 10.0  # seconds between polls
 
+# After a sibling PR merges (or a concurrent dependamerge run lands a
+# change), GitHub recomputes a PR's mergeability asynchronously and
+# briefly reports ``mergeable=null`` / ``mergeable_state="unknown"`` —
+# typically for a few seconds.  Before dispatching a merge in a
+# repo-scoped batch we re-read the PR and, when GitHub is still
+# computing, poll up to this many seconds for a concrete value so the
+# merge decision is made against fresh state rather than the
+# (possibly stale) fetch-time snapshot.
+MERGEABILITY_REFRESH_TIMEOUT_SECONDS: float = 10.0
+
 # Required verification checks (DCO, lint, build, etc.) normally
 # start reporting within a few seconds.  When a *required* check has
 # been pending for longer than this on a PR that itself was created
@@ -114,6 +124,7 @@ class AsyncMergeManager:
         no_netrc: bool = False,
         netrc_file: Path | None = None,
         rebase_local: bool = True,
+        repo_scoped: bool = False,
     ):
         self.token = token
         self.default_merge_method = merge_method
@@ -137,6 +148,15 @@ class AsyncMergeManager:
         # the legacy REST-only path (simpler but loses signature
         # verification on signed branches).
         self.rebase_local = rebase_local
+        # When True, the batch targets a single repository, so a merge
+        # by one worker can make a sibling PR ``dirty`` / ``behind``
+        # between the up-front fetch and this worker's dispatch.  In
+        # that mode we refresh each PR's live merge state immediately
+        # before dispatching the merge (see
+        # ``_refresh_pr_mergeability``).  Left False for org-wide runs,
+        # where PRs target different repositories and the snapshot is
+        # not invalidated by our own merges.
+        self._repo_scoped = repo_scoped
         self.log = logging.getLogger(__name__)
 
         # Centralised merge-operation timing
@@ -1606,9 +1626,30 @@ class AsyncMergeManager:
                         repo_owner, repo_name
                     )
                     async with dispatch_lock:
-                        merged = await self._merge_pr_with_retry(
-                            pr_info, repo_owner, repo_name
-                        )
+                        # In a repo-scoped batch, an earlier merge in
+                        # this repo (or a concurrent dependamerge run)
+                        # may have made this PR ``dirty`` / ``behind``
+                        # since it was fetched.  Refresh the live state
+                        # now that we hold the dispatch lock — this is
+                        # the only point that is both serialised and
+                        # ordered after any sibling merge.  See
+                        # ``_refresh_pr_mergeability``.
+                        if self._repo_scoped:
+                            await self._refresh_pr_mergeability(
+                                pr_info, repo_owner, repo_name
+                            )
+                        if pr_info.mergeable_state == "dirty":
+                            # A real merge conflict the merge API
+                            # cannot resolve.  Skip the doomed attempt
+                            # so the failure path reports the accurate
+                            # cause ("merge conflicts") instead of
+                            # "Failed to merge after all retry
+                            # attempts".
+                            merged = False
+                        else:
+                            merged = await self._merge_pr_with_retry(
+                                pr_info, repo_owner, repo_name
+                            )
 
                 if merged is None:
                     # Auto-merge is active — PR will merge asynchronously.
@@ -3614,6 +3655,117 @@ class AsyncMergeManager:
         if not isinstance(pr_data, dict):
             return False
         return pr_data.get("state") == "closed" and bool(pr_data.get("merged"))
+
+    async def _refresh_pr_mergeability(
+        self, pr_info: PullRequestInfo, owner: str, repo: str
+    ) -> None:
+        """Refresh ``pr_info`` with the PR's current live merge state.
+
+        The batch of PRs is fetched once up front, so a worker may act
+        on a snapshot taken seconds-to-minutes earlier.  In a
+        repo-scoped run this is routinely wrong: merging one PR can
+        immediately make a sibling PR ``dirty`` (the classic
+        ``uv.lock`` / workflow-pin conflict) or ``behind``.  A
+        concurrent ``dependamerge`` run elsewhere in the org can do the
+        same.  We therefore re-read the PR's state immediately before
+        dispatching the merge, rather than trusting the fetch-time
+        snapshot.
+
+        GitHub recomputes ``mergeable`` / ``mergeable_state``
+        asynchronously after the base branch moves, reporting
+        ``mergeable=None`` and ``mergeable_state="unknown"`` (or an
+        empty string) in the gap — usually for a few seconds.  When we
+        catch the PR in that window we poll up to
+        :data:`MERGEABILITY_REFRESH_TIMEOUT_SECONDS` for a concrete
+        value so the merge decision is made against real data.
+
+        Mutates ``pr_info`` in place (``state``, ``mergeable``,
+        ``mergeable_state``, ``head_sha``).  Best-effort: any API error
+        leaves the existing snapshot untouched so the caller's
+        downstream logic still runs.
+        """
+        if not self._github_client:
+            return
+
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + MERGEABILITY_REFRESH_TIMEOUT_SECONDS
+        # Poll cadence for the "still computing" window.  Kept short
+        # (GitHub usually settles in ~5s) but never longer than the
+        # configured recheck interval.
+        poll_interval = min(2.0, self._merge_recheck_interval)
+
+        while True:
+            try:
+                data = await self._github_client.get(
+                    f"/repos/{owner}/{repo}/pulls/{pr_info.number}"
+                )
+            except Exception as exc:
+                self.log.debug(
+                    "Mergeability refresh failed for %s/%s#%s: %s",
+                    owner,
+                    repo,
+                    pr_info.number,
+                    exc,
+                )
+                return
+
+            if not isinstance(data, dict):
+                return
+
+            state = data.get("state")
+            if isinstance(state, str) and state:
+                pr_info.state = state
+            head_sha = (data.get("head") or {}).get("sha")
+            if head_sha:
+                pr_info.head_sha = head_sha
+
+            mergeable = data.get("mergeable")
+            mergeable_state = data.get("mergeable_state")
+
+            # A closed PR will never resolve to a concrete mergeable
+            # value; record what we have and let the caller's
+            # closed-PR handling take over.
+            if state == "closed":
+                pr_info.mergeable = mergeable
+                pr_info.mergeable_state = mergeable_state
+                return
+
+            # GitHub signals "still computing" with a null ``mergeable``
+            # and an ``unknown``/empty ``mergeable_state``.  Keep
+            # polling until it settles or the deadline passes.
+            still_computing = mergeable is None or mergeable_state in (
+                None,
+                "",
+                "unknown",
+            )
+            if not still_computing:
+                pr_info.mergeable = mergeable
+                pr_info.mergeable_state = mergeable_state
+                return
+
+            now = loop.time()
+            if now >= deadline:
+                # Timed out waiting for GitHub to settle.  Record the
+                # latest values we did get (even if still computing) so
+                # downstream logic sees GitHub's current best answer
+                # rather than the older snapshot.
+                if mergeable is not None:
+                    pr_info.mergeable = mergeable
+                if mergeable_state not in (None, ""):
+                    pr_info.mergeable_state = mergeable_state
+                self.log.debug(
+                    "Mergeability for %s/%s#%s still computing after %.0fs; "
+                    "proceeding with mergeable=%s state=%s",
+                    owner,
+                    repo,
+                    pr_info.number,
+                    MERGEABILITY_REFRESH_TIMEOUT_SECONDS,
+                    pr_info.mergeable,
+                    pr_info.mergeable_state,
+                )
+                return
+
+            await asyncio.sleep(min(poll_interval, deadline - now))
 
     def _get_failure_summary(self, pr_info: PullRequestInfo) -> str:
         """

--- a/src/dependamerge/merge_manager.py
+++ b/src/dependamerge/merge_manager.py
@@ -3993,9 +3993,6 @@ class AsyncMergeManager:
                 f"🔀 Merge conflict: {pr_info.html_url}",
                 level="info",
             )
-            self._console.print(
-                f"❌ Failed: {pr_info.html_url} [merge conflicts]", markup=False
-            )
             result.status = MergeStatus.FAILED
             result.error = "merge conflicts"
             if self.progress_tracker:
@@ -4011,8 +4008,11 @@ class AsyncMergeManager:
             level="info",
         )
         if not await self._request_dependabot_rebase(pr_info, owner, repo):
-            self._console.print(
-                f"❌ Failed: {pr_info.html_url} [merge conflicts]", markup=False
+            log_and_print(
+                self.log,
+                self._console,
+                f"🔀 Merge conflict: {pr_info.html_url}",
+                level="info",
             )
             result.status = MergeStatus.FAILED
             result.error = "merge conflicts"
@@ -4040,8 +4040,11 @@ class AsyncMergeManager:
         if pr_info.mergeable_state == "dirty":
             # Timed out still conflicting — the rebase did not happen
             # or could not resolve the conflict.
-            self._console.print(
-                f"❌ Failed: {pr_info.html_url} [merge conflicts]", markup=False
+            log_and_print(
+                self.log,
+                self._console,
+                f"🔀 Merge conflict: {pr_info.html_url}",
+                level="info",
             )
             result.status = MergeStatus.FAILED
             result.error = "merge conflicts"
@@ -4132,11 +4135,7 @@ class AsyncMergeManager:
         )
         if self.progress_tracker:
             self.progress_tracker.merge_failure()
-        self._console.print(
-            f"❌ Failed: {pr_info.html_url} "
-            "[rebase landed but merge/auto-merge unavailable]",
-            markup=False,
-        )
+        self._console.print(f"❌ Failed: {pr_info.html_url}", markup=False)
         return result
 
     async def _report_merge_failure(

--- a/src/dependamerge/merge_manager.py
+++ b/src/dependamerge/merge_manager.py
@@ -71,6 +71,13 @@ MERGEABILITY_REFRESH_TIMEOUT_SECONDS: float = 10.0
 # decide whether to ask dependabot to recreate the PR.
 STUCK_CHECK_THRESHOLD_SECONDS: float = 60.0
 
+# pre-commit.ci normally reports back within a few minutes.  A
+# ``pre-commit.ci - pr`` status stuck in ``pending`` for longer than
+# this is treated as a hung run that needs a fresh ``pre-commit.ci
+# run`` trigger.  Kept deliberately generous so a slow-but-normal run
+# is never interrupted; used by ``_trigger_stale_precommit_ci``.
+PRECOMMIT_CI_STUCK_PENDING_SECONDS: float = 300.0
+
 
 class MergeStatus(Enum):
     """Status of a PR merge operation."""
@@ -2410,13 +2417,19 @@ class AsyncMergeManager:
         return True, "All merge requirements appear to be met"
 
     async def _trigger_stale_precommit_ci(self, pr_info: PullRequestInfo) -> bool:
-        """
-        Detect and retrigger a stuck pre-commit.ci run by posting a comment.
+        """Detect and retrigger a stuck pre-commit.ci run by posting a comment.
 
-        pre-commit.ci uses the commit status API and sometimes fails to report
-        any status at all, leaving the PR permanently blocked when
-        'pre-commit.ci - pr' is a required status check. Posting the comment
-        ``pre-commit.ci run`` triggers a fresh run.
+        pre-commit.ci uses the commit status API and sometimes gets
+        stuck — either never reporting a status at all, or leaving the
+        ``pre-commit.ci - pr`` context in ``pending`` indefinitely.
+        Either way the PR stays blocked when that context is a required
+        status check.  Posting ``pre-commit.ci run`` triggers a fresh
+        run.
+
+        A run is treated as stuck when the status is missing entirely,
+        or when it has been ``pending`` for longer than
+        :data:`PRECOMMIT_CI_STUCK_PENDING_SECONDS` (a slow-but-normal
+        run within that window is left alone).
 
         Args:
             pr_info: Pull request information
@@ -2444,16 +2457,17 @@ class AsyncMergeManager:
         except Exception:
             return False
 
-        # 2. Check whether the status has already been reported
+        # 2. Inspect the existing pre-commit.ci status.  Retrigger when
+        #    it is missing entirely or has been ``pending`` past the
+        #    stuck threshold; leave any other state (success / failure
+        #    / error, or a pending run still within its normal window).
+        from datetime import datetime, timezone
+
+        now = datetime.now(timezone.utc)
         try:
             status_data = await self._github_client.get(
                 f"/repos/{repo_owner}/{repo_name}/commits/{pr_info.head_sha}/status"
             )
-            if isinstance(status_data, dict):
-                for s in status_data.get("statuses", []):
-                    if isinstance(s, dict) and s.get("context") == precommit_context:
-                        # Status exists (success, pending, failure, etc.) — not stale
-                        return False
         except Exception as e:
             self.log.debug(
                 "Failed to fetch commit status for pre-commit.ci check on %s#%s "
@@ -2465,9 +2479,50 @@ class AsyncMergeManager:
             )
             return False
 
-        # 3. Status is missing entirely — check for an existing trigger comment
-        # before posting a duplicate (avoids spam if dependamerge runs repeatedly
-        # while the status is still missing).
+        precommit_status: dict[str, Any] | None = None
+        if isinstance(status_data, dict):
+            for s in status_data.get("statuses", []):
+                if isinstance(s, dict) and s.get("context") == precommit_context:
+                    precommit_status = s
+                    break
+
+        if precommit_status is not None:
+            state = precommit_status.get("state")
+            if state != "pending":
+                # A reported, non-pending result (success / failure /
+                # error) is not stale — nothing to retrigger.
+                return False
+            # Pending: only stuck once it has been pending longer than
+            # the threshold.  Use ``updated_at`` (when pre-commit.ci
+            # set the pending status), falling back to ``created_at``.
+            raw_ts = precommit_status.get("updated_at") or precommit_status.get(
+                "created_at"
+            )
+            pending_age: float | None = None
+            if isinstance(raw_ts, str) and raw_ts:
+                try:
+                    ts = datetime.fromisoformat(raw_ts.replace("Z", "+00:00"))
+                    pending_age = (now - ts).total_seconds()
+                except ValueError:
+                    pending_age = None
+            if (
+                pending_age is None
+                or pending_age < PRECOMMIT_CI_STUCK_PENDING_SECONDS
+            ):
+                # Still within the normal window (or no timestamp to
+                # judge by) — leave the run to finish.
+                return False
+            self.log.info(
+                "pre-commit.ci on %s#%s pending for %.0fs; treating as stuck.",
+                pr_info.repository_full_name,
+                pr_info.number,
+                pending_age,
+            )
+
+        # 3. The run is stale (missing, or stuck pending) — check for
+        # an existing trigger comment before posting a duplicate
+        # (avoids spam if dependamerge runs repeatedly while the
+        # status is still not progressing).
         try:
             comments = await self._github_client.get(
                 f"/repos/{repo_owner}/{repo_name}/issues/{pr_info.number}/comments?per_page=100"
@@ -2492,8 +2547,7 @@ class AsyncMergeManager:
         log_and_print(
             self.log,
             self._console,
-            f"⏳ Triggering pre-commit.ci re-run: {pr_info.html_url} "
-            "[status never reported]",
+            f"🔄 Re-triggering pre-commit.ci: {pr_info.html_url}",
             level="info",
         )
 

--- a/src/dependamerge/merge_manager.py
+++ b/src/dependamerge/merge_manager.py
@@ -3646,9 +3646,20 @@ class AsyncMergeManager:
         immediately make a sibling PR ``dirty`` (the classic
         ``uv.lock`` / workflow-pin conflict) or ``behind``.  A
         concurrent ``dependamerge`` run elsewhere in the org can do the
-        same.  We therefore re-read the PR's state immediately before
-        dispatching the merge, rather than trusting the fetch-time
-        snapshot.
+        same.
+
+        This method is the **post-failure** half of the conflict-
+        detection pair, called from ``_merge_single_pr`` *after* a
+        repo-scoped merge attempt returns falsy and always **outside**
+        the per-repo dispatch lock.  It catches the case where a PR
+        turned ``dirty`` *during* our own merge window (a sibling
+        merged between the pre-dispatch check and the merge call) so a
+        freshly-conflicted PR is routed to conflict recovery rather
+        than reported as a generic merge failure.  The complementary
+        **pre-dispatch** check is the single-GET ``_is_pr_dirty_now``,
+        which runs *inside* the dispatch lock; the polling done here
+        deliberately stays off that lock so GitHub's recompute window
+        never serialises the whole repo batch.
 
         GitHub recomputes ``mergeable`` / ``mergeable_state``
         asynchronously after the base branch moves, reporting
@@ -3840,7 +3851,15 @@ class AsyncMergeManager:
                             pr_info.mergeable = refreshed_mergeable
                     if "mergeable_state" in refreshed_wait:
                         refreshed_state = refreshed_wait.get("mergeable_state")
-                        if refreshed_state is not None:
+                        # Preserve the previous concrete state while
+                        # GitHub is still recomputing mergeability: it
+                        # returns ``null`` / ``""`` / ``"unknown"``
+                        # transiently, and overwriting with those would
+                        # push the state out of ``continue_states`` and
+                        # break the wait loop early (e.g. a ``blocked``
+                        # PR briefly going ``unknown`` would exit and
+                        # trigger a premature manual merge).
+                        if refreshed_state not in (None, "", "unknown"):
                             pr_info.mergeable_state = refreshed_state
                     # The head can change while we wait (rebase,
                     # force-push); keep it current so any later
@@ -3855,6 +3874,18 @@ class AsyncMergeManager:
                         )
                         pr_info.state = "closed"
                         break
+                # A PR that becomes immediately mergeable while still
+                # ``unstable`` (only a non-required check is red) will
+                # never reach ``clean`` and never leave ``unstable``,
+                # so keeping it in ``continue_states`` would spin the
+                # wait to the deadline — the exact slow hang the
+                # Step 5.5 routing fix removes for PRs that *start*
+                # mergeable.  Break out as soon as GitHub reports
+                # ``unstable`` + ``mergeable is True`` so the caller can
+                # dispatch (auto-merge, already armed before this wait,
+                # will land it; failing that the caller merges directly).
+                if pr_info.mergeable_state == "unstable" and pr_info.mergeable is True:
+                    break
                 # Continue waiting only while the PR is in a state the
                 # caller still considers rescuable; any other value
                 # means it became mergeable, closed, or hit a terminal
@@ -4056,8 +4087,25 @@ class AsyncMergeManager:
         # before — approving the pre-rebase head would just be
         # dismissed by dependabot's force-push, producing the
         # duplicate approvals we want to avoid) and try to enable
-        # auto-merge.
-        await self._approve_pr(owner, repo, pr_info.number)
+        # auto-merge.  Handle an approval failure (permission / API
+        # error) here rather than letting it bubble to the generic
+        # catch-all, which would lose the conflict-recovery context.
+        try:
+            await self._approve_pr(owner, repo, pr_info.number)
+        except Exception as exc:
+            self.log.warning(
+                "Failed to approve %s/%s#%s after rebase: %s",
+                owner,
+                repo,
+                pr_info.number,
+                exc,
+            )
+            result.status = MergeStatus.FAILED
+            result.error = f"rebase cleared the conflict but approval failed: {exc}"
+            if self.progress_tracker:
+                self.progress_tracker.merge_failure()
+            self._console.print(f"❌ Failed: {pr_info.html_url}", markup=False)
+            return result
         auto_ok = await self._enable_auto_merge_for_pr(pr_info, owner, repo)
         if auto_ok:
             log_and_print(

--- a/src/dependamerge/merge_manager.py
+++ b/src/dependamerge/merge_manager.py
@@ -1549,37 +1549,53 @@ class AsyncMergeManager:
                     dispatch_lock = await self._get_merge_dispatch_lock(
                         repo_owner, repo_name
                     )
-                    conflict_detected = False
+                    dirty_before_dispatch = False
                     async with dispatch_lock:
-                        # In a repo-scoped batch, an earlier merge in
-                        # this repo (or a concurrent dependamerge run)
-                        # may have made this PR ``dirty`` / ``behind``
-                        # since it was fetched.  Refresh the live state
-                        # now that we hold the dispatch lock — this is
-                        # the only point that is both serialised and
-                        # ordered after any sibling merge.  See
-                        # ``_refresh_pr_mergeability``.
+                        # Re-read live merge state *before* dispatch — a
+                        # single GET, no recompute poll.  In a
+                        # repo-scoped batch an earlier sibling merge can
+                        # turn this PR ``dirty`` between the one-shot
+                        # fetch and dispatch (the classic shared
+                        # ``uv.lock`` conflict); routing it straight to
+                        # conflict recovery avoids dispatching a doomed
+                        # merge that 405s and then churns the retry loop
+                        # against the stale ``clean`` snapshot.  We keep
+                        # this to a single GET (not the polling
+                        # ``_refresh_pr_mergeability``) because the
+                        # dispatch lock is the one point serialised *and*
+                        # ordered after a sibling merge, so polling
+                        # GitHub's recompute window here would serialise
+                        # the whole repo batch.
                         if self._repo_scoped:
-                            await self._refresh_pr_mergeability(
+                            dirty_before_dispatch = await self._is_pr_dirty_now(
                                 pr_info, repo_owner, repo_name
                             )
-                        if pr_info.mergeable_state == "dirty":
-                            # A real merge conflict (a sibling merged
-                            # first).  Defer recovery until *after* we
-                            # release the dispatch lock: the conflict
-                            # handler can wait for the full
-                            # ``merge_timeout`` and must not block other
-                            # PRs' merges on this repo.
-                            conflict_detected = True
+                        if dirty_before_dispatch:
                             merged = False
                         else:
                             merged = await self._merge_pr_with_retry(
                                 pr_info, repo_owner, repo_name
                             )
-                    if conflict_detected:
+                    # Conflict recovery runs *outside* the dispatch lock
+                    # so the rebase wait never blocks sibling merges.
+                    if dirty_before_dispatch:
                         return await self._handle_merge_conflict(
                             pr_info, repo_owner, repo_name, result
                         )
+                    # A PR can also turn ``dirty`` *during* our own merge
+                    # window (a sibling merged between the pre-dispatch
+                    # check and the merge call).  The post-failure
+                    # refresh — off the lock, with its recompute poll —
+                    # catches that so a freshly-dirty PR is never
+                    # reported as a generic merge failure.
+                    if not merged and self._repo_scoped:
+                        await self._refresh_pr_mergeability(
+                            pr_info, repo_owner, repo_name
+                        )
+                        if pr_info.mergeable_state == "dirty":
+                            return await self._handle_merge_conflict(
+                                pr_info, repo_owner, repo_name, result
+                            )
 
                 if merged is None:
                     # Auto-merge is active — PR will merge asynchronously.
@@ -2515,7 +2531,12 @@ class AsyncMergeManager:
                 try:
                     ts = datetime.fromisoformat(raw_ts.replace("Z", "+00:00"))
                     pending_age = (now - ts).total_seconds()
-                except ValueError:
+                except (ValueError, TypeError):
+                    # ``ValueError``: unparsable timestamp.
+                    # ``TypeError``: a timestamp lacking tz info parses
+                    # to a naive datetime, which cannot be subtracted
+                    # from the tz-aware ``now``.  Either way, degrade to
+                    # ``None`` (fail closed) rather than abort the run.
                     pending_age = None
             if (
                 pending_age is None
@@ -2687,9 +2708,17 @@ class AsyncMergeManager:
                 return None
             try:
                 # GitHub returns RFC 3339 with a trailing ``Z``.
-                return datetime.fromisoformat(value.replace("Z", "+00:00"))
+                ts = datetime.fromisoformat(value.replace("Z", "+00:00"))
             except ValueError:
                 return None
+            # A timestamp without tz info parses to a naive datetime,
+            # which raises ``TypeError`` when subtracted from the
+            # tz-aware ``now`` below.  Treat it as unparsable (fail
+            # closed) so the detector degrades gracefully instead of
+            # aborting the merge run.
+            if ts.tzinfo is None:
+                return None
+            return ts
 
         def _is_dco_name(name: str) -> bool:
             """Return True when ``name`` looks like a DCO check.
@@ -3635,6 +3664,73 @@ class AsyncMergeManager:
             return False
         return pr_data.get("state") == "closed" and bool(pr_data.get("merged"))
 
+    async def _is_pr_dirty_now(
+        self, pr_info: PullRequestInfo, owner: str, repo: str
+    ) -> bool:
+        """Best-effort single GET: ``True`` only if the PR is *concretely* dirty.
+
+        Called inside the per-repo dispatch lock, immediately before the
+        merge is dispatched, to catch a PR that an earlier sibling merge
+        in the same repo-scoped batch has turned ``dirty`` (the classic
+        shared-``uv.lock`` conflict) since the one-shot fetch snapshot.
+        Routing such a PR straight to conflict recovery avoids
+        dispatching a doomed merge that 405s and then churns
+        :meth:`_merge_pr_with_retry`'s retry loop against the stale
+        ``clean`` snapshot (which misreads the 405 as a transient error
+        on a mergeable PR and sleeps under the dispatch lock before
+        re-fetching).
+
+        Deliberately a *single* GET with no recompute poll — unlike
+        :meth:`_refresh_pr_mergeability`, which polls GitHub's
+        "still computing" window and therefore runs only *after* a
+        failed merge, off the lock.  The dispatch lock is the one point
+        serialised *and* ordered after a sibling merge, so polling here
+        would serialise the whole repo batch.  We therefore act only on
+        a *concrete* ``dirty``; a still-computing, closed, non-dirty, or
+        errored result returns ``False`` so the merge attempt proceeds
+        and the off-lock post-failure refresh settles anything that
+        turns out to be a fresh conflict.
+
+        Mutates ``pr_info`` (``mergeable``, ``mergeable_state``,
+        ``head_sha``) only when it confirms a concrete ``dirty``, so the
+        conflict handler and failure summary report accurate state.  The
+        snapshot is otherwise left untouched — in particular a transient
+        ``unknown`` never overwrites a concrete ``clean``, preserving the
+        transient-405-on-``clean`` retry path in
+        :meth:`_merge_pr_with_retry`.
+        """
+        if not self._github_client:
+            return False
+        try:
+            data = await self._github_client.get(
+                f"/repos/{owner}/{repo}/pulls/{pr_info.number}"
+            )
+        except Exception as exc:
+            self.log.debug(
+                "Pre-dispatch dirty check failed for %s/%s#%s: %s",
+                owner,
+                repo,
+                pr_info.number,
+                exc,
+            )
+            return False
+        if not isinstance(data, dict):
+            return False
+        # A closed PR is handled by the caller's closed-PR path, not as
+        # a conflict.
+        if data.get("state") == "closed":
+            return False
+        if data.get("mergeable_state") != "dirty":
+            return False
+        # Concrete conflict: record it so ``_handle_merge_conflict`` and
+        # the failure summary act on accurate, current state.
+        pr_info.mergeable = data.get("mergeable")
+        pr_info.mergeable_state = "dirty"
+        head_sha = (data.get("head") or {}).get("sha")
+        if head_sha:
+            pr_info.head_sha = head_sha
+        return True
+
     async def _refresh_pr_mergeability(
         self, pr_info: PullRequestInfo, owner: str, repo: str
     ) -> None:
@@ -3738,11 +3834,18 @@ class AsyncMergeManager:
                 # Timed out waiting for GitHub to settle.  Record the
                 # latest values we did get (even if still computing) so
                 # downstream logic sees GitHub's current best answer
-                # rather than the older snapshot.
+                # rather than the older snapshot.  Reaching here means we
+                # are still in the recompute window, where GitHub signals
+                # "still computing" with ``mergeable=None`` and a
+                # ``mergeable_state`` of ``None``, ``""`` or
+                # ``"unknown"``.  Normalise any of those to a concrete
+                # ``"unknown"`` and always record it, so a stale concrete
+                # state (e.g. ``clean``) is never left in place —
+                # consistent with the ``still_computing`` check above,
+                # which treats ``None``/``""``/``"unknown"`` alike.
                 if mergeable is not None:
                     pr_info.mergeable = mergeable
-                if mergeable_state not in (None, ""):
-                    pr_info.mergeable_state = mergeable_state
+                pr_info.mergeable_state = mergeable_state or "unknown"
                 self.log.debug(
                     "Mergeability for %s/%s#%s still computing after %.0fs; "
                     "proceeding with mergeable=%s state=%s",

--- a/src/dependamerge/merge_manager.py
+++ b/src/dependamerge/merge_manager.py
@@ -898,7 +898,8 @@ class AsyncMergeManager:
                 self.progress_tracker.merge_failure()
             self._console.print(
                 f"❌ Failed: {pr_info.html_url} "
-                "[token lacks permissions on this repository]"
+                "[token lacks permissions on this repository]",
+                markup=False,
             )
             result.duration = time.time() - start_time
             return result
@@ -950,7 +951,8 @@ class AsyncMergeManager:
                     # Attempt to submit the Gerrit change
                     self._console.print(
                         f"🔄 Submitting Gerrit change for {pr_info.html_url} "
-                        f"[{skip_msg}]"
+                        f"[{skip_msg}]",
+                        markup=False,
                     )
                     submitted = await self._submit_gerrit_change(
                         mapping, pr_info, repo_owner, repo_name
@@ -975,7 +977,8 @@ class AsyncMergeManager:
                         self.progress_tracker.merge_failure()
                     self._console.print(
                         f"❌ Failed: {pr_info.html_url} "
-                        f"[Gerrit submit failed for {skip_msg}]"
+                        f"[Gerrit submit failed for {skip_msg}]",
+                        markup=False,
                     )
                     return result
 
@@ -1003,7 +1006,9 @@ class AsyncMergeManager:
                     return result
                 result.status = MergeStatus.FAILED
                 result.error = "PR is already closed"
-                self._console.print(f"🛑 Failed: {pr_info.html_url} [already closed]")
+                self._console.print(
+                    f"🛑 Failed: {pr_info.html_url} [already closed]", markup=False
+                )
                 return result
 
             # A merge conflict (``dirty``) has no merge path of its
@@ -1187,7 +1192,8 @@ class AsyncMergeManager:
                 result.status = MergeStatus.FAILED
                 result.error = "Copilot review processing incomplete - not approving to avoid pollution"
                 self._console.print(
-                    f"❌ Failed: {pr_info.html_url} [copilot processing incomplete]"
+                    f"❌ Failed: {pr_info.html_url} [copilot processing incomplete]",
+                    markup=False,
                 )
                 return result
 
@@ -1405,7 +1411,8 @@ class AsyncMergeManager:
                     result.status = MergeStatus.SKIPPED
                     result.error = "PR is behind base branch and --no-fix option is set"
                     self._console.print(
-                        f"⏭️ Skipped: {pr_info.html_url} [behind, rebase disabled]"
+                        f"⏭️ Skipped: {pr_info.html_url} [behind, rebase disabled]",
+                        markup=False,
                     )
                 elif pr_info.mergeable_state == "behind" and self.fix_out_of_date:
                     # For behind PRs with fix enabled, show warning with rebase info
@@ -1414,13 +1421,15 @@ class AsyncMergeManager:
                     if self.progress_tracker:
                         self.progress_tracker.merge_success()
                     self._console.print(
-                        f"⚠️  Rebase/merge: {pr_info.html_url} [behind base branch]"
+                        f"⚠️  Rebase/merge: {pr_info.html_url} [behind base branch]",
+                        markup=False,
                     )
                 elif pr_info.mergeable_state == "dirty":
                     result.status = MergeStatus.BLOCKED
                     result.error = "PR has merge conflicts"
                     self._console.print(
-                        f"🛑 Blocked: {pr_info.html_url} [merge conflicts]"
+                        f"🛑 Blocked: {pr_info.html_url} [merge conflicts]",
+                        markup=False,
                     )
                 elif (
                     pr_info.mergeable is False and pr_info.mergeable_state == "blocked"
@@ -1428,7 +1437,8 @@ class AsyncMergeManager:
                     result.status = MergeStatus.BLOCKED
                     result.error = "PR blocked by failing checks"
                     self._console.print(
-                        f"🛑 Blocked: {pr_info.html_url} [blocked by failing checks]"
+                        f"🛑 Blocked: {pr_info.html_url} [blocked by failing checks]",
+                        markup=False,
                     )
                 else:
                     # Simulate successful merge in preview mode
@@ -1765,7 +1775,8 @@ class AsyncMergeManager:
                             )
                             self._console.print(
                                 f"❌ Failed: {recreated_pr.html_url} "
-                                "[recreated PR merge failed]"
+                                "[recreated PR merge failed]",
+                                markup=False,
                             )
                     else:
                         await self._report_merge_failure(
@@ -1798,7 +1809,8 @@ class AsyncMergeManager:
             # Extract operation-specific error message
             operation_desc = e.operation.replace("_", " ")
             self._console.print(
-                f"❌ Failed: {pr_info.html_url} [permission denied: {operation_desc}]"
+                f"❌ Failed: {pr_info.html_url} [permission denied: {operation_desc}]",
+                markup=False,
             )
 
             if not first_failure_for_repo:
@@ -3981,7 +3993,9 @@ class AsyncMergeManager:
                 f"🔀 Merge conflict: {pr_info.html_url}",
                 level="info",
             )
-            self._console.print(f"❌ Failed: {pr_info.html_url} [merge conflicts]")
+            self._console.print(
+                f"❌ Failed: {pr_info.html_url} [merge conflicts]", markup=False
+            )
             result.status = MergeStatus.FAILED
             result.error = "merge conflicts"
             if self.progress_tracker:
@@ -3997,7 +4011,9 @@ class AsyncMergeManager:
             level="info",
         )
         if not await self._request_dependabot_rebase(pr_info, owner, repo):
-            self._console.print(f"❌ Failed: {pr_info.html_url} [merge conflicts]")
+            self._console.print(
+                f"❌ Failed: {pr_info.html_url} [merge conflicts]", markup=False
+            )
             result.status = MergeStatus.FAILED
             result.error = "merge conflicts"
             if self.progress_tracker:
@@ -4024,7 +4040,9 @@ class AsyncMergeManager:
         if pr_info.mergeable_state == "dirty":
             # Timed out still conflicting — the rebase did not happen
             # or could not resolve the conflict.
-            self._console.print(f"❌ Failed: {pr_info.html_url} [merge conflicts]")
+            self._console.print(
+                f"❌ Failed: {pr_info.html_url} [merge conflicts]", markup=False
+            )
             result.status = MergeStatus.FAILED
             result.error = "merge conflicts"
             if self.progress_tracker:
@@ -4034,9 +4052,11 @@ class AsyncMergeManager:
         # Conflict cleared.  Approve the rebased commit *now* (not
         # before — approving the pre-rebase head would just be
         # dismissed by dependabot's force-push, producing the
-        # duplicate approvals we want to avoid) and enable auto-merge.
+        # duplicate approvals we want to avoid) and try to enable
+        # auto-merge.
         await self._approve_pr(owner, repo, pr_info.number)
-        if await self._enable_auto_merge_for_pr(pr_info, owner, repo):
+        auto_ok = await self._enable_auto_merge_for_pr(pr_info, owner, repo)
+        if auto_ok:
             log_and_print(
                 self.log,
                 self._console,
@@ -4044,38 +4064,78 @@ class AsyncMergeManager:
                 level="debug",
             )
 
-        # Phase 2: wait (sharing the deadline) for required checks and
-        # auto-merge to complete.  ``stop_on_clean=False`` keeps us
-        # waiting once the PR goes ``clean`` so we observe auto-merge
-        # actually close the PR (reporting MERGED) rather than exiting
-        # the moment it becomes mergeable.
-        closed, merged = await self._wait_for_auto_merge(
-            pr_info,
-            owner,
-            repo,
-            continue_states=(
+        # Phase 2: wait (sharing the deadline) for required checks to
+        # land.  When auto-merge is armed we wait *through* ``clean``
+        # (``stop_on_clean=False``) so we can observe GitHub actually
+        # close the PR and report MERGED.  When auto-merge could NOT be
+        # enabled, waiting through ``clean`` would just spin until the
+        # deadline (nothing would merge the PR), so we stop on ``clean``
+        # and merge it ourselves below.
+        if auto_ok:
+            continue_states: tuple[str, ...] = (
                 "clean",
                 "blocked",
                 "behind",
                 "unstable",
                 "unknown",
                 "",
-            ),
+            )
+        else:
+            continue_states = ("blocked", "behind", "unstable", "unknown", "")
+        closed, merged = await self._wait_for_auto_merge(
+            pr_info,
+            owner,
+            repo,
+            continue_states=continue_states,
             deadline=deadline,
-            stop_on_clean=False,
+            stop_on_clean=not auto_ok,
         )
         if closed:
             return self._finish_conflict_close(pr_info, result, merged)
 
-        # Not merged within the window, but the rebase landed and
-        # auto-merge is armed: GitHub will complete the merge once the
-        # required checks pass (often after our run ends).
-        result.status = MergeStatus.AUTO_MERGE_PENDING
-        log_and_print(
-            self.log,
-            self._console,
-            f"⏳ Waiting: {pr_info.html_url} [auto-merge after rebase]",
-            level="debug",
+        if auto_ok:
+            # Auto-merge is armed: GitHub will complete the merge once
+            # the required checks pass (often after our run ends).
+            result.status = MergeStatus.AUTO_MERGE_PENDING
+            log_and_print(
+                self.log,
+                self._console,
+                f"⏳ Waiting: {pr_info.html_url} [auto-merge after rebase]",
+                level="debug",
+            )
+            return result
+
+        # Auto-merge could not be enabled.  If the rebase left the PR
+        # mergeable, merge it directly now; otherwise it will not land
+        # on its own — report the failure rather than a misleading
+        # ``AUTO_MERGE_PENDING`` that would never resolve.
+        if pr_info.mergeable_state == "clean":
+            dispatch_lock = await self._get_merge_dispatch_lock(owner, repo)
+            async with dispatch_lock:
+                merged = await self._merge_pr_with_retry(pr_info, owner, repo)
+            if merged:
+                result.status = MergeStatus.MERGED
+                if self.progress_tracker:
+                    self.progress_tracker.merge_success()
+                log_and_print(
+                    self.log,
+                    self._console,
+                    f"✅ Merged: {pr_info.html_url}",
+                    level="debug",
+                )
+                return result
+
+        result.status = MergeStatus.FAILED
+        result.error = (
+            "rebase cleared the conflict but the PR could not be merged "
+            "(auto-merge unavailable)"
+        )
+        if self.progress_tracker:
+            self.progress_tracker.merge_failure()
+        self._console.print(
+            f"❌ Failed: {pr_info.html_url} "
+            "[rebase landed but merge/auto-merge unavailable]",
+            markup=False,
         )
         return result
 
@@ -4133,14 +4193,19 @@ class AsyncMergeManager:
 
         result.status = MergeStatus.FAILED
         if not stuck_reported:
-            result.error = "Failed to merge after all retry attempts"
+            # Use the (now informative) failure reason as the result
+            # error too, so the end-of-run summary surfaces the real
+            # cause rather than a generic "all retry attempts" line.
+            result.error = failure_reason or "Failed to merge after all retry attempts"
         if self.progress_tracker:
             self.progress_tracker.merge_failure()
         # The ``⚠️ Stuck check`` line above is the cause for stuck PRs;
-        # only emit the generic failure line otherwise.
+        # only emit the generic failure line otherwise.  ``markup=False``
+        # keeps Rich from swallowing the bracketed reason.
         if not stuck_reported:
             self._console.print(
-                f"❌ Failed: {pr_info.html_url} [{failure_reason}]"
+                f"❌ Failed: {pr_info.html_url} [{failure_reason}]",
+                markup=False,
             )
         return result
 
@@ -4163,6 +4228,19 @@ class AsyncMergeManager:
         if last_exception:
             error_msg = str(last_exception)
             self.log.debug(f"Last exception for {pr_key}: {error_msg[:200]}")
+            # The merge layer (github_async.merge_pull_request) embeds
+            # GitHub's own explanation after a "GitHub: " marker — the
+            # ruleset violation, "Required workflows ... are not
+            # satisfied", required-check names, etc.  This is the
+            # actionable cause, so surface it ahead of any generic
+            # state-based inference.  We trim the PR-state context we
+            # appended after it so the reason stays concise.
+            marker = "GitHub: "
+            if marker in error_msg:
+                detail = error_msg.split(marker, 1)[1]
+                detail = detail.split(" (PR state:", 1)[0].strip()
+                if detail:
+                    return detail[:300]
             # Check for workflow scope error - be very specific to avoid false positives
             # Only match the exact error message pattern we raise in github_async.py
             if "Missing 'workflow' scope" in error_msg:

--- a/src/dependamerge/merge_manager.py
+++ b/src/dependamerge/merge_manager.py
@@ -1290,10 +1290,28 @@ class AsyncMergeManager:
             # them.
             pr_key_for_wait = f"{repo_owner}/{repo_name}#{pr_info.number}"
             already_rebased = pr_key_for_wait in self._rebased_prs
+            # ``unstable`` means a non-required check is failing or
+            # pending but the PR is otherwise mergeable.  When GitHub
+            # also reports ``mergeable is True`` the green button is
+            # live and a direct merge succeeds *now*, so entering the
+            # auto-merge wait would be pure waste: the state never
+            # reaches ``clean`` (the non-required check stays red, e.g.
+            # an excluded Zizmor scan), so the loop burns the full
+            # ``merge_timeout``; and ``enablePullRequestAutoMerge``
+            # is rejected outright on an already-mergeable PR, so the
+            # wait isn't even backed by auto-merge.  Route those
+            # straight to the Step 6 direct merge.  We still wait on
+            # ``unstable`` when ``mergeable`` is not literally True
+            # (GitHub still computing the value, or a required check
+            # transiently failing) so a genuinely not-yet-ready PR is
+            # not merged prematurely.
+            state_is_waitable = pr_info.mergeable_state in ("blocked", "behind") or (
+                pr_info.mergeable_state == "unstable" and pr_info.mergeable is not True
+            )
             base_should_wait = (
                 not self.preview_mode
                 and self._github_client is not None
-                and pr_info.mergeable_state in ("blocked", "behind", "unstable")
+                and state_is_waitable
                 and self.force_level != "all"
                 and not already_rebased
             )

--- a/src/dependamerge/output_utils.py
+++ b/src/dependamerge/output_utils.py
@@ -44,8 +44,15 @@ def log_and_print(
     """
     log_func = getattr(logger, level.lower(), logger.info)
     log_func(message)
+    # ``markup=False`` is important: status messages routinely embed a
+    # bracketed reason (e.g. "❌ Failed: <url> [merge conflicts]").  With
+    # Rich markup enabled (the default), ``[merge conflicts]`` is parsed
+    # as a style tag and silently dropped, so the reason never reaches
+    # the user.  These messages never use intentional Rich markup — the
+    # ``style`` argument is the supported styling path — so disabling
+    # markup is safe and keeps the reason visible.
     if style:
-        console.print(message, style=style)
+        console.print(message, style=style, markup=False)
     else:
         # Route through the Rich console rather than the builtin
         # ``print`` so output coordinates correctly with any active
@@ -53,4 +60,4 @@ def log_and_print(
         # ``print`` here causes the Live re-draw to garble or eat
         # interleaved messages (e.g. per-PR ✅/❌ lines emitted
         # while a progress tracker is running).
-        console.print(message)
+        console.print(message, markup=False)

--- a/src/dependamerge/resolve_conflicts.py
+++ b/src/dependamerge/resolve_conflicts.py
@@ -40,7 +40,6 @@ from .git_ops import (
     clone,
     commit_amend_no_edit,
     create_secure_tempdir,
-    fetch,
     fetch_branch,
     list_conflicted_files,
     push_force_with_lease,

--- a/tests/test_auto_merge.py
+++ b/tests/test_auto_merge.py
@@ -1369,3 +1369,80 @@ class TestBlockReasonIndicatesPendingChecks:
             )
             is False
         )
+
+
+class TestWaitForAutoMergeRecompute:
+    """`_wait_for_auto_merge` must survive GitHub's recompute window."""
+
+    @pytest.mark.asyncio
+    async def test_transient_unknown_does_not_break_loop_early(self) -> None:
+        """A transient 'unknown' must not exit the wait or clobber state."""
+        mgr, client = make_merge_manager()
+        pr = _DEFAULT_PR.model_copy(
+            update={"mergeable_state": "blocked", "state": "open"}
+        )
+        # 1st poll: GitHub still recomputing (unknown / null).
+        # 2nd poll: auto-merge has landed (closed + merged).
+        client.get = AsyncMock(
+            side_effect=[
+                {"mergeable_state": "unknown", "mergeable": None},
+                {"state": "closed", "merged": True},
+            ]
+        )
+        with patch("dependamerge.merge_manager.asyncio.sleep", new_callable=AsyncMock):
+            closed, merged = await mgr._wait_for_auto_merge(
+                pr,
+                "owner",
+                "repo",
+                continue_states=("blocked", "behind", "unstable"),
+            )
+
+        # Without the fix the loop would break after the first poll
+        # ("unknown" not in continue_states); with it, it waits through
+        # the recompute and observes the merge.
+        assert client.get.await_count == 2
+        assert closed is True
+        assert merged is True
+        # The transient "unknown" never overwrote the prior state.
+        assert pr.mergeable_state == "blocked"
+
+    @pytest.mark.asyncio
+    async def test_unstable_mergeable_true_breaks_wait_early(self) -> None:
+        """unstable + mergeable=True must exit the wait, not spin to timeout."""
+        # Enter the wait while still computing (mergeable=None), then
+        # GitHub settles on unstable + mergeable=True.  Because
+        # ``unstable`` is in continue_states, the loop would otherwise
+        # keep waiting until the deadline; the fix breaks out as soon as
+        # the PR is immediately mergeable so the caller can dispatch.
+        mgr, client = make_merge_manager(merge_timeout=30.0)
+        pr = _DEFAULT_PR.model_copy(
+            update={
+                "mergeable_state": "blocked",
+                "mergeable": None,
+                "state": "open",
+            }
+        )
+        client.get = AsyncMock(
+            side_effect=[
+                {"mergeable_state": "unknown", "mergeable": None},
+                {"mergeable_state": "unstable", "mergeable": True},
+                # A third poll would only be reached if the loop failed
+                # to break; surface that as an explicit stuck state.
+                {"mergeable_state": "unstable", "mergeable": True},
+            ]
+        )
+        with patch("dependamerge.merge_manager.asyncio.sleep", new_callable=AsyncMock):
+            closed, merged = await mgr._wait_for_auto_merge(
+                pr,
+                "owner",
+                "repo",
+                continue_states=("blocked", "behind", "unstable"),
+            )
+
+        # Broke out on the 2nd poll (unstable + mergeable=True); never
+        # polled a 3rd time or ran to the deadline.
+        assert client.get.await_count == 2
+        assert closed is False
+        assert merged is False
+        assert pr.mergeable_state == "unstable"
+        assert pr.mergeable is True

--- a/tests/test_auto_merge.py
+++ b/tests/test_auto_merge.py
@@ -1195,6 +1195,107 @@ class TestStep5_5UnstableRoutesToAutoMerge:
         mock_merge_retry.assert_not_called()
 
 
+class TestStep5_5UnstableMergeableMergesDirectly:
+    """``unstable`` + ``mergeable is True`` merges directly (no wait).
+
+    Regression guard for the slow/silent hang observed on
+    ``test-tags-calver#27`` / ``test-tags-semantic#27``: once a
+    non-required check (e.g. an excluded Zizmor scan) is the only
+    failing gate, GitHub reports ``mergeable_state == "unstable"`` *and*
+    ``mergeable is True`` — the green button is live.  Routing such a PR
+    into the Step 5.5 auto-merge wait was pure waste: the state never
+    reaches ``clean`` (the non-required check stays red), so the loop
+    burned the full ``merge_timeout``, and ``enablePullRequestAutoMerge``
+    is rejected on an already-mergeable PR anyway.  The PR must instead
+    flow straight to the Step 6 direct merge.
+    """
+
+    @pytest.mark.asyncio
+    async def test_unstable_mergeable_true_merges_directly(self) -> None:
+        """unstable + mergeable=True → MERGED via direct merge, no wait."""
+        # A long timeout makes the test fail loudly (hang) if the PR is
+        # wrongly routed into the wait loop instead of merging directly.
+        mgr, client = make_merge_manager(preview_mode=False, merge_timeout=30.0)
+        pr = _DEFAULT_PR.model_copy(
+            update={
+                "mergeable_state": "unstable",
+                "mergeable": True,
+                "state": "open",
+            }
+        )
+
+        # If these are reached the fix has regressed: an already-mergeable
+        # unstable PR must neither enable auto-merge nor enter the wait.
+        client.enable_auto_merge = AsyncMock(return_value=True)
+        client.post_issue_comment = AsyncMock()
+        client.get = AsyncMock(
+            return_value={
+                "mergeable": True,
+                "mergeable_state": "unstable",
+                "state": "open",
+            }
+        )
+        client.get_required_status_checks = AsyncMock(return_value=[])
+        client.analyze_block_reason = AsyncMock(
+            return_value="a non-required check failed"
+        )
+
+        no_g2g = GitHub2GerritDetectionResult()
+        with (
+            patch.object(
+                mgr,
+                "_detect_github2gerrit",
+                new_callable=AsyncMock,
+                return_value=no_g2g,
+            ),
+            patch.object(
+                mgr,
+                "_get_merge_method_for_repo",
+                new_callable=AsyncMock,
+                return_value="merge",
+            ),
+            patch.object(
+                mgr,
+                "_trigger_stale_precommit_ci",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+            patch.object(
+                mgr,
+                "_check_merge_requirements",
+                new_callable=AsyncMock,
+                return_value=(True, ""),
+            ),
+            patch.object(
+                mgr,
+                "_approve_pr",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
+            patch.object(
+                mgr,
+                "_merge_pr_with_retry",
+                new_callable=AsyncMock,
+                return_value=True,
+            ) as mock_merge_retry,
+            patch.object(
+                mgr,
+                "_wait_for_auto_merge",
+                new_callable=AsyncMock,
+                return_value=(False, False),
+            ) as mock_wait,
+        ):
+            result = await mgr._merge_single_pr(pr)
+
+        # Direct merge ran and succeeded; the auto-merge wait was never
+        # entered and auto-merge was never enabled.
+        assert result.status == MergeStatus.MERGED
+        mock_merge_retry.assert_awaited_once()
+        mock_wait.assert_not_called()
+        client.enable_auto_merge.assert_not_awaited()
+        assert "owner/repo#42" not in mgr._auto_merge_enabled
+
+
 # ---------------------------------------------------------------------------
 # 20. ``dirty`` PRs are still blocked (genuine merge conflict invariant)
 # ---------------------------------------------------------------------------

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7,7 +7,12 @@ from unittest.mock import AsyncMock, Mock, patch
 import pytest
 from typer.testing import CliRunner
 
-from dependamerge.cli import _generate_override_sha, _validate_override_sha, app
+from dependamerge.cli import (
+    _format_failure_reason,
+    _generate_override_sha,
+    _validate_override_sha,
+    app,
+)
 from dependamerge.models import PullRequestInfo
 
 
@@ -736,3 +741,39 @@ class TestCLI:
         assert result.exit_code == 0
         assert "not from a recognized automation tool" in result.stdout
         assert "--override" in result.stdout
+
+
+class TestFormatFailureReason:
+    """Tests for the failed-PR summary reason formatter."""
+
+    def test_plain_reason_is_unchanged(self):
+        assert _format_failure_reason("merge conflicts") == ["merge conflicts"]
+
+    def test_ruleset_not_satisfied_is_expanded(self):
+        reason = (
+            "Repository rule violations found Required workflows "
+            "'Autolabeler, Semantic Pull Request 🛠️, "
+            "Audit GitHub Actions 📌' are not satisfied"
+        )
+        assert _format_failure_reason(reason) == [
+            "Repository rule violations found",
+            "Required workflows not satisfied:",
+            "• Autolabeler",
+            "• Semantic Pull Request 🛠️",
+            "• Audit GitHub Actions 📌",
+        ]
+
+    def test_ruleset_failed_variant_uses_failed_header(self):
+        reason = (
+            "Repository rule violations found Required workflows 'Autolabeler' failed"
+        )
+        assert _format_failure_reason(reason) == [
+            "Repository rule violations found",
+            "Required workflows failed:",
+            "• Autolabeler",
+        ]
+
+    def test_non_ruleset_message_left_alone(self):
+        # Without the ruleset prefix, leave the reason unchanged.
+        reason = "Required workflows 'X' are not satisfied"
+        assert _format_failure_reason(reason) == [reason]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -10,6 +10,8 @@ from typer.testing import CliRunner
 from dependamerge.cli import (
     _format_failure_reason,
     _generate_override_sha,
+    _MergeContext,
+    _restart_merge_progress_tracker,
     _validate_override_sha,
     app,
 )
@@ -777,3 +779,77 @@ class TestFormatFailureReason:
         # Without the ruleset prefix, leave the reason unchanged.
         reason = "Required workflows 'X' are not satisfied"
         assert _format_failure_reason(reason) == [reason]
+
+
+def _make_merge_context(show_progress: bool) -> _MergeContext:
+    """Build a minimal ``_MergeContext`` for tracker-lifecycle tests."""
+    ctx = _MergeContext(
+        pr_url="https://github.com/owner/repo/pull/1",
+        no_confirm=True,
+        similarity_threshold=0.8,
+        merge_method="merge",
+        token="fake-token",
+        override=None,
+        no_fix=False,
+        merge_timeout=300.0,
+        show_progress=show_progress,
+        debug_matching=False,
+        dismiss_copilot=False,
+        force="none",
+        verbose=False,
+        no_netrc=False,
+        netrc_file=None,
+        netrc_optional=True,
+        github2gerrit_mode="ignore",
+    )
+    ctx.owner = "owner"
+    ctx.repo_name = "repo"
+    return ctx
+
+
+class TestRestartMergeProgressTracker:
+    """``_restart_merge_progress_tracker`` revives the merge-phase display.
+
+    The org-wide scan stops the tracker it used (tearing down its Rich
+    ``Live``).  Reusing that stopped tracker for the real merge means
+    the background wait-status ticker pushes updates into a dead
+    ``Live`` — silently dropped — so the user sees no countdown while
+    PRs sit in the Step 5.5 auto-merge wait.  This helper must stand up
+    a fresh, *started* tracker so the ticker has somewhere to render.
+    """
+
+    def test_replaces_stopped_tracker_with_started_one(self) -> None:
+        from dependamerge.progress_tracker import MergeProgressTracker
+
+        ctx = _make_merge_context(show_progress=True)
+        # Simulate the post-scan state: a tracker that has been stopped
+        # (its Live torn down -> ``live is None``).
+        stopped = MergeProgressTracker("owner")
+        stopped.start()
+        stopped.stop()
+        assert stopped.live is None
+        ctx.progress_tracker = stopped
+
+        _restart_merge_progress_tracker(ctx, total_prs=3)
+
+        # A brand-new tracker is installed and started.
+        assert ctx.progress_tracker is not stopped
+        assert ctx.progress_tracker is not None
+        assert ctx.progress_tracker.total_prs == 3
+        # When Rich is available the Live display is active again; when
+        # it is not (e.g. non-TTY CI), ``start()`` is a no-op and there
+        # is nothing to assert about ``live``.
+        if ctx.progress_tracker.rich_available:
+            assert ctx.progress_tracker.live is not None
+            # Avoid leaking an active Rich Live into other tests.
+            ctx.progress_tracker.stop()
+
+    def test_no_op_when_progress_disabled(self) -> None:
+        ctx = _make_merge_context(show_progress=False)
+        ctx.progress_tracker = None
+
+        _restart_merge_progress_tracker(ctx, total_prs=5)
+
+        # ``--no-progress`` keeps the tracker absent; the plain-text
+        # ticker provides feedback instead.
+        assert ctx.progress_tracker is None

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -758,8 +758,7 @@ class TestFormatFailureReason:
             "Audit GitHub Actions 📌' are not satisfied"
         )
         assert _format_failure_reason(reason) == [
-            "Repository rule violations found",
-            "Required workflows not satisfied:",
+            "Repository rule violations found / Required workflows not satisfied",
             "• Autolabeler",
             "• Semantic Pull Request 🛠️",
             "• Audit GitHub Actions 📌",
@@ -770,9 +769,43 @@ class TestFormatFailureReason:
             "Repository rule violations found Required workflows 'Autolabeler' failed"
         )
         assert _format_failure_reason(reason) == [
-            "Repository rule violations found",
-            "Required workflows failed:",
+            "Repository rule violations found / Required workflows failed",
             "• Autolabeler",
+        ]
+
+    def test_ruleset_status_check_failing_is_expanded(self):
+        # Single-line GitHub status-check violation -> type line + bullet,
+        # consistent with the Required workflows shape.
+        reason = (
+            "Repository rule violations found Required status check "
+            '"pre-commit.ci - pr" is failing.'
+        )
+        assert _format_failure_reason(reason) == [
+            "Repository rule violations found / Required status checks failed",
+            "• pre-commit.ci - pr",
+        ]
+
+    def test_ruleset_status_check_multiple_names(self):
+        reason = (
+            "Repository rule violations found Required status checks "
+            '"lint", "build" are failing.'
+        )
+        assert _format_failure_reason(reason) == [
+            "Repository rule violations found / Required status checks failed",
+            "• lint",
+            "• build",
+        ]
+
+    def test_ruleset_status_check_not_satisfied_variant(self):
+        # A pending/expected (non-failing) required check uses the
+        # "not satisfied" verb rather than "failed".
+        reason = (
+            "Repository rule violations found Required status check "
+            '"pre-commit.ci - pr" is expected.'
+        )
+        assert _format_failure_reason(reason) == [
+            "Repository rule violations found / Required status checks not satisfied",
+            "• pre-commit.ci - pr",
         ]
 
     def test_non_ruleset_message_left_alone(self):

--- a/tests/test_dependabot_recreate.py
+++ b/tests/test_dependabot_recreate.py
@@ -841,7 +841,9 @@ class TestMergeSinglePrRecreateIntegration:
             result = await mgr._merge_single_pr(pr)
 
         assert result.status == MergeStatus.FAILED
-        assert "Failed to merge" in (result.error or "")
+        # The failure now surfaces the real reason (from
+        # _get_failure_summary) rather than a generic retry message.
+        assert "branch protection rules prevent merge" in (result.error or "")
 
     @pytest.mark.asyncio
     async def test_recreate_new_pr_merge_fails(self):

--- a/tests/test_merge_conflict_handling.py
+++ b/tests/test_merge_conflict_handling.py
@@ -136,6 +136,7 @@ class TestHandleMergeConflict:
                 mgr, "_wait_for_auto_merge", new_callable=AsyncMock
             ) as mock_wait,
             patch("dependamerge.merge_manager.log_and_print") as mock_log,
+            patch.object(mgr, "_console") as mock_console,
         ):
             result = await mgr._handle_merge_conflict(
                 pr, "lfreleng-actions", "lftools-uv", _result(pr)
@@ -149,6 +150,11 @@ class TestHandleMergeConflict:
         assert any(
             "🔀 Merge conflict" in str(call.args[2]) for call in mock_log.call_args_list
         )
+        # ...and it is NOT duplicated with a redundant ❌ Failed line.
+        printed = " ".join(
+            str(c.args[0]) for c in mock_console.print.call_args_list if c.args
+        )
+        assert "❌ Failed" not in printed
 
     @pytest.mark.asyncio
     async def test_rebase_request_failure_fails(self) -> None:

--- a/tests/test_merge_conflict_handling.py
+++ b/tests/test_merge_conflict_handling.py
@@ -310,6 +310,101 @@ class TestHandleMergeConflict:
         assert result.status == MergeStatus.FAILED
         assert "closed without merging" in (result.error or "")
 
+    @pytest.mark.asyncio
+    async def test_rebase_clears_but_auto_merge_unavailable_merges_directly(
+        self,
+    ) -> None:
+        """Rebase clears to clean but auto-merge fails -> merge directly.
+
+        Regression for the Copilot finding: when
+        ``_enable_auto_merge_for_pr`` returns False we must not return
+        a misleading AUTO_MERGE_PENDING; if the PR is mergeable we
+        merge it ourselves.
+        """
+        mgr, _client = make_merge_manager()
+        pr = _make_pr()
+        calls = {"n": 0}
+
+        async def fake_wait(pr_info, owner, repo, **kwargs):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                pr_info.mergeable_state = "clean"
+                return (False, False)
+            return (False, False)
+
+        with (
+            patch.object(
+                mgr,
+                "_request_dependabot_rebase",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
+            patch.object(mgr, "_wait_for_auto_merge", new=fake_wait),
+            patch.object(mgr, "_approve_pr", new_callable=AsyncMock, return_value=True),
+            patch.object(
+                mgr,
+                "_enable_auto_merge_for_pr",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+            patch.object(
+                mgr,
+                "_merge_pr_with_retry",
+                new_callable=AsyncMock,
+                return_value=True,
+            ) as mock_merge,
+        ):
+            result = await mgr._handle_merge_conflict(
+                pr, "lfreleng-actions", "lftools-uv", _result(pr)
+            )
+
+        assert result.status == MergeStatus.MERGED
+        mock_merge.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_rebase_clears_but_auto_merge_unavailable_and_not_clean(
+        self,
+    ) -> None:
+        """Auto-merge unavailable and PR not mergeable -> FAILED (not pending)."""
+        mgr, _client = make_merge_manager()
+        pr = _make_pr()
+        calls = {"n": 0}
+
+        async def fake_wait(pr_info, owner, repo, **kwargs):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                pr_info.mergeable_state = "blocked"
+                return (False, False)
+            return (False, False)
+
+        with (
+            patch.object(
+                mgr,
+                "_request_dependabot_rebase",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
+            patch.object(mgr, "_wait_for_auto_merge", new=fake_wait),
+            patch.object(mgr, "_approve_pr", new_callable=AsyncMock, return_value=True),
+            patch.object(
+                mgr,
+                "_enable_auto_merge_for_pr",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+            patch.object(
+                mgr, "_merge_pr_with_retry", new_callable=AsyncMock
+            ) as mock_merge,
+        ):
+            result = await mgr._handle_merge_conflict(
+                pr, "lfreleng-actions", "lftools-uv", _result(pr)
+            )
+
+        # Must NOT be AUTO_MERGE_PENDING (auto-merge was never armed).
+        assert result.status == MergeStatus.FAILED
+        assert "auto-merge unavailable" in (result.error or "")
+        mock_merge.assert_not_called()
+
 
 class TestConflictRoutingFromMergeSinglePr:
     """``_merge_single_pr`` routes ``dirty`` PRs to the conflict handler."""

--- a/tests/test_merge_conflict_handling.py
+++ b/tests/test_merge_conflict_handling.py
@@ -503,10 +503,16 @@ class TestConflictRoutingFromMergeSinglePr:
 
     @pytest.mark.asyncio
     async def test_dispatch_dirty_routes_to_handler(self) -> None:
-        """A PR that becomes dirty mid-batch is caught at dispatch."""
+        """A PR that becomes dirty mid-merge is caught after a failed merge.
+
+        The pre-dispatch peek still sees a clean PR (so the merge is
+        attempted); the merge then fails and the off-lock post-failure
+        refresh reveals the conflict and routes it to recovery.
+        """
         mgr, client = make_merge_manager(repo_scoped=True)
         mgr._post_approval_delay = 0.0
-        # Snapshot clean -> passes early checks; refresh reveals dirty.
+        # Snapshot clean -> passes early checks; the merge fails and the
+        # post-failure refresh reveals the conflict.
         client.get = AsyncMock(
             return_value={
                 "state": "open",
@@ -530,11 +536,19 @@ class TestConflictRoutingFromMergeSinglePr:
             patch.object(
                 mgr, "_approve_pr", new_callable=AsyncMock, return_value=False
             ),
+            # The pre-dispatch peek sees it still clean; the conflict
+            # only surfaces on the post-failure refresh.
+            patch.object(
+                mgr, "_is_pr_dirty_now", new_callable=AsyncMock, return_value=False
+            ),
             patch.object(
                 mgr, "_handle_merge_conflict", new_callable=AsyncMock
             ) as mock_handler,
             patch.object(
-                mgr, "_merge_pr_with_retry", new_callable=AsyncMock
+                mgr,
+                "_merge_pr_with_retry",
+                new_callable=AsyncMock,
+                return_value=False,
             ) as mock_merge,
         ):
             mock_handler.return_value = MergeResult(
@@ -542,6 +556,6 @@ class TestConflictRoutingFromMergeSinglePr:
             )
             await mgr._merge_single_pr(pr)
 
+        # The merge is attempted; the failure + refresh route to recovery.
+        mock_merge.assert_awaited_once()
         mock_handler.assert_awaited_once()
-        # The doomed merge call is skipped in favour of recovery.
-        mock_merge.assert_not_called()

--- a/tests/test_merge_conflict_handling.py
+++ b/tests/test_merge_conflict_handling.py
@@ -1,0 +1,408 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 The Linux Foundation
+
+"""Tests for merge-conflict recovery in ``AsyncMergeManager``.
+
+When a PR is ``dirty`` (a real merge conflict), it has no merge path
+of its own.  ``_handle_merge_conflict`` recovers dependabot PRs by
+posting ``@dependabot rebase`` (which regenerates lockfiles and
+re-signs the commit), then waits \u2014 bounded by ``merge_timeout`` \u2014 for
+the rebase and required checks to land, approving the rebased commit
+and enabling auto-merge.  Any other author is reported and failed fast
+(no wait), since there is no automated way to clear a content conflict.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from dependamerge.merge_manager import MergeResult, MergeStatus
+from dependamerge.models import PullRequestInfo
+from tests.conftest import make_merge_manager
+
+
+def _make_pr(
+    *,
+    author: str = "dependabot[bot]",
+    mergeable_state: str | None = "dirty",
+    number: int = 425,
+    repo: str = "lfreleng-actions/lftools-uv",
+) -> PullRequestInfo:
+    """Build a conflicted ``PullRequestInfo`` for conflict tests."""
+    return PullRequestInfo(
+        number=number,
+        node_id="PR_kwDOTestNode",
+        title="Chore: Bump safety from 3.7.0 to 3.8.1",
+        body="bump",
+        author=author,
+        head_sha="cafe" * 10,
+        base_branch="main",
+        head_branch="dependabot/uv/safety-3.8.1",
+        state="open",
+        mergeable=False,
+        mergeable_state=mergeable_state,
+        behind_by=None,
+        files_changed=[],
+        repository_full_name=repo,
+        html_url=f"https://github.com/{repo}/pull/{number}",
+        reviews=[],
+        review_comments=[],
+    )
+
+
+def _result(pr: PullRequestInfo) -> MergeResult:
+    return MergeResult(pr_info=pr, status=MergeStatus.PENDING)
+
+
+class TestRequestDependabotRebase:
+    """Unit tests for ``_request_dependabot_rebase``."""
+
+    @pytest.mark.asyncio
+    async def test_posts_when_no_existing_comment(self) -> None:
+        mgr, client = make_merge_manager()
+        client.get = AsyncMock(return_value=[])
+        client.post_issue_comment = AsyncMock()
+        pr = _make_pr()
+
+        ok = await mgr._request_dependabot_rebase(pr, "owner", "repo")
+
+        assert ok is True
+        client.post_issue_comment.assert_awaited_once_with(
+            "owner", "repo", 425, "@dependabot rebase"
+        )
+
+    @pytest.mark.asyncio
+    async def test_skips_when_rebase_comment_exists(self) -> None:
+        """An existing rebase request is treated as in-flight (no dup)."""
+        mgr, client = make_merge_manager()
+        client.get = AsyncMock(return_value=[{"body": "@dependabot rebase"}])
+        client.post_issue_comment = AsyncMock()
+        pr = _make_pr()
+
+        ok = await mgr._request_dependabot_rebase(pr, "owner", "repo")
+
+        assert ok is True
+        client.post_issue_comment.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_posts_when_comment_listing_fails(self) -> None:
+        """If we cannot list comments, post anyway (dup is harmless)."""
+        mgr, client = make_merge_manager()
+        client.get = AsyncMock(side_effect=RuntimeError("boom"))
+        client.post_issue_comment = AsyncMock()
+        pr = _make_pr()
+
+        ok = await mgr._request_dependabot_rebase(pr, "owner", "repo")
+
+        assert ok is True
+        client.post_issue_comment.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_returns_false_when_post_fails(self) -> None:
+        mgr, client = make_merge_manager()
+        client.get = AsyncMock(return_value=[])
+        client.post_issue_comment = AsyncMock(side_effect=RuntimeError("nope"))
+        pr = _make_pr()
+
+        ok = await mgr._request_dependabot_rebase(pr, "owner", "repo")
+
+        assert ok is False
+
+    @pytest.mark.asyncio
+    async def test_returns_false_without_client(self) -> None:
+        mgr, _client = make_merge_manager()
+        mgr._github_client = None
+
+        ok = await mgr._request_dependabot_rebase(_make_pr(), "o", "r")
+
+        assert ok is False
+
+
+class TestHandleMergeConflict:
+    """Outcome tests for ``_handle_merge_conflict``."""
+
+    @pytest.mark.asyncio
+    async def test_non_dependabot_fails_fast(self) -> None:
+        """A non-dependabot conflict is reported and failed without a wait."""
+        mgr, _client = make_merge_manager()
+        pr = _make_pr(author="someuser")
+        with (
+            patch.object(
+                mgr, "_request_dependabot_rebase", new_callable=AsyncMock
+            ) as mock_rebase,
+            patch.object(
+                mgr, "_wait_for_auto_merge", new_callable=AsyncMock
+            ) as mock_wait,
+            patch("dependamerge.merge_manager.log_and_print") as mock_log,
+        ):
+            result = await mgr._handle_merge_conflict(
+                pr, "lfreleng-actions", "lftools-uv", _result(pr)
+            )
+
+        assert result.status == MergeStatus.FAILED
+        assert result.error == "merge conflicts"
+        mock_rebase.assert_not_called()
+        mock_wait.assert_not_called()
+        # The specific 🔀 cause line is emitted.
+        assert any(
+            "🔀 Merge conflict" in str(call.args[2]) for call in mock_log.call_args_list
+        )
+
+    @pytest.mark.asyncio
+    async def test_rebase_request_failure_fails(self) -> None:
+        mgr, _client = make_merge_manager()
+        pr = _make_pr()
+        with (
+            patch.object(
+                mgr,
+                "_request_dependabot_rebase",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+            patch.object(
+                mgr, "_wait_for_auto_merge", new_callable=AsyncMock
+            ) as mock_wait,
+        ):
+            result = await mgr._handle_merge_conflict(
+                pr, "lfreleng-actions", "lftools-uv", _result(pr)
+            )
+
+        assert result.status == MergeStatus.FAILED
+        assert result.error == "merge conflicts"
+        mock_wait.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_rebase_clears_and_merges(self) -> None:
+        """Rebase lands (phase 1) then auto-merge closes the PR (phase 2)."""
+        mgr, _client = make_merge_manager()
+        pr = _make_pr()
+        calls = {"n": 0}
+
+        async def fake_wait(pr_info, owner, repo, **kwargs):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                # Dependabot rebased: conflict cleared, now waiting checks.
+                pr_info.mergeable_state = "blocked"
+                return (False, False)
+            # Phase 2: auto-merge fires and the PR closes merged.
+            pr_info.state = "closed"
+            return (True, True)
+
+        with (
+            patch.object(
+                mgr,
+                "_request_dependabot_rebase",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
+            patch.object(mgr, "_wait_for_auto_merge", new=fake_wait),
+            patch.object(
+                mgr, "_approve_pr", new_callable=AsyncMock, return_value=True
+            ) as mock_approve,
+            patch.object(
+                mgr,
+                "_enable_auto_merge_for_pr",
+                new_callable=AsyncMock,
+                return_value=True,
+            ) as mock_enable,
+        ):
+            result = await mgr._handle_merge_conflict(
+                pr, "lfreleng-actions", "lftools-uv", _result(pr)
+            )
+
+        assert result.status == MergeStatus.MERGED
+        # Approval happens only after the rebase cleared the conflict.
+        mock_approve.assert_awaited_once()
+        mock_enable.assert_awaited_once()
+        assert calls["n"] == 2
+
+    @pytest.mark.asyncio
+    async def test_still_dirty_at_timeout_fails(self) -> None:
+        """If the conflict never clears, fail with the conflict cause."""
+        mgr, _client = make_merge_manager()
+        pr = _make_pr()
+
+        async def fake_wait(pr_info, owner, repo, **kwargs):
+            # Phase 1 times out still dirty.
+            return (False, False)
+
+        with (
+            patch.object(
+                mgr,
+                "_request_dependabot_rebase",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
+            patch.object(mgr, "_wait_for_auto_merge", new=fake_wait),
+            patch.object(mgr, "_approve_pr", new_callable=AsyncMock) as mock_approve,
+        ):
+            result = await mgr._handle_merge_conflict(
+                pr, "lfreleng-actions", "lftools-uv", _result(pr)
+            )
+
+        assert result.status == MergeStatus.FAILED
+        assert result.error == "merge conflicts"
+        # Never approved a PR that stayed conflicted.
+        mock_approve.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_rebase_clears_but_checks_pending(self) -> None:
+        """Rebase lands but checks outlast the window -> auto-merge pending."""
+        mgr, _client = make_merge_manager()
+        pr = _make_pr()
+        calls = {"n": 0}
+
+        async def fake_wait(pr_info, owner, repo, **kwargs):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                pr_info.mergeable_state = "behind"
+                return (False, False)
+            # Phase 2 times out without closing (checks still running).
+            return (False, False)
+
+        with (
+            patch.object(
+                mgr,
+                "_request_dependabot_rebase",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
+            patch.object(mgr, "_wait_for_auto_merge", new=fake_wait),
+            patch.object(mgr, "_approve_pr", new_callable=AsyncMock, return_value=True),
+            patch.object(
+                mgr,
+                "_enable_auto_merge_for_pr",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
+        ):
+            result = await mgr._handle_merge_conflict(
+                pr, "lfreleng-actions", "lftools-uv", _result(pr)
+            )
+
+        assert result.status == MergeStatus.AUTO_MERGE_PENDING
+
+    @pytest.mark.asyncio
+    async def test_closed_without_merge_fails(self) -> None:
+        """A PR closed without merging during the wait is a failure."""
+        mgr, _client = make_merge_manager()
+        pr = _make_pr()
+
+        async def fake_wait(pr_info, owner, repo, **kwargs):
+            pr_info.state = "closed"
+            return (True, False)
+
+        with (
+            patch.object(
+                mgr,
+                "_request_dependabot_rebase",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
+            patch.object(mgr, "_wait_for_auto_merge", new=fake_wait),
+        ):
+            result = await mgr._handle_merge_conflict(
+                pr, "lfreleng-actions", "lftools-uv", _result(pr)
+            )
+
+        assert result.status == MergeStatus.FAILED
+        assert "closed without merging" in (result.error or "")
+
+
+class TestConflictRoutingFromMergeSinglePr:
+    """``_merge_single_pr`` routes ``dirty`` PRs to the conflict handler."""
+
+    @staticmethod
+    def _common_patches(mgr):
+        from dependamerge.github2gerrit_detector import (
+            GitHub2GerritDetectionResult,
+        )
+
+        return (
+            patch.object(
+                mgr,
+                "_detect_github2gerrit",
+                new_callable=AsyncMock,
+                return_value=GitHub2GerritDetectionResult(),
+            ),
+            patch.object(
+                mgr,
+                "_get_merge_method_for_repo",
+                new_callable=AsyncMock,
+                return_value="merge",
+            ),
+        )
+
+    @pytest.mark.asyncio
+    async def test_snapshot_dirty_routes_before_approval(self) -> None:
+        """A PR dirty at fetch goes to the handler without being approved."""
+        mgr, client = make_merge_manager()
+        pr = _make_pr(mergeable_state="dirty")
+        client.get = AsyncMock(return_value={"state": "open"})
+
+        p1, p2 = self._common_patches(mgr)
+        with (
+            p1,
+            p2,
+            patch.object(
+                mgr,
+                "_handle_merge_conflict",
+                new_callable=AsyncMock,
+            ) as mock_handler,
+            patch.object(mgr, "_approve_pr", new_callable=AsyncMock) as mock_approve,
+        ):
+            mock_handler.return_value = MergeResult(
+                pr_info=pr, status=MergeStatus.AUTO_MERGE_PENDING
+            )
+            await mgr._merge_single_pr(pr)
+
+        mock_handler.assert_awaited_once()
+        # The PR must not be approved before the rebase is requested.
+        mock_approve.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_dispatch_dirty_routes_to_handler(self) -> None:
+        """A PR that becomes dirty mid-batch is caught at dispatch."""
+        mgr, client = make_merge_manager(repo_scoped=True)
+        mgr._post_approval_delay = 0.0
+        # Snapshot clean -> passes early checks; refresh reveals dirty.
+        client.get = AsyncMock(
+            return_value={
+                "state": "open",
+                "mergeable": False,
+                "mergeable_state": "dirty",
+            }
+        )
+        pr = _make_pr(mergeable_state="clean")
+        pr.mergeable = True
+
+        p1, p2 = self._common_patches(mgr)
+        with (
+            p1,
+            p2,
+            patch.object(
+                mgr,
+                "_check_merge_requirements",
+                new_callable=AsyncMock,
+                return_value=(True, ""),
+            ),
+            patch.object(
+                mgr, "_approve_pr", new_callable=AsyncMock, return_value=False
+            ),
+            patch.object(
+                mgr, "_handle_merge_conflict", new_callable=AsyncMock
+            ) as mock_handler,
+            patch.object(
+                mgr, "_merge_pr_with_retry", new_callable=AsyncMock
+            ) as mock_merge,
+        ):
+            mock_handler.return_value = MergeResult(
+                pr_info=pr, status=MergeStatus.AUTO_MERGE_PENDING
+            )
+            await mgr._merge_single_pr(pr)
+
+        mock_handler.assert_awaited_once()
+        # The doomed merge call is skipped in favour of recovery.
+        mock_merge.assert_not_called()

--- a/tests/test_merge_conflict_handling.py
+++ b/tests/test_merge_conflict_handling.py
@@ -411,6 +411,44 @@ class TestHandleMergeConflict:
         assert "auto-merge unavailable" in (result.error or "")
         mock_merge.assert_not_called()
 
+    @pytest.mark.asyncio
+    async def test_approval_failure_after_rebase_is_reported(self) -> None:
+        """An approval error after the rebase is reported locally, not bubbled."""
+        mgr, _client = make_merge_manager()
+        pr = _make_pr()
+
+        async def fake_wait(pr_info, owner, repo, **kwargs):
+            # Rebase cleared the conflict (now blocked, awaiting review).
+            pr_info.mergeable_state = "blocked"
+            return (False, False)
+
+        with (
+            patch.object(
+                mgr,
+                "_request_dependabot_rebase",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
+            patch.object(mgr, "_wait_for_auto_merge", new=fake_wait),
+            patch.object(
+                mgr,
+                "_approve_pr",
+                new_callable=AsyncMock,
+                side_effect=RuntimeError("403 Forbidden"),
+            ),
+            patch.object(
+                mgr, "_enable_auto_merge_for_pr", new_callable=AsyncMock
+            ) as mock_enable,
+        ):
+            result = await mgr._handle_merge_conflict(
+                pr, "lfreleng-actions", "lftools-uv", _result(pr)
+            )
+
+        assert result.status == MergeStatus.FAILED
+        assert "approval failed" in (result.error or "")
+        # The failure is handled before auto-merge is even attempted.
+        mock_enable.assert_not_called()
+
 
 class TestConflictRoutingFromMergeSinglePr:
     """``_merge_single_pr`` routes ``dirty`` PRs to the conflict handler."""

--- a/tests/test_mergeability_refresh.py
+++ b/tests/test_mergeability_refresh.py
@@ -26,7 +26,7 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 from dependamerge.github2gerrit_detector import GitHub2GerritDetectionResult
-from dependamerge.merge_manager import MergeStatus
+from dependamerge.merge_manager import MergeResult, MergeStatus
 from dependamerge.models import PullRequestInfo
 from tests.conftest import make_merge_manager
 
@@ -154,6 +154,65 @@ class TestRefreshPrMergeability:
         client.get.assert_awaited_once()
 
     @pytest.mark.asyncio
+    async def test_timeout_normalizes_empty_state_to_unknown(self, monkeypatch) -> None:
+        """An empty ``mergeable_state`` at timeout is recorded as ``unknown``.
+
+        GitHub signals "still computing" as either ``"unknown"`` or an
+        empty string; both must overwrite a stale concrete snapshot so
+        downstream reporting never shows a misleading ``clean`` once the
+        recompute window times out.
+        """
+        monkeypatch.setattr(
+            "dependamerge.merge_manager.MERGEABILITY_REFRESH_TIMEOUT_SECONDS",
+            0.0,
+        )
+        mgr, client = make_merge_manager()
+        client.get = AsyncMock(
+            return_value={
+                "state": "open",
+                "mergeable": None,
+                "mergeable_state": "",
+            }
+        )
+        pr = _make_pr(mergeable=True, mergeable_state="clean")
+
+        await mgr._refresh_pr_mergeability(pr, "owner", "repo")
+
+        # The empty string is normalised so the stale ``clean`` snapshot
+        # is not left in place.
+        assert pr.mergeable_state == "unknown"
+        client.get.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_timeout_normalizes_null_state_to_unknown(self, monkeypatch) -> None:
+        """A null ``mergeable_state`` at timeout is recorded as ``unknown``.
+
+        ``mergeable_state is None`` is a still-computing signal too; if
+        GitHub returns it for the whole refresh window the stale
+        concrete snapshot must still be overwritten with an honest
+        ``unknown`` rather than left as a misleading ``clean``.
+        """
+        monkeypatch.setattr(
+            "dependamerge.merge_manager.MERGEABILITY_REFRESH_TIMEOUT_SECONDS",
+            0.0,
+        )
+        mgr, client = make_merge_manager()
+        client.get = AsyncMock(
+            return_value={
+                "state": "open",
+                "mergeable": None,
+                "mergeable_state": None,
+            }
+        )
+        pr = _make_pr(mergeable=True, mergeable_state="clean")
+
+        await mgr._refresh_pr_mergeability(pr, "owner", "repo")
+
+        # A null state at timeout is normalised, not dropped.
+        assert pr.mergeable_state == "unknown"
+        client.get.assert_awaited_once()
+
+    @pytest.mark.asyncio
     async def test_closed_state_short_circuits(self) -> None:
         """A closed PR is recorded and returns without polling."""
         mgr, client = make_merge_manager()
@@ -206,8 +265,124 @@ class TestRefreshPrMergeability:
         assert pr.mergeable_state == "clean"
 
 
-class TestDispatchRefreshSkipsConflict:
-    """``_merge_single_pr`` dispatch-time refresh + dirty-skip behaviour."""
+class TestIsPrDirtyNow:
+    """Direct unit tests for the pre-dispatch ``_is_pr_dirty_now`` peek."""
+
+    @pytest.mark.asyncio
+    async def test_concrete_dirty_returns_true_and_records_state(self) -> None:
+        """A concrete ``dirty`` returns True and records current state."""
+        mgr, client = make_merge_manager()
+        client.get = AsyncMock(
+            return_value={
+                "state": "open",
+                "mergeable": False,
+                "mergeable_state": "dirty",
+                "head": {"sha": "conflictsha"},
+            }
+        )
+        pr = _make_pr(mergeable=True, mergeable_state="clean")
+
+        assert await mgr._is_pr_dirty_now(pr, "owner", "repo") is True
+        assert pr.mergeable_state == "dirty"
+        assert pr.mergeable is False
+        assert pr.head_sha == "conflictsha"
+        client.get.assert_awaited_once_with("/repos/owner/repo/pulls/425")
+
+    @pytest.mark.asyncio
+    async def test_concrete_clean_returns_false_without_mutating(self) -> None:
+        """A concrete ``clean`` peek leaves the snapshot untouched."""
+        mgr, client = make_merge_manager()
+        client.get = AsyncMock(
+            return_value={
+                "state": "open",
+                "mergeable": True,
+                "mergeable_state": "clean",
+            }
+        )
+        pr = _make_pr(mergeable=True, mergeable_state="clean")
+
+        assert await mgr._is_pr_dirty_now(pr, "owner", "repo") is False
+        assert pr.mergeable_state == "clean"
+
+    @pytest.mark.asyncio
+    async def test_still_computing_returns_false_without_mutating(self) -> None:
+        """A transient ``unknown`` must not overwrite a concrete ``clean``.
+
+        The peek is a single GET with no recompute poll; when GitHub is
+        still computing it returns False and preserves the prior
+        snapshot so the transient-405-on-``clean`` retry path is kept.
+        """
+        mgr, client = make_merge_manager()
+        client.get = AsyncMock(
+            return_value={
+                "state": "open",
+                "mergeable": None,
+                "mergeable_state": "unknown",
+            }
+        )
+        pr = _make_pr(mergeable=True, mergeable_state="clean")
+
+        assert await mgr._is_pr_dirty_now(pr, "owner", "repo") is False
+        assert pr.mergeable_state == "clean"
+        assert pr.mergeable is True
+        client.get.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_closed_pr_returns_false(self) -> None:
+        """A closed PR is not a conflict; defer to the closed-PR path."""
+        mgr, client = make_merge_manager()
+        client.get = AsyncMock(
+            return_value={
+                "state": "closed",
+                "mergeable": None,
+                "mergeable_state": "dirty",
+            }
+        )
+        pr = _make_pr(mergeable=True, mergeable_state="clean")
+
+        assert await mgr._is_pr_dirty_now(pr, "owner", "repo") is False
+        assert pr.mergeable_state == "clean"
+
+    @pytest.mark.asyncio
+    async def test_api_error_returns_false_without_mutating(self) -> None:
+        """An errored peek degrades to False and preserves the snapshot."""
+        mgr, client = make_merge_manager()
+        client.get = AsyncMock(side_effect=RuntimeError("boom"))
+        pr = _make_pr(mergeable=True, mergeable_state="clean")
+
+        assert await mgr._is_pr_dirty_now(pr, "owner", "repo") is False
+        assert pr.mergeable_state == "clean"
+
+    @pytest.mark.asyncio
+    async def test_non_dict_payload_returns_false(self) -> None:
+        """A non-dict payload degrades to False rather than crashing."""
+        mgr, client = make_merge_manager()
+        client.get = AsyncMock(return_value=["unexpected"])
+        pr = _make_pr(mergeable=True, mergeable_state="clean")
+
+        assert await mgr._is_pr_dirty_now(pr, "owner", "repo") is False
+        assert pr.mergeable_state == "clean"
+
+    @pytest.mark.asyncio
+    async def test_no_client_returns_false(self) -> None:
+        """With no GitHub client the peek is a no-op returning False."""
+        mgr, _client = make_merge_manager()
+        mgr._github_client = None
+        pr = _make_pr(mergeable=True, mergeable_state="clean")
+
+        assert await mgr._is_pr_dirty_now(pr, "owner", "repo") is False
+        assert pr.mergeable_state == "clean"
+
+
+class TestDispatchMergeabilityRouting:
+    """``_merge_single_pr`` pre-dispatch peek + post-failure refresh.
+
+    A repo-scoped run peeks live merge state inside the dispatch lock
+    (a single GET) so a sibling-conflicted PR is routed to conflict
+    recovery *without* a doomed merge attempt; a PR that turns dirty
+    during the merge window is still caught by the off-lock
+    post-failure refresh.
+    """
 
     @staticmethod
     def _patches(mgr):
@@ -237,12 +412,17 @@ class TestDispatchRefreshSkipsConflict:
         )
 
     @pytest.mark.asyncio
-    async def test_fresh_conflict_skips_merge_and_reports_conflict(self) -> None:
-        """A conflict revealed at dispatch skips the doomed merge call."""
+    async def test_predispatch_dirty_routes_without_merge_attempt(self) -> None:
+        """A sibling conflict is caught pre-dispatch, skipping the merge.
+
+        The pre-dispatch peek reveals the ``dirty`` state, so we route
+        straight to conflict recovery without ever calling
+        ``_merge_pr_with_retry`` (which would 405 and churn its retry
+        loop against the stale ``clean`` snapshot).
+        """
         mgr, client = make_merge_manager(repo_scoped=True)
         mgr._post_approval_delay = 0.0
-        # Snapshot says clean (passes early eligibility); the live
-        # refresh at dispatch reveals the sibling-merge conflict.
+        # The pre-dispatch peek reveals the sibling-merge conflict.
         client.get = AsyncMock(
             return_value={
                 "state": "open",
@@ -260,27 +440,70 @@ class TestDispatchRefreshSkipsConflict:
             p3,
             p4,
             patch.object(
-                mgr, "_merge_pr_with_retry", new_callable=AsyncMock
+                mgr,
+                "_merge_pr_with_retry",
+                new_callable=AsyncMock,
+                return_value=False,
             ) as mock_merge,
         ):
             result = await mgr._merge_single_pr(pr)
 
+        # The merge is never attempted; the conflict is handled directly
+        # (renovate is non-dependabot, so it fails as a plain conflict).
+        mock_merge.assert_not_awaited()
         assert result.status == MergeStatus.FAILED
-        # The doomed merge API call must be skipped entirely.
-        mock_merge.assert_not_called()
+        assert result.error == "merge conflicts"
 
     @pytest.mark.asyncio
-    async def test_clean_after_refresh_proceeds_to_merge(self) -> None:
-        """When the refresh confirms ``clean`` the merge proceeds normally."""
-        mgr, client = make_merge_manager(repo_scoped=True)
+    async def test_during_window_dirty_routes_via_post_failure_refresh(self) -> None:
+        """A PR that turns dirty mid-merge is caught after the failure.
+
+        The pre-dispatch peek sees a still-clean PR (returns False), the
+        merge is attempted and fails, and only then does the off-lock
+        post-failure refresh reveal the fresh conflict and route it.
+        """
+        mgr, _client = make_merge_manager(repo_scoped=True)
         mgr._post_approval_delay = 0.0
-        client.get = AsyncMock(
-            return_value={
-                "state": "open",
-                "mergeable": True,
-                "mergeable_state": "clean",
-            }
-        )
+        pr = _make_pr(mergeable=True, mergeable_state="clean")
+
+        async def _reveal_dirty(pr_info, _owner, _repo):
+            pr_info.mergeable_state = "dirty"
+
+        p1, p2, p3, p4 = self._patches(mgr)
+        with (
+            p1,
+            p2,
+            p3,
+            p4,
+            patch.object(
+                mgr, "_is_pr_dirty_now", new_callable=AsyncMock, return_value=False
+            ) as mock_peek,
+            patch.object(
+                mgr,
+                "_merge_pr_with_retry",
+                new_callable=AsyncMock,
+                return_value=False,
+            ) as mock_merge,
+            patch.object(
+                mgr,
+                "_refresh_pr_mergeability",
+                new_callable=AsyncMock,
+                side_effect=_reveal_dirty,
+            ) as mock_refresh,
+        ):
+            result = await mgr._merge_single_pr(pr)
+
+        mock_peek.assert_awaited_once()
+        mock_merge.assert_awaited_once()
+        mock_refresh.assert_awaited_once()
+        assert result.status == MergeStatus.FAILED
+        assert result.error == "merge conflicts"
+
+    @pytest.mark.asyncio
+    async def test_successful_merge_peeks_but_skips_poll_refresh(self) -> None:
+        """A clean PR pays only the cheap peek, never the poll refresh."""
+        mgr, _client = make_merge_manager(repo_scoped=True)
+        mgr._post_approval_delay = 0.0
         pr = _make_pr(mergeable=True, mergeable_state="clean")
 
         p1, p2, p3, p4 = self._patches(mgr)
@@ -289,6 +512,12 @@ class TestDispatchRefreshSkipsConflict:
             p2,
             p3,
             p4,
+            patch.object(
+                mgr, "_is_pr_dirty_now", new_callable=AsyncMock, return_value=False
+            ) as mock_peek,
+            patch.object(
+                mgr, "_refresh_pr_mergeability", new_callable=AsyncMock
+            ) as mock_refresh,
             patch.object(
                 mgr,
                 "_merge_pr_with_retry",
@@ -300,11 +529,15 @@ class TestDispatchRefreshSkipsConflict:
 
         assert result.status == MergeStatus.MERGED
         mock_merge.assert_awaited_once()
+        # The bounded single-GET peek runs; the heavier poll refresh
+        # (reserved for the post-failure path) does not.
+        mock_peek.assert_awaited_once()
+        mock_refresh.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_org_scoped_run_does_not_refresh(self) -> None:
-        """Outside repo-scoped mode the dispatch-time refresh is skipped."""
-        mgr, client = make_merge_manager(repo_scoped=False)
+    async def test_org_scope_skips_peek_and_refresh(self) -> None:
+        """Outside repo scope neither the peek nor the refresh runs."""
+        mgr, _client = make_merge_manager(repo_scoped=False)
         mgr._post_approval_delay = 0.0
         pr = _make_pr(mergeable=True, mergeable_state="clean")
 
@@ -315,16 +548,29 @@ class TestDispatchRefreshSkipsConflict:
             p3,
             p4,
             patch.object(
+                mgr, "_is_pr_dirty_now", new_callable=AsyncMock, return_value=False
+            ) as mock_peek,
+            patch.object(
                 mgr, "_refresh_pr_mergeability", new_callable=AsyncMock
             ) as mock_refresh,
             patch.object(
                 mgr,
                 "_merge_pr_with_retry",
                 new_callable=AsyncMock,
-                return_value=True,
+                return_value=False,
             ),
+            patch.object(
+                mgr, "_is_pr_already_merged", new_callable=AsyncMock, return_value=False
+            ),
+            patch.object(
+                mgr, "_report_merge_failure", new_callable=AsyncMock
+            ) as mock_report,
         ):
-            result = await mgr._merge_single_pr(pr)
+            mock_report.return_value = MergeResult(
+                pr_info=pr, status=MergeStatus.FAILED
+            )
+            await mgr._merge_single_pr(pr)
 
-        assert result.status == MergeStatus.MERGED
+        # The repo_scoped gate means org runs never peek or refresh.
+        mock_peek.assert_not_called()
         mock_refresh.assert_not_called()

--- a/tests/test_mergeability_refresh.py
+++ b/tests/test_mergeability_refresh.py
@@ -1,0 +1,324 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 The Linux Foundation
+
+"""Tests for pre-dispatch mergeability refresh in ``AsyncMergeManager``.
+
+In a repo-scoped batch the PR list is fetched once up front, so a
+worker can act on a stale snapshot: merging one PR may make a sibling
+PR ``dirty`` (a ``uv.lock`` / workflow-pin conflict) before its own
+merge is dispatched.  ``_refresh_pr_mergeability`` re-reads the PR's
+live state immediately before the merge dispatch (inside the per-repo
+dispatch lock, the only point ordered after any sibling merge) so the
+conflict is detected and reported accurately instead of producing a
+misleading "Failed to merge after all retry attempts".
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from dependamerge.github2gerrit_detector import GitHub2GerritDetectionResult
+from dependamerge.merge_manager import MergeStatus
+from dependamerge.models import PullRequestInfo
+from tests.conftest import make_merge_manager
+
+
+def _make_pr(
+    *,
+    state: str = "open",
+    mergeable: bool | None = True,
+    mergeable_state: str | None = "clean",
+    author: str = "renovate[bot]",
+    number: int = 425,
+    repo: str = "lfreleng-actions/lftools-uv",
+) -> PullRequestInfo:
+    """Build a minimal ``PullRequestInfo`` for refresh tests."""
+    return PullRequestInfo(
+        number=number,
+        node_id="PR_kwDOTestNode",
+        title="Chore: Bump safety from 3.7.0 to 3.8.1",
+        body="bump",
+        author=author,
+        head_sha="cafe" * 10,
+        base_branch="main",
+        head_branch="dependabot/uv/safety-3.8.1",
+        state=state,
+        mergeable=mergeable,
+        mergeable_state=mergeable_state,
+        behind_by=None,
+        files_changed=[],
+        repository_full_name=repo,
+        html_url=f"https://github.com/{repo}/pull/{number}",
+        reviews=[],
+        review_comments=[],
+    )
+
+
+class TestRefreshPrMergeability:
+    """Direct unit tests for ``_refresh_pr_mergeability``."""
+
+    @pytest.mark.asyncio
+    async def test_concrete_dirty_updates_in_one_get(self) -> None:
+        """A concrete ``dirty`` state is recorded with a single GET."""
+        mgr, client = make_merge_manager()
+        client.get = AsyncMock(
+            return_value={
+                "state": "open",
+                "mergeable": False,
+                "mergeable_state": "dirty",
+                "head": {"sha": "newsha123"},
+            }
+        )
+        pr = _make_pr(mergeable=True, mergeable_state="clean")
+
+        await mgr._refresh_pr_mergeability(pr, "owner", "repo")
+
+        assert pr.mergeable_state == "dirty"
+        assert pr.mergeable is False
+        assert pr.head_sha == "newsha123"
+        client.get.assert_awaited_once_with("/repos/owner/repo/pulls/425")
+
+    @pytest.mark.asyncio
+    async def test_concrete_clean_updates_in_one_get(self) -> None:
+        """A concrete ``clean`` state is recorded with a single GET."""
+        mgr, client = make_merge_manager()
+        client.get = AsyncMock(
+            return_value={
+                "state": "open",
+                "mergeable": True,
+                "mergeable_state": "clean",
+            }
+        )
+        pr = _make_pr(mergeable=None, mergeable_state="unknown")
+
+        await mgr._refresh_pr_mergeability(pr, "owner", "repo")
+
+        assert pr.mergeable_state == "clean"
+        assert pr.mergeable is True
+        client.get.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_polls_while_computing_then_settles(self) -> None:
+        """While GitHub recomputes (``mergeable=null``) we poll until concrete."""
+        mgr, client = make_merge_manager()
+        client.get = AsyncMock(
+            side_effect=[
+                # GitHub is still recomputing after the base moved.
+                {"state": "open", "mergeable": None, "mergeable_state": "unknown"},
+                # Settled: the sibling merge created a conflict.
+                {"state": "open", "mergeable": False, "mergeable_state": "dirty"},
+            ]
+        )
+        pr = _make_pr(mergeable=True, mergeable_state="clean")
+
+        with patch(
+            "dependamerge.merge_manager.asyncio.sleep", new_callable=AsyncMock
+        ) as mock_sleep:
+            await mgr._refresh_pr_mergeability(pr, "owner", "repo")
+
+        assert pr.mergeable_state == "dirty"
+        assert client.get.await_count == 2
+        mock_sleep.assert_awaited()
+
+    @pytest.mark.asyncio
+    async def test_timeout_records_latest_known_state(self, monkeypatch) -> None:
+        """When GitHub never settles, record its latest answer and return."""
+        # Zero timeout: the deadline passes on the first poll iteration.
+        monkeypatch.setattr(
+            "dependamerge.merge_manager.MERGEABILITY_REFRESH_TIMEOUT_SECONDS",
+            0.0,
+        )
+        mgr, client = make_merge_manager()
+        client.get = AsyncMock(
+            return_value={
+                "state": "open",
+                "mergeable": None,
+                "mergeable_state": "unknown",
+            }
+        )
+        pr = _make_pr(mergeable=True, mergeable_state="clean")
+
+        await mgr._refresh_pr_mergeability(pr, "owner", "repo")
+
+        # The latest concrete-ish value GitHub gave us is recorded so
+        # downstream logic does not act on the older snapshot.
+        assert pr.mergeable_state == "unknown"
+        client.get.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_closed_state_short_circuits(self) -> None:
+        """A closed PR is recorded and returns without polling."""
+        mgr, client = make_merge_manager()
+        client.get = AsyncMock(
+            return_value={
+                "state": "closed",
+                "mergeable": None,
+                "mergeable_state": "unknown",
+            }
+        )
+        pr = _make_pr(state="open")
+
+        await mgr._refresh_pr_mergeability(pr, "owner", "repo")
+
+        assert pr.state == "closed"
+        client.get.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_no_client_is_noop(self) -> None:
+        """With no GitHub client the snapshot is left untouched."""
+        mgr, _client = make_merge_manager()
+        mgr._github_client = None
+        pr = _make_pr(mergeable=True, mergeable_state="clean")
+
+        await mgr._refresh_pr_mergeability(pr, "owner", "repo")
+
+        assert pr.mergeable_state == "clean"
+
+    @pytest.mark.asyncio
+    async def test_api_error_leaves_snapshot_untouched(self) -> None:
+        """A failed refresh must not blank out the existing snapshot."""
+        mgr, client = make_merge_manager()
+        client.get = AsyncMock(side_effect=RuntimeError("boom"))
+        pr = _make_pr(mergeable=True, mergeable_state="clean")
+
+        await mgr._refresh_pr_mergeability(pr, "owner", "repo")
+
+        assert pr.mergeable_state == "clean"
+        assert pr.mergeable is True
+
+    @pytest.mark.asyncio
+    async def test_non_dict_payload_is_ignored(self) -> None:
+        """A non-dict payload degrades to a no-op rather than crashing."""
+        mgr, client = make_merge_manager()
+        client.get = AsyncMock(return_value=["unexpected"])
+        pr = _make_pr(mergeable=True, mergeable_state="clean")
+
+        await mgr._refresh_pr_mergeability(pr, "owner", "repo")
+
+        assert pr.mergeable_state == "clean"
+
+
+class TestDispatchRefreshSkipsConflict:
+    """``_merge_single_pr`` dispatch-time refresh + dirty-skip behaviour."""
+
+    @staticmethod
+    def _patches(mgr):
+        """Patch the manager methods that run before the dispatch lock."""
+        return (
+            patch.object(
+                mgr,
+                "_detect_github2gerrit",
+                new_callable=AsyncMock,
+                return_value=GitHub2GerritDetectionResult(),
+            ),
+            patch.object(
+                mgr,
+                "_get_merge_method_for_repo",
+                new_callable=AsyncMock,
+                return_value="merge",
+            ),
+            patch.object(
+                mgr,
+                "_check_merge_requirements",
+                new_callable=AsyncMock,
+                return_value=(True, ""),
+            ),
+            patch.object(
+                mgr, "_approve_pr", new_callable=AsyncMock, return_value=False
+            ),
+        )
+
+    @pytest.mark.asyncio
+    async def test_fresh_conflict_skips_merge_and_reports_conflict(self) -> None:
+        """A conflict revealed at dispatch skips the doomed merge call."""
+        mgr, client = make_merge_manager(repo_scoped=True)
+        mgr._post_approval_delay = 0.0
+        # Snapshot says clean (passes early eligibility); the live
+        # refresh at dispatch reveals the sibling-merge conflict.
+        client.get = AsyncMock(
+            return_value={
+                "state": "open",
+                "mergeable": False,
+                "mergeable_state": "dirty",
+                "head": {"sha": "conflictsha"},
+            }
+        )
+        pr = _make_pr(mergeable=True, mergeable_state="clean")
+
+        p1, p2, p3, p4 = self._patches(mgr)
+        with (
+            p1,
+            p2,
+            p3,
+            p4,
+            patch.object(
+                mgr, "_merge_pr_with_retry", new_callable=AsyncMock
+            ) as mock_merge,
+        ):
+            result = await mgr._merge_single_pr(pr)
+
+        assert result.status == MergeStatus.FAILED
+        # The doomed merge API call must be skipped entirely.
+        mock_merge.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_clean_after_refresh_proceeds_to_merge(self) -> None:
+        """When the refresh confirms ``clean`` the merge proceeds normally."""
+        mgr, client = make_merge_manager(repo_scoped=True)
+        mgr._post_approval_delay = 0.0
+        client.get = AsyncMock(
+            return_value={
+                "state": "open",
+                "mergeable": True,
+                "mergeable_state": "clean",
+            }
+        )
+        pr = _make_pr(mergeable=True, mergeable_state="clean")
+
+        p1, p2, p3, p4 = self._patches(mgr)
+        with (
+            p1,
+            p2,
+            p3,
+            p4,
+            patch.object(
+                mgr,
+                "_merge_pr_with_retry",
+                new_callable=AsyncMock,
+                return_value=True,
+            ) as mock_merge,
+        ):
+            result = await mgr._merge_single_pr(pr)
+
+        assert result.status == MergeStatus.MERGED
+        mock_merge.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_org_scoped_run_does_not_refresh(self) -> None:
+        """Outside repo-scoped mode the dispatch-time refresh is skipped."""
+        mgr, client = make_merge_manager(repo_scoped=False)
+        mgr._post_approval_delay = 0.0
+        pr = _make_pr(mergeable=True, mergeable_state="clean")
+
+        p1, p2, p3, p4 = self._patches(mgr)
+        with (
+            p1,
+            p2,
+            p3,
+            p4,
+            patch.object(
+                mgr, "_refresh_pr_mergeability", new_callable=AsyncMock
+            ) as mock_refresh,
+            patch.object(
+                mgr,
+                "_merge_pr_with_retry",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
+        ):
+            result = await mgr._merge_single_pr(pr)
+
+        assert result.status == MergeStatus.MERGED
+        mock_refresh.assert_not_called()

--- a/tests/test_mergeability_refresh.py
+++ b/tests/test_mergeability_refresh.py
@@ -1,16 +1,22 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: 2026 The Linux Foundation
 
-"""Tests for pre-dispatch mergeability refresh in ``AsyncMergeManager``.
+"""Tests for repo-scoped mergeability conflict detection in ``AsyncMergeManager``.
 
 In a repo-scoped batch the PR list is fetched once up front, so a
 worker can act on a stale snapshot: merging one PR may make a sibling
 PR ``dirty`` (a ``uv.lock`` / workflow-pin conflict) before its own
-merge is dispatched.  ``_refresh_pr_mergeability`` re-reads the PR's
-live state immediately before the merge dispatch (inside the per-repo
-dispatch lock, the only point ordered after any sibling merge) so the
-conflict is detected and reported accurately instead of producing a
-misleading "Failed to merge after all retry attempts".
+merge is dispatched.  Two complementary checks catch this:
+
+* ``_is_pr_dirty_now`` is the **pre-dispatch** check — a single GET
+  run *inside* the per-repo dispatch lock (the only point ordered
+  after any sibling merge), immediately before the merge dispatch, so
+  a freshly-conflicted PR skips the doomed merge entirely.
+* ``_refresh_pr_mergeability`` is the **post-failure** check — it
+  polls GitHub's recompute window and therefore runs only *after* a
+  failed merge attempt and *off* the dispatch lock, catching a PR that
+  turned ``dirty`` during our own merge window instead of producing a
+  misleading "Failed to merge after all retry attempts".
 """
 
 from __future__ import annotations

--- a/tests/test_output_utils.py
+++ b/tests/test_output_utils.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import io
 import logging
 from unittest.mock import MagicMock, patch
 
@@ -24,8 +25,9 @@ class TestLogAndPrint:
         log_and_print(logger, console, "Test message", level="info")
 
         # Unstyled output now goes through console.print so it
-        # coordinates with any active Rich Live display.
-        console.print.assert_called_once_with("Test message")
+        # coordinates with any active Rich Live display.  markup=False
+        # keeps bracketed reasons from being eaten by Rich.
+        console.print.assert_called_once_with("Test message", markup=False)
 
     def test_log_and_print_with_style(self):
         """Test logging and printing with Rich style."""
@@ -34,8 +36,10 @@ class TestLogAndPrint:
 
         log_and_print(logger, console, "Styled message", style="bold red", level="info")
 
-        # Verify console.print was called with style
-        console.print.assert_called_once_with("Styled message", style="bold red")
+        # Verify console.print was called with style (markup disabled)
+        console.print.assert_called_once_with(
+            "Styled message", style="bold red", markup=False
+        )
 
     def test_log_and_print_debug_level(self):
         """Test logging at DEBUG level."""
@@ -86,7 +90,7 @@ class TestLogAndPrint:
 
         log_and_print(logger, console, "✅ Success message", level="info")
 
-        console.print.assert_called_once_with("✅ Success message")
+        console.print.assert_called_once_with("✅ Success message", markup=False)
 
     def test_log_and_print_message_with_url(self):
         """Test handling of messages with URLs."""
@@ -96,7 +100,7 @@ class TestLogAndPrint:
 
         log_and_print(logger, console, message, level="info")
 
-        console.print.assert_called_once_with(message)
+        console.print.assert_called_once_with(message, markup=False)
 
     def test_log_and_print_multiline_message(self):
         """Test handling of multiline messages."""
@@ -106,7 +110,7 @@ class TestLogAndPrint:
 
         log_and_print(logger, console, message, level="info")
 
-        console.print.assert_called_once_with(message)
+        console.print.assert_called_once_with(message, markup=False)
 
     def test_log_and_print_empty_message(self):
         """Test handling of empty message."""
@@ -115,7 +119,7 @@ class TestLogAndPrint:
 
         log_and_print(logger, console, "", level="info")
 
-        console.print.assert_called_once_with("")
+        console.print.assert_called_once_with("", markup=False)
 
     def test_log_and_print_default_level(self):
         """Test that default log level is INFO when not specified."""
@@ -135,4 +139,29 @@ class TestLogAndPrint:
 
         log_and_print(logger, console, "Message", style=None, level="info")
 
-        console.print.assert_called_once_with("Message")
+        console.print.assert_called_once_with("Message", markup=False)
+
+
+class TestLogAndPrintMarkupDisabled:
+    """Bracketed reasons must survive (Rich markup must be disabled).
+
+    Regression test: with markup enabled (Rich's default), a reason
+    such as ``[branch protection rules prevent merge]`` is parsed as a
+    style tag and silently dropped, so the user sees no reason at all.
+    """
+
+    def test_bracketed_reason_is_rendered_literally(self):
+        logger = logging.getLogger("test_markup")
+        buffer = io.StringIO()
+        console = Console(file=buffer, force_terminal=False, width=200)
+
+        log_and_print(
+            logger,
+            console,
+            "❌ Failed: https://x/pull/1 [branch protection rules prevent merge]",
+            level="info",
+        )
+
+        out = buffer.getvalue()
+        # The whole bracketed reason must appear verbatim.
+        assert "[branch protection rules prevent merge]" in out

--- a/tests/test_precommit_ci_trigger.py
+++ b/tests/test_precommit_ci_trigger.py
@@ -212,6 +212,40 @@ class TestStuckPendingRetrigger:
         assert result is False
         client.post_issue_comment.assert_not_called()
 
+    @pytest.mark.asyncio
+    async def test_naive_timestamp_does_not_crash(self):
+        """A pending status with a tz-naive timestamp degrades, not crashes.
+
+        A timestamp lacking tz info parses to a naive datetime that
+        would raise ``TypeError`` when subtracted from the tz-aware
+        ``now``; the detector must fail closed (return ``False``)
+        rather than abort the merge run.
+        """
+        mgr, client = _make_manager()
+        pr = _make_pr_info()
+
+        client.get_required_status_checks = AsyncMock(
+            return_value=[{"context": "pre-commit.ci - pr"}]
+        )
+        client.get = AsyncMock(
+            return_value={
+                "statuses": [
+                    {
+                        "context": "pre-commit.ci - pr",
+                        "state": "pending",
+                        # No trailing "Z"/offset -> a naive datetime.
+                        "updated_at": "2026-06-08T16:00:00",
+                    }
+                ]
+            }
+        )
+        client.post_issue_comment = AsyncMock()
+
+        result = await mgr._trigger_stale_precommit_ci(pr)
+
+        assert result is False
+        client.post_issue_comment.assert_not_called()
+
 
 # ---------------------------------------------------------------------------
 # 3. Preview mode -> no comment (guarded at call-site, not inside method,

--- a/tests/test_precommit_ci_trigger.py
+++ b/tests/test_precommit_ci_trigger.py
@@ -15,6 +15,7 @@ Covers:
 - Ruleset branch filtering (_ruleset_applies_to_branch)
 """
 
+from datetime import datetime, timedelta, timezone
 from typing import Any
 from unittest.mock import AsyncMock, patch
 
@@ -129,6 +130,79 @@ class TestStatusAlreadyReported:
         client.get = AsyncMock(
             return_value={
                 "statuses": [{"context": "pre-commit.ci - pr", "state": state}]
+            }
+        )
+        client.post_issue_comment = AsyncMock()
+
+        result = await mgr._trigger_stale_precommit_ci(pr)
+
+        assert result is False
+        client.post_issue_comment.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# 2b. Status pending past the stuck threshold -> retrigger
+# ---------------------------------------------------------------------------
+class TestStuckPendingRetrigger:
+    """A pre-commit.ci status stuck in ``pending`` is retriggered."""
+
+    @staticmethod
+    def _iso(seconds_ago: float) -> str:
+        ts = datetime.now(timezone.utc) - timedelta(seconds=seconds_ago)
+        return ts.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    @pytest.mark.asyncio
+    async def test_retriggers_when_pending_past_threshold(self):
+        """Pending longer than the stuck threshold posts a fresh trigger."""
+        mgr, client = _make_manager()
+        pr = _make_pr_info()
+
+        client.get_required_status_checks = AsyncMock(
+            return_value=[{"context": "pre-commit.ci - pr"}]
+        )
+        stuck = {
+            "statuses": [
+                {
+                    "context": "pre-commit.ci - pr",
+                    "state": "pending",
+                    "updated_at": self._iso(600),
+                }
+            ]
+        }
+        success = {"statuses": [{"context": "pre-commit.ci - pr", "state": "success"}]}
+        client.get.side_effect = [
+            stuck,  # step 2: status check (stuck pending)
+            [],  # step 3: duplicate-comment check
+            success,  # first poll iteration
+        ]
+        client.post_issue_comment = AsyncMock()
+
+        with patch("asyncio.sleep", new_callable=AsyncMock):
+            result = await mgr._trigger_stale_precommit_ci(pr)
+
+        assert result is True
+        client.post_issue_comment.assert_called_once_with(
+            "owner", "repo", 42, "pre-commit.ci run"
+        )
+
+    @pytest.mark.asyncio
+    async def test_leaves_recent_pending_run_alone(self):
+        """A pending run still within its normal window is not retriggered."""
+        mgr, client = _make_manager()
+        pr = _make_pr_info()
+
+        client.get_required_status_checks = AsyncMock(
+            return_value=[{"context": "pre-commit.ci - pr"}]
+        )
+        client.get = AsyncMock(
+            return_value={
+                "statuses": [
+                    {
+                        "context": "pre-commit.ci - pr",
+                        "state": "pending",
+                        "updated_at": self._iso(30),
+                    }
+                ]
             }
         )
         client.post_issue_comment = AsyncMock()

--- a/tests/test_stuck_check_detection.py
+++ b/tests/test_stuck_check_detection.py
@@ -558,9 +558,11 @@ class TestReportMergeFailure:
         # The result error now surfaces the real reason so the
         # end-of-run summary is informative (was a generic message).
         assert out.error == "branch protection rules prevent merge"
+        # The inline line is now terse (URL only); the reason is
+        # reserved for the end-of-run summary to avoid duplication.
         printed = _printed(mock_console)
         assert "❌ Failed" in printed
-        assert "branch protection" in printed
+        assert "branch protection" not in printed
 
     @pytest.mark.asyncio
     async def test_dependabot_skips_stuck_detection(self) -> None:

--- a/tests/test_stuck_check_detection.py
+++ b/tests/test_stuck_check_detection.py
@@ -25,11 +25,15 @@ Covers:
 
 from datetime import datetime, timedelta, timezone
 from typing import Any
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from dependamerge.merge_manager import STUCK_CHECK_THRESHOLD_SECONDS
+from dependamerge.merge_manager import (
+    STUCK_CHECK_THRESHOLD_SECONDS,
+    MergeResult,
+    MergeStatus,
+)
 from dependamerge.models import PullRequestInfo
 
 
@@ -464,3 +468,111 @@ class TestDetectStuckDcoRobustness:
         assert is_stuck is False
         assert name is None
         assert age == 0.0
+
+
+def _printed(console_mock) -> str:
+    """Join the positional text of every ``console.print`` call."""
+    return " ".join(
+        str(call.args[0]) for call in console_mock.print.call_args_list if call.args
+    )
+
+
+class TestReportMergeFailure:
+    """Non-dependabot stuck-check reporting in ``_report_merge_failure``."""
+
+    @pytest.mark.asyncio
+    async def test_stuck_check_reports_and_arms_auto_merge(self) -> None:
+        """A stuck check yields the ⚠️ line and arms auto-merge (non-dirty)."""
+        mgr, _client = _make_manager()
+        pr = _make_pr_info(author="someuser", mergeable_state="blocked")
+        result = MergeResult(pr_info=pr, status=MergeStatus.PENDING)
+        with (
+            patch.object(
+                mgr,
+                "_detect_stuck_required_check",
+                new_callable=AsyncMock,
+                return_value=(True, "DCO", 120.0),
+            ),
+            patch.object(
+                mgr,
+                "_enable_auto_merge_for_pr",
+                new_callable=AsyncMock,
+                return_value=True,
+            ) as mock_enable,
+            patch.object(mgr, "_console") as mock_console,
+        ):
+            out = await mgr._report_merge_failure(pr, "o", "r", result, "blocked")
+
+        assert out.status == MergeStatus.FAILED
+        assert out.error == "stuck check: DCO"
+        mock_enable.assert_awaited_once()
+        printed = _printed(mock_console)
+        assert "⚠️ Stuck check" in printed
+        # The generic failure line is suppressed for stuck PRs.
+        assert "❌ Failed" not in printed
+
+    @pytest.mark.asyncio
+    async def test_stuck_check_when_dirty_does_not_arm_auto_merge(self) -> None:
+        """A dirty PR cannot take auto-merge, so it is not armed."""
+        mgr, _client = _make_manager()
+        pr = _make_pr_info(author="someuser", mergeable_state="dirty")
+        result = MergeResult(pr_info=pr, status=MergeStatus.PENDING)
+        with (
+            patch.object(
+                mgr,
+                "_detect_stuck_required_check",
+                new_callable=AsyncMock,
+                return_value=(True, "DCO", 120.0),
+            ),
+            patch.object(
+                mgr, "_enable_auto_merge_for_pr", new_callable=AsyncMock
+            ) as mock_enable,
+            patch.object(mgr, "_console"),
+        ):
+            out = await mgr._report_merge_failure(
+                pr, "o", "r", result, "merge conflicts"
+            )
+
+        assert out.status == MergeStatus.FAILED
+        mock_enable.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_no_stuck_check_emits_generic_failure(self) -> None:
+        mgr, _client = _make_manager()
+        pr = _make_pr_info(author="someuser")
+        result = MergeResult(pr_info=pr, status=MergeStatus.PENDING)
+        with (
+            patch.object(
+                mgr,
+                "_detect_stuck_required_check",
+                new_callable=AsyncMock,
+                return_value=(False, None, 0.0),
+            ),
+            patch.object(mgr, "_console") as mock_console,
+        ):
+            out = await mgr._report_merge_failure(
+                pr, "o", "r", result, "branch protection rules prevent merge"
+            )
+
+        assert out.status == MergeStatus.FAILED
+        assert out.error == "Failed to merge after all retry attempts"
+        printed = _printed(mock_console)
+        assert "❌ Failed" in printed
+        assert "branch protection" in printed
+
+    @pytest.mark.asyncio
+    async def test_dependabot_skips_stuck_detection(self) -> None:
+        """For dependabot the recreate path handles stuck checks, not here."""
+        mgr, _client = _make_manager()
+        pr = _make_pr_info(author="dependabot[bot]")
+        result = MergeResult(pr_info=pr, status=MergeStatus.PENDING)
+        with (
+            patch.object(
+                mgr, "_detect_stuck_required_check", new_callable=AsyncMock
+            ) as mock_detect,
+            patch.object(mgr, "_console"),
+        ):
+            out = await mgr._report_merge_failure(pr, "o", "r", result, "blocked")
+
+        assert out.status == MergeStatus.FAILED
+        mock_detect.assert_not_called()

--- a/tests/test_stuck_check_detection.py
+++ b/tests/test_stuck_check_detection.py
@@ -555,7 +555,9 @@ class TestReportMergeFailure:
             )
 
         assert out.status == MergeStatus.FAILED
-        assert out.error == "Failed to merge after all retry attempts"
+        # The result error now surfaces the real reason so the
+        # end-of-run summary is informative (was a generic message).
+        assert out.error == "branch protection rules prevent merge"
         printed = _printed(mock_console)
         assert "❌ Failed" in printed
         assert "branch protection" in printed

--- a/tests/test_stuck_check_detection.py
+++ b/tests/test_stuck_check_detection.py
@@ -356,6 +356,45 @@ class TestDetectStuckDcoCheckRuns:
         assert name is None
 
     @pytest.mark.asyncio
+    async def test_naive_pr_timestamp_does_not_crash(self) -> None:
+        """A tz-naive PR timestamp fails closed instead of crashing.
+
+        ``_parse_ts`` would otherwise return a naive datetime that
+        raises ``TypeError`` when subtracted from the tz-aware ``now``;
+        it must degrade to ``None`` so the detector returns
+        ``(False, None, 0.0)`` rather than aborting the merge run.
+        """
+        mgr, client = _make_manager()
+        now = datetime.now(timezone.utc)
+        old = now - timedelta(seconds=STUCK_CHECK_THRESHOLD_SECONDS + 30)
+        pr = _make_pr_info()
+
+        client.get = AsyncMock(
+            side_effect=_build_get_responder(
+                pr_response={
+                    # No trailing "Z"/offset -> naive datetimes.
+                    "created_at": "2026-06-08T16:00:00",
+                    "updated_at": "2026-06-08T16:00:00",
+                },
+                check_runs_response={
+                    "check_runs": [
+                        {
+                            "name": "DCO",
+                            "status": "in_progress",
+                            "started_at": _iso(old),
+                        }
+                    ],
+                },
+                status_response={"statuses": []},
+            )
+        )
+
+        is_stuck, name, age = await mgr._detect_stuck_required_check(pr)
+        assert is_stuck is False
+        assert name is None
+        assert age == 0.0
+
+    @pytest.mark.asyncio
     async def test_dco_slash_dco_name_variant_matches(self) -> None:
         """The ``dco/dco`` status-context naming is matched."""
         mgr, client = _make_manager()

--- a/tests/test_transient_merge_errors.py
+++ b/tests/test_transient_merge_errors.py
@@ -552,6 +552,27 @@ class TestMergeApiBodyCapture:
 
         assert result is True
 
+    @pytest.mark.asyncio
+    async def test_surfaces_body_when_state_refetch_fails(self):
+        """If the PR-state re-fetch fails, still surface GitHub's body."""
+        from dependamerge.github_async import GitHubAsync
+
+        api = GitHubAsync(token="t")
+        api.put = AsyncMock(
+            side_effect=_make_405_with_body(
+                "Required workflows 'Autolabeler' are not satisfied"
+            )
+        )
+        # The follow-up PR-state GET also fails.
+        api.get = AsyncMock(side_effect=RuntimeError("re-fetch failed"))
+
+        with pytest.raises(Exception) as excinfo:
+            await api.merge_pull_request("o", "r", 1, "merge")
+
+        msg = str(excinfo.value)
+        assert "GitHub:" in msg
+        assert "Required workflows" in msg
+
 
 class TestFailureSummarySurfacesGitHubDetail:
     """``_get_failure_summary`` surfaces the GitHub-supplied reason."""

--- a/tests/test_transient_merge_errors.py
+++ b/tests/test_transient_merge_errors.py
@@ -537,6 +537,11 @@ class TestMergeApiBodyCapture:
         assert "GitHub:" in msg
         assert "Required workflows" in msg
         assert "not satisfied" in msg
+        # The original status line MUST be preserved so
+        # _merge_pr_with_retry still classifies the 405 as terminal
+        # (and fails fast) instead of retrying it 3x.
+        assert "405" in msg
+        assert "Method Not Allowed" in msg
 
     @pytest.mark.asyncio
     async def test_merge_succeeded_despite_exception_returns_true(self):

--- a/tests/test_transient_merge_errors.py
+++ b/tests/test_transient_merge_errors.py
@@ -484,3 +484,91 @@ class TestPostApprovalDelayConfig:
                 merge_method="merge",
             )
             assert mgr._post_approval_delay == 3.0
+
+
+def _make_405_with_body(message: str) -> httpx.HTTPStatusError:
+    """Build a 405 ``HTTPStatusError`` carrying a JSON ``message`` body."""
+    request = httpx.Request("PUT", "https://api.github.com/repos/o/r/pulls/1/merge")
+    response = httpx.Response(
+        status_code=405, request=request, json={"message": message}
+    )
+    return httpx.HTTPStatusError(
+        "Client error '405 Method Not Allowed' for url "
+        "'https://api.github.com/repos/o/r/pulls/1/merge'",
+        request=request,
+        response=response,
+    )
+
+
+class TestMergeApiBodyCapture:
+    """``merge_pull_request`` must surface GitHub's response body.
+
+    GitHub puts the real reason (ruleset violations, "Required
+    workflows ... not satisfied") in the response *body*; the
+    ``HTTPStatusError`` text only carries the status line.  A bare
+    ``raise`` previously discarded the body — these tests lock in that
+    the body now reaches the raised error.
+    """
+
+    @pytest.mark.asyncio
+    async def test_merge_error_surfaces_response_body(self):
+        from dependamerge.github_async import GitHubAsync
+
+        api = GitHubAsync(token="t")
+        body_msg = (
+            "Repository rule violations found\n\n"
+            "Required workflows 'Autolabeler, Semantic Pull Request' "
+            "are not satisfied"
+        )
+        api.put = AsyncMock(side_effect=_make_405_with_body(body_msg))
+        api.get = AsyncMock(
+            return_value={
+                "state": "open",
+                "mergeable": True,
+                "mergeable_state": "blocked",
+                "merged": False,
+            }
+        )
+
+        with pytest.raises(Exception) as excinfo:
+            await api.merge_pull_request("o", "r", 1, "merge")
+
+        msg = str(excinfo.value)
+        assert "GitHub:" in msg
+        assert "Required workflows" in msg
+        assert "not satisfied" in msg
+
+    @pytest.mark.asyncio
+    async def test_merge_succeeded_despite_exception_returns_true(self):
+        """The race-recovery path (was dead code) must work again."""
+        from dependamerge.github_async import GitHubAsync
+
+        api = GitHubAsync(token="t")
+        api.put = AsyncMock(side_effect=_make_405_with_body("transient"))
+        # Re-fetch shows the PR actually merged despite the exception.
+        api.get = AsyncMock(return_value={"state": "closed", "merged": True})
+
+        result = await api.merge_pull_request("o", "r", 1, "merge")
+
+        assert result is True
+
+
+class TestFailureSummarySurfacesGitHubDetail:
+    """``_get_failure_summary`` surfaces the GitHub-supplied reason."""
+
+    def test_github_detail_extracted_from_exception(self):
+        mgr, _client = make_merge_manager(merge_method="merge")
+        pr = _make_pr_info(mergeable_state="blocked", mergeable=True)
+        exc = Exception(
+            "Failed to merge PR #39 in org/repo. GitHub: Required "
+            "workflows 'Autolabeler' are not satisfied (PR state: open, "
+            "mergeable: True, mergeable_state: blocked) "
+            "[blocked by branch protection / required checks]"
+        )
+        mgr._last_merge_exception["org/repo#39"] = exc
+
+        summary = mgr._get_failure_summary(pr)
+
+        # The actionable GitHub message is returned, trimmed of the
+        # appended PR-state context.
+        assert summary == "Required workflows 'Autolabeler' are not satisfied"


### PR DESCRIPTION
## Problem

When merging all open PRs in a single repository, merging one dependency bump can make a *queued* PR conflict on a shared file (classically `uv.lock`). The PR list is fetched once up front, so a worker would approve and attempt to merge a PR against its **stale `clean` snapshot**, then hard-fail with the misleading `Failed to merge after all retry attempts` — observed on `lfreleng-actions/lftools-uv#425`.

Beyond that, merge conflicts had **no recovery path**, and stuck CI / DCO checks on non-dependabot PRs produced only a generic failure line.

A second, separate failure mode surfaced once repos with only a failing **non-required** check (e.g. an excluded Zizmor scan) were merged: GitHub reports those as `mergeable_state="unstable"` with `mergeable=true` — the green button is live — yet the tool would silently hang for the full `merge_timeout` (300s) before merging, with no on-screen feedback. Observed on `lfreleng-actions/test-tags-calver#27` and `test-tags-semantic#27`.

## Changes (10 atomic commits)

1. **`Fix: Remove unused git_ops.fetch import`** — pre-existing ruff `F401`.
2. **`Fix(merge): Refresh mergeability before dispatch`** — in a repo-scoped batch, refresh each PR&#39;s live merge state **inside the per-repo dispatch lock** (the only point serialised *and* ordered after a sibling merge), polling up to 10s while GitHub recomputes mergeability. Adds an explicit `repo_scoped` flag (the repo path no longer runs at `concurrency=1`).
3. **`Refactor(merge): Extract auto-merge wait helper`** — extract Step 5.5&#39;s wait loop into `_wait_for_auto_merge(continue_states, deadline, stop_on_clean)` so the conflict path can reuse it. No behaviour change.
4. **`Feat(merge): Recover from merge conflicts`** — route `dirty` PRs (at fetch *and* when the pre-dispatch refresh reveals a fresh conflict, always **outside** the dispatch lock) to `_handle_merge_conflict`:
   - **`dependabot[bot]`** → `🔄 Requesting dependabot rebase:` + `@dependabot rebase` (regenerates the lockfile and re-signs), then a two-phase wait sharing one `merge_timeout` budget — first for the rebase to clear the conflict, then for checks + auto-merge. The rebased commit is approved **only after** the conflict clears (no duplicate approval). Outcomes: `MERGED`, `AUTO_MERGE_PENDING` (rebase landed, checks still running at timeout), or `FAILED [merge conflicts]`.
   - **other authors** → `🔀 Merge conflict:` + fast fail, no wait (no macro can regenerate a conflicted lockfile and a force-push would break this org&#39;s self-merge rule).
5. **`Feat(merge): Retrigger stuck-pending pre-commit.ci`** — `_trigger_stale_precommit_ci` now also retriggers when `pre-commit.ci - pr` is stuck in `pending` past `PRECOMMIT_CI_STUCK_PENDING_SECONDS` (5 min, generous), not only when the status is missing. Console line aligned to `🔄 Re-triggering pre-commit.ci: `.
6. **`Feat(merge): Report non-dependabot stuck checks`** — when a non-dependabot merge fails with a stuck required check (incl. DCO), emit `⚠️ Stuck check:  []` and arm auto-merge if the PR is otherwise mergeable (Option A; no force-push). Failure reporting extracted into `_report_merge_failure` to keep `_merge_single_pr` within the type checker&#39;s code-flow limit.
7. **`Fix(merge): Merge mergeable unstable PRs directly`** — Step 5.5 no longer routes an `unstable` PR into the auto-merge wait when GitHub reports `mergeable is True`. Such a PR (green button, only a *non-required* check failing — e.g. an excluded Zizmor scan) flows straight to the Step 6 direct merge instead of burning the full `merge_timeout`: the state never reaches `clean` (the non-required check stays red), and `enablePullRequestAutoMerge` is rejected on an already-mergeable PR anyway. The `unstable + mergeable != True` case (GitHub still computing, or a required check transiently failing) still waits, exactly as before.
8. **`Fix(cli): Restart progress tracker for merge phase`** — the org-wide scan stops the progress tracker it used, tearing down its Rich `Live`. The real merge then reused that stopped tracker, so the background wait-status ticker pushed `update_operation` calls into a dead `Live` (silently dropped by `_refresh_display`), leaving the user with no countdown while PRs waited. A fresh, started tracker is now stood up for the merge phase (mirroring the repo-scoped path) and stopped afterwards. Preview runs keep the stopped tracker since they print one line per PR with no wait loop.
9. **`Style(output): Use play icon for merge phase`** — the merge-phase progress panel shared the `🔀` icon with the org-wide similar-PR scan; switch it to `▶️` so the heading reads as the operation actively moving forward (play) and is visually distinct from the preceding scan phase. Applies to the org-wide and repo-scoped merge trackers via their `operation_icon`; the scan phase keeps its default `🔀`.
10. **`Feat(output): Unify failed-PR reason formatting`** — the final `❌ Failed PRs` summary rendered ruleset violations inconsistently: `Required workflows` failures got a header + trailing-colon sub-header + bullets, while `Required status check` violations stayed as one raw GitHub sentence. Both now render through one consistent three-part shape: the PR URL, a single failure-type line whose parts are joined with `` / `` and carry no trailing colon (e.g. `Repository rule violations found / Required workflows failed`), then one bullet per individual failing condition. `Required status check(s)` violations are now parsed too — the quoted check names become bullets — so a pre-commit.ci or Zizmor failure reports the same way whichever ruleset clause GitHub returns.

The `Fix(merge): Address Copilot review feedback` commit also collects the smaller review-driven fixes folded in across review rounds — most recently: `_wait_for_auto_merge` now breaks out of the wait as soon as GitHub reports `unstable` + `mergeable is True` (so a PR that becomes immediately mergeable mid-wait can&#39;t spin to the deadline), and the stale `_refresh_pr_mergeability` "before dispatch" wording was corrected in both the source and `tests/test_mergeability_refresh.py` docstrings (the pre-dispatch check is the single-GET `_is_pr_dirty_now`; `_refresh_pr_mergeability` runs post-failure, off the lock).

## `#425` scenario, end to end

1. Repo merge → `repo_scoped=True`; `#425` is `clean` at fetch.
2. A sibling `uv.lock` bump merges first; `#425`&#39;s worker reaches the dispatch lock, refreshes, and GitHub now reports `dirty`.
3. The lock is released and `_handle_merge_conflict` runs (off the lock, so other PRs keep merging) → `@dependabot rebase`.
4. Phase 1 waits for the rebase to clear the conflict; the rebased commit is then approved and auto-merge enabled.
5. Phase 2 waits (one shared 300s budget) for checks + auto-merge → `✅ Merged (auto-merge)`, or `⏳ Waiting [auto-merge after rebase]` if CI outlasts the window.

Throughout, the PR sits in `_waiting_prs`, so the Rich ticker shows the countdown and the run stays alive until the background waits finish.

## `unstable` scenario, end to end

1. A PR&#39;s only failing gate is a non-required check (e.g. a Zizmor scan now excluded from the org ruleset) → GitHub reports `mergeable_state="unstable"`, `mergeable=true`.
2. Step 5.5 sees `unstable` + `mergeable is True` and **skips** the auto-merge wait.
3. Step 6 performs the direct merge → `✅ Merged` immediately (≈6s for two PRs end to end, versus the previous ~300s silent hang).
4. The merge-phase progress panel (`▶️ Merging PRs … 2/2`) renders live throughout, so any genuine wait now shows a countdown instead of silence.

## Failure-summary formatting

The end-of-run `❌ Failed PRs` block now reports every recognised ruleset failure in the same three-part shape:

```
❌ Failed PRs:
   • https://github.com/lfreleng-actions/central-publish-action/pull/14
     Repository rule violations found / Required status checks failed
     • pre-commit.ci - pr
   • https://github.com/lfreleng-actions/nexus-staging-action/pull/23
     Repository rule violations found / Required workflows failed
     • 🌈 Zizmor Scan
```

## Testing

- `prek run --all-files` green (ruff, ruff-format, mypy, basedpyright, reuse, codespell, yamllint, actionlint, pytest, …).
- Full suite **987 passing**, including `tests/test_mergeability_refresh.py`, `tests/test_merge_conflict_handling.py`, the pre-commit.ci and stuck-check suites, plus new coverage: `test_unstable_mergeable_true_merges_directly` and `test_unstable_mergeable_true_breaks_wait_early` in `tests/test_auto_merge.py`, `TestRestartMergeProgressTracker` and the expanded `TestFormatFailureReason` (Required-workflows + Required-status-check variants) in `tests/test_cli.py`.
- Verified live against `lfreleng-actions/test-tags-calver#27` and `test-tags-semantic#27`: both merge directly in ~6s with the merge-phase progress display rendering correctly.

🤖 Generated with assistance from Claude.