### PR TITLE
Build(deps): Add uv exclude-newer cooldown

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,6 +103,14 @@ dev = [
   "types-requests>=2.32.4.20260107",
 ]
 
+[tool.uv]
+# Supply-chain cooldown: refuse to resolve anything published in the
+# last 7 days, giving the community time to catch a compromised release
+# before it can be locked. Rolling window, re-evaluated on every
+# `uv lock` (no manual date bump). The relative-duration form requires
+# uv >= 0.9.17.
+exclude-newer = "7 days"
+
 [tool.pytest.ini_options]
 testpaths = [
   "tests/",

--- a/uv.lock
+++ b/uv.lock
@@ -6,6 +6,10 @@ resolution-markers = [
     "python_full_version < '3.15'",
 ]
 
+[options]
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer-span = "P7D"
+
 [[package]]
 name = "aiolimiter"
 version = "1.2.1"


### PR DESCRIPTION
Adds a `[tool.uv] exclude-newer = "7 days"` resolver cooldown and refreshes `uv.lock`.

**Why:** uv refuses to lock any dependency published within the last 7 days, giving the community time to catch a compromised release before it enters the lockfile. Complements the existing Dependabot `uv` cooldown, which only gates update PRs (not local or agent `uv lock` resolutions).

**Notes:**
- uv 0.11.x stores the cooldown as a relative span (`exclude-newer-span = "P7D"`), so the lock diff is deterministic and conflict-free. No dependency versions changed in this refresh.
- Requires uv >= 0.9.17 for the relative-duration form; the lockfile carries a backwards-compatible no-op placeholder so older uv in CI still reads it.
- Part of an organisation-wide rollout across uv-managed repositories.