### PR TITLE
CI: Remove cache-clearing job from build-test

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -8,12 +8,6 @@ name: 'Python Build/Test'
 # yamllint disable-line rule:truthy
 on:
   workflow_dispatch:
-    inputs:
-      clear_cache:
-        description: 'Clear all Python dependency caches'
-        type: boolean
-        default: false
-        required: false
   pull_request:
     types: [opened, reopened, synchronize]
     branches:
@@ -79,110 +73,8 @@ jobs:
           artifact_upload: 'true'
           artifact_formats: 'json'
 
-  clear-cache:
-    name: 'Clear Python Caches'
-    # Only runs on manual dispatch with clear_cache enabled
-    if: >-
-      github.event_name == 'workflow_dispatch'
-      && github.event.inputs.clear_cache == 'true'
-    runs-on: ubuntu-latest
-    permissions:
-      actions: write  # Required for gh cache delete
-    timeout-minutes: 5
-    env:
-      GH_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-    steps:
-      # Load the egress allow-list out-of-band from
-      # lfreleng-actions/.github and publish it as
-      # $CONNECTION_ALLOW_LIST for the harden-runner step below
-      # to consume in 'block' mode. Loading out-of-band means
-      # the workflow no longer depends on any org-level GitHub
-      # variable being exposed at runtime (org variables are
-      # unreachable from workflows triggered by PRs raised from
-      # forks, which previously forced a fallback to audit mode).
-      # yamllint disable-line rule:line-length
-      - uses: lfreleng-actions/harden-runner-block-action@42663a22f7abe31521cbc6120901353a4b2849bc  # v0.2.0
-        with:
-          # yamllint disable-line rule:line-length
-          config: 'lfreleng-actions//.github/harden-runner/lfreleng-actions/allow_list.txt@18d9c4446bea555d0783e850f6d295f844fe8f67'  # v0.1.1
-
-      # Harden the runner with the just-loaded allow-list.
-      - name: 'Harden runner (block)'
-        # yamllint disable-line rule:line-length
-        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411  # v2.19.4
-        with:
-          egress-policy: 'block'
-          allowed-endpoints: >
-            ${{ env.CONNECTION_ALLOW_LIST }}
-
-      - name: 'Clear Python dependency caches'
-        env:
-          REPO: "${{ github.repository }}"
-        run: |
-          # Clear Python dependency caches (scoped to Python key prefixes)
-          # Matches cache keys created by:
-          #   python-*        lfreleng-actions (actions/cache)
-          #   setup-python-*  actions/setup-python built-in caching
-          #   setup-uv-*      astral-sh/setup-uv
-          echo "Clearing Python dependency caches 🗑️"
-          deleted=0
-          failed=0
-          for prefix in python- setup-python- setup-uv-; do
-            while true; do
-              if ! keys=$(gh cache list --repo "$REPO" \
-                --key "$prefix" --limit 100 \
-                --json key --jq '.[].key' 2>&1); then
-                echo "::warning::Failed to list caches" \
-                  "for prefix '$prefix': $keys"
-                echo "Warning: failed to list caches for" \
-                  "prefix \`$prefix\`: $keys" \
-                  >> "$GITHUB_STEP_SUMMARY"
-                failed=1
-                break
-              fi
-              [ -n "$keys" ] || break
-
-              batch_deleted=0
-              while IFS= read -r key; do
-                [ -n "$key" ] || continue
-                if delete_out=$(gh cache delete "$key" \
-                  --repo "$REPO" 2>&1); then
-                  echo "Deleted cache: $key"
-                  deleted=$((deleted + 1))
-                  batch_deleted=$((batch_deleted + 1))
-                else
-                  echo "::warning::Failed to delete" \
-                    "cache '$key': $delete_out"
-                  echo "Warning: failed to delete cache" \
-                    "\`$key\`: $delete_out" \
-                    >> "$GITHUB_STEP_SUMMARY"
-                  failed=1
-                fi
-              done <<< "$keys"
-
-              # Stop if nothing was deleted to avoid looping
-              # forever on the same result set
-              [ "$batch_deleted" -gt 0 ] || break
-            done
-          done
-          if [ "$deleted" -gt 0 ]; then
-            echo "Cleared $deleted Python cache(s) ✅" \
-              >> "$GITHUB_STEP_SUMMARY"
-          elif [ "$failed" -eq 0 ]; then
-            echo "No Python caches found to clear 💬" \
-              >> "$GITHUB_STEP_SUMMARY"
-          fi
-          if [ "$failed" -ne 0 ]; then
-            echo "Cache clearing completed with errors ❌" \
-              >> "$GITHUB_STEP_SUMMARY"
-            exit 1
-          fi
-
   python-build:
     name: 'Python Build'
-    needs: 'clear-cache'
-    # Run regardless of clear-cache outcome (success, failure, or skipped);
-    if: ${{ always() && !cancelled() }}
     runs-on: 'ubuntu-latest'
     outputs:
       matrix_json: "${{ steps.python-build.outputs.matrix_json }}"


### PR DESCRIPTION
## Summary

Removes the manual Python cache-clearing functionality from the
`build-test.yaml` workflow and simplifies the related job wiring.

## Changes

- Drop the `clear_cache` `workflow_dispatch` input.
- Remove the conditional `clear-cache` job — the `gh cache list` /
  `gh cache delete` logic over the `python-`, `setup-python-`, and
  `setup-uv-` cache key prefixes — along with its `actions: write`
  permission, `GH_TOKEN` env, and harden-runner setup.
- Remove the now-redundant `needs: 'clear-cache'` dependency and the
  `if: ${{ always() && !cancelled() }}` guard from the `python-build`
  job.

## Notes

- The `workflow_dispatch` trigger is **retained**, so the workflow can
  still be triggered manually at any time.
- Net change: 108 deletions, 0 insertions (pure simplification).

## Validation

- `yamllint .github/workflows/build-test.yaml` — clean
- `actionlint .github/workflows/build-test.yaml` — clean
- Job dependency graph verified: `python-tests`, `python-audit`, and
  `sbom` still depend on `python-build`; `grype` depends on `sbom`.