### PR TITLE
Fix: Resolve CodeQL code quality findings

### DIFF
--- a/src/dependamerge/cli.py
+++ b/src/dependamerge/cli.py
@@ -118,7 +118,6 @@ def main(
     """
     # The actual handling is done via the version_callback.
     # This callback exists only to expose --version at the top level.
-    pass
 
 
 console = Console(markup=False)

--- a/src/dependamerge/git_ops.py
+++ b/src/dependamerge/git_ops.py
@@ -597,16 +597,20 @@ def _chmod_tree_safe(
                 try:
                     os.chmod(fp, file_mode)
                 except Exception:
+                    # Best-effort: skip files we cannot chmod; the
+                    # later rmtree retry handles stubborn paths.
                     pass
             for name in dirs:
                 dp = Path(root) / name
                 try:
                     os.chmod(dp, dir_mode)
                 except Exception:
+                    # Best-effort: skip dirs we cannot chmod.
                     pass
         try:
             os.chmod(p, dir_mode)
         except Exception:
+            # Best-effort: ignore failure to chmod the tree root.
             pass
     except Exception:
         # Ignore any errors; deletion attempts will proceed anyway

--- a/src/dependamerge/github2gerrit_detector.py
+++ b/src/dependamerge/github2gerrit_detector.py
@@ -38,9 +38,29 @@ from typing import Any
 
 # Re-export .gitreview symbols so existing callers don't need to change
 # their imports.  The canonical implementation lives in gitreview.py.
-from .gitreview import GitReviewInfo as GitReviewInfo
-from .gitreview import fetch_gitreview_from_github as fetch_gitreview_from_github
-from .gitreview import parse_gitreview_text as parse_gitreview_text
+from .gitreview import (
+    GitReviewInfo,
+    fetch_gitreview_from_github,
+    parse_gitreview_text,
+)
+
+__all__ = [
+    # Re-exported .gitreview symbols (backward-compatible API).
+    "GitReviewInfo",
+    "fetch_gitreview_from_github",
+    "parse_gitreview_text",
+    # Public API defined in this module.
+    "GITHUB2GERRIT_BOT_AUTHORS",
+    "GitHub2GerritMode",
+    "GitHub2GerritMapping",
+    "GitHub2GerritDetectionResult",
+    "detect_github2gerrit_comments",
+    "detect_github2gerrit_from_graphql_comments",
+    "has_github2gerrit_comments",
+    "build_gerrit_change_url_from_mapping",
+    "build_gerrit_submission_comment",
+    "build_gerrit_skip_message",
+]
 
 log = logging.getLogger("dependamerge.github2gerrit_detector")
 
@@ -287,7 +307,7 @@ def build_gerrit_submission_comment(
         lines.extend(
             [
                 "The corresponding Gerrit change has been reviewed (+2) "
-                "and submitted ✅",
+                + "and submitted ✅",
                 "",
                 f"Gerrit change URL: {gerrit_url}",
                 "",
@@ -297,7 +317,7 @@ def build_gerrit_submission_comment(
         lines.extend(
             [
                 "The corresponding Gerrit change has been reviewed (+2) "
-                "and submitted ✅",
+                + "and submitted ✅",
                 "",
             ]
         )
@@ -305,11 +325,11 @@ def build_gerrit_submission_comment(
     lines.extend(
         [
             "The changes from this PR are now part of the main codebase "
-            "in Gerrit.",
+            + "in Gerrit.",
             "",
             "---",
             "*This is an automated action performed by dependamerge "
-            "(GitHub2Gerrit awareness).*",
+            + "(GitHub2Gerrit awareness).*",
         ]
     )
 

--- a/src/dependamerge/github_async.py
+++ b/src/dependamerge/github_async.py
@@ -312,6 +312,8 @@ class GitHubAsync:
                 try:
                     response_text = str(getattr(response, "text", "")).lower()
                 except AttributeError:
+                    # Response object exposes no readable body; fall
+                    # back to the empty default and keep classifying.
                     pass
 
             error_lower = error_str.lower()
@@ -500,19 +502,26 @@ class GitHubAsync:
 
             # Primary rate limit exhausted
             if remaining == 0 or _is_primary_rate_limited(body_text):
-                # Check for Retry-After header on 429 responses
+                # Honor a Retry-After header if present (primary rate
+                # limits may be reported as 403 or 429).  Parse it up
+                # front so that an unparsable value (e.g. an HTTP-date)
+                # falls back to the reset/backoff handling below rather
+                # than triggering an immediate retry.
                 retry_after = r.headers.get("Retry-After")
+                retry_after_delay: float | None = None
                 if retry_after:
                     try:
-                        delay = float(retry_after)
-                        self._last_retry_after = delay
-                        self.log.warning(
-                            "Primary rate limit with Retry-After: %ss", delay
-                        )
-                        await asyncio.sleep(max(0.0, delay))
-                        self._apply_retry_after_throttling(delay)
-                    except Exception:
-                        pass
+                        retry_after_delay = float(retry_after)
+                    except (TypeError, ValueError):
+                        retry_after_delay = None
+                if retry_after_delay is not None:
+                    self._last_retry_after = retry_after_delay
+                    self.log.warning(
+                        "Primary rate limit with Retry-After: %ss",
+                        retry_after_delay,
+                    )
+                    await asyncio.sleep(max(0.0, retry_after_delay))
+                    self._apply_retry_after_throttling(retry_after_delay)
                 elif reset_epoch:
                     self.log.warning(
                         "Primary rate limit exhausted. Waiting until reset: %s",
@@ -535,16 +544,22 @@ class GitHubAsync:
             # Check for Retry-After on 429 or 503 responses
             retry_after = r.headers.get("Retry-After")
             if retry_after:
+                retry_after_delay = None
                 try:
-                    delay = float(retry_after)
-                    self._last_retry_after = delay
+                    retry_after_delay = float(retry_after)
+                except (TypeError, ValueError):
+                    # Retry-After was not a numeric delay; fall through
+                    # to the standard retry handling.
+                    retry_after_delay = None
+                if retry_after_delay is not None:
+                    self._last_retry_after = retry_after_delay
                     self.log.debug(
-                        "HTTP %s with Retry-After: %ss", r.status_code, delay
+                        "HTTP %s with Retry-After: %ss",
+                        r.status_code,
+                        retry_after_delay,
                     )
-                    await asyncio.sleep(max(0.0, delay))
-                    self._apply_retry_after_throttling(delay)
-                except Exception:
-                    pass
+                    await asyncio.sleep(max(0.0, retry_after_delay))
+                    self._apply_retry_after_throttling(retry_after_delay)
 
             self._track_error("transient_error")
             self.log.debug("Retryable HTTP status %s received", r.status_code)
@@ -1321,6 +1336,8 @@ class GitHubAsync:
                                 seen_contexts.add(ctx)
                                 required_checks.append(check)
             except Exception:
+                # Branch protection may be absent or inaccessible with
+                # the current token; treat as no required checks.
                 pass
 
         return required_checks
@@ -1401,7 +1418,6 @@ class GitHubAsync:
                 self.log.debug(
                     f"Could not check detailed collaborator permissions: {e}"
                 )
-                pass
 
             # If we have push permissions but not admin
             if permissions.get("push"):
@@ -1655,6 +1671,8 @@ class GitHubAsync:
                         else:
                             human_changes_requested = True
         except Exception:
+            # Review data is best-effort; on API error leave the
+            # approval/changes flags at their safe defaults.
             pass
 
         # Check for unresolved review comments
@@ -1672,6 +1690,8 @@ class GitHubAsync:
                         if "dismissed" not in body and "resolved" not in body:
                             unresolved_copilot_comments += 1
         except Exception:
+            # Review comments are best-effort; ignore fetch errors and
+            # leave the Copilot comment count unchanged.
             pass
 
         # Check runs and status contexts - look for failing (check this first as it's most specific)
@@ -1701,6 +1721,8 @@ class GitHubAsync:
                     if conclusion in ["failure", "cancelled", "timed_out"]:
                         failing_checks.append(name)
         except Exception:
+            # Check-runs API may be unavailable; proceed with whatever
+            # checks were collected so far.
             pass
 
         try:
@@ -1724,6 +1746,8 @@ class GitHubAsync:
                         if context not in failing_checks:
                             failing_checks.append(context)
         except Exception:
+            # Status API may be unavailable; proceed with whatever
+            # status contexts were collected so far.
             pass
 
         # Detect missing/pending required status checks (e.g. stale pre-commit.ci)

--- a/src/dependamerge/github_service.py
+++ b/src/dependamerge/github_service.py
@@ -147,6 +147,7 @@ class GitHubService:
                     f"Tuning: prs={DEFAULT_PRS_PAGE_SIZE} files={DEFAULT_FILES_PAGE_SIZE} comments={DEFAULT_COMMENTS_PAGE_SIZE} contexts={DEFAULT_CONTEXTS_PAGE_SIZE}"
                 )
             except Exception:
+                # Progress display is best-effort; ignore UI errors.
                 pass
 
     async def _on_rate_limit_cleared(self) -> None:
@@ -160,6 +161,7 @@ class GitHubService:
                 f"Tuning: prs={DEFAULT_PRS_PAGE_SIZE} files={DEFAULT_FILES_PAGE_SIZE} comments={DEFAULT_COMMENTS_PAGE_SIZE} contexts={DEFAULT_CONTEXTS_PAGE_SIZE}"
             )
         except Exception:
+            # Progress display is best-effort; ignore UI errors.
             pass
 
     async def _on_metrics(self, concurrency: int, rps: float) -> None:
@@ -442,6 +444,7 @@ class GitHubService:
             try:
                 self._progress.analyze_pr(pr.get("number", 0), repo_full_name)
             except Exception:
+                # Progress display is best-effort; ignore UI errors.
                 pass
 
         reasons: list[UnmergeableReason] = []
@@ -753,6 +756,9 @@ class GitHubService:
                         try:
                             self._progress.found_similar_pr()  # type: ignore[attr-defined]
                         except Exception:
+                            # No-op when the tracker lacks this method or
+                            # the display update fails; counting is
+                            # cosmetic only.
                             pass
 
             results.extend(matching_prs_in_repo)

--- a/src/dependamerge/merge_manager.py
+++ b/src/dependamerge/merge_manager.py
@@ -505,6 +505,8 @@ class AsyncMergeManager:
                 try:
                     self.progress_tracker.update_operation("")
                 except Exception:
+                    # Defensive: a failing tracker must never take down
+                    # the shutdown path.
                     pass
             raise
 
@@ -535,6 +537,8 @@ class AsyncMergeManager:
                                 f"[{int(remaining)}s remaining]"
                             )
                         except Exception:
+                            # Console output is best-effort; ignore
+                            # write errors on unusual terminals.
                             pass
                         last_emit = now
                 else:
@@ -2141,6 +2145,7 @@ class AsyncMergeManager:
         try:
             self._console.print(f"⚠️ Unable to add pull request comment: {html_url}")
         except Exception:
+            # Console output is best-effort; ignore write errors.
             pass
         return False
 
@@ -4463,7 +4468,6 @@ class AsyncMergeManager:
             except Exception as e:
                 self.log.debug(f"Failed to get detailed block reason: {e}")
                 # Fallback to generic message
-                pass
 
             # Fallback logic when detailed analysis fails
             if pr_info.mergeable is True:

--- a/src/dependamerge/progress_tracker.py
+++ b/src/dependamerge/progress_tracker.py
@@ -107,6 +107,8 @@ class ProgressTracker:
             try:
                 self.live.stop()
             except Exception:
+                # Best-effort teardown: ignore errors from Rich when
+                # the terminal no longer accepts control sequences.
                 pass
         else:
             # Non-Rich fallback: emit a final newline so the shell
@@ -123,6 +125,8 @@ class ProgressTracker:
             try:
                 self.live.stop()
             except Exception:
+                # Best-effort suspend: ignore Rich teardown errors so an
+                # interactive prompt can still take over the terminal.
                 pass
             self.paused = True
 
@@ -549,27 +553,13 @@ class DummyProgressTracker(ProgressTracker):
     """A no-op progress tracker for when progress display is disabled."""
 
     def __init__(self) -> None:
-        # Don't call super().__init__() to avoid Rich initialization
-        self.organization = ""
-        self.start_time = datetime.now()
+        # Initialize the base tracker, then neutralize Rich so this
+        # stand-in performs no terminal output.
+        super().__init__("", show_pr_stats=False)
         self.console = None
-        self.total_repositories = 0
-        self.completed_repositories = 0
-        self.current_repository = ""
-        self.total_prs_analyzed = 0
-        self.unmergeable_prs_found = 0
-        self.current_operation = ""
-        self.errors_count = 0
-        self.show_pr_stats = False
-        self.rate_limited = False
-        self.rate_limit_reset_time = None
-        self.live = None
         self.rich_available = False
-        self.paused = False
-        self.metrics_concurrency = None
-        self.metrics_rps = None
-        self._last_display = ""
-        # MergeProgressTracker fields
+        self.current_operation = ""
+        # MergeProgressTracker fields (Dummy stands in for either tracker)
         self.similar_prs_found = 0
         self.prs_merged = 0
         self.prs_failed = 0

--- a/src/dependamerge/rebase.py
+++ b/src/dependamerge/rebase.py
@@ -462,6 +462,8 @@ async def local_rebase_pr(
             try:
                 rebase_abort(cwd=workspace, logger=log.debug)
             except Exception:
+                # Cleanup abort is best-effort; ignore so the original
+                # rebase failure still drives the retry below.
                 pass
 
             try:
@@ -504,6 +506,8 @@ async def local_rebase_pr(
                 try:
                     rebase_abort(cwd=workspace, logger=log.debug)
                 except Exception:
+                    # Cleanup abort is best-effort; ignore and return
+                    # failure to the caller regardless.
                     pass
                 return False
             log.debug(

--- a/src/dependamerge/resolve_conflicts.py
+++ b/src/dependamerge/resolve_conflicts.py
@@ -239,6 +239,7 @@ class FixOrchestrator:
                     try:
                         op("Fetching PR details for fix candidates...")
                     except Exception:
+                        # Progress display is best-effort; ignore UI errors.
                         pass
 
             contexts = asyncio.run(self.fetch_pr_details(selections))
@@ -262,6 +263,7 @@ class FixOrchestrator:
                         try:
                             op("Preparing workspaces (clone/fetch repos)...")
                         except Exception:
+                            # Progress display is best-effort; ignore UI errors.
                             pass
                 prepared += self._prepare_workspaces_parallel(
                     to_prepare, base_dir, options
@@ -293,6 +295,7 @@ class FixOrchestrator:
                         try:
                             suspend_fn()
                         except Exception:
+                            # Progress display is best-effort; ignore UI errors.
                             pass
                 self._log(
                     f"Starting interactive rebase for {ctx.base_repo_full_name}#{ctx.pr_number} in {workspace}"
@@ -314,6 +317,8 @@ class FixOrchestrator:
                     try:
                         rebase_abort(cwd=workspace)
                     except Exception:
+                        # Cleanup abort is best-effort; the failure is
+                        # already recorded below regardless.
                         pass
                     results.append(
                         FixResult(
@@ -343,6 +348,7 @@ class FixOrchestrator:
                             try:
                                 resume_fn()
                             except Exception:
+                                # Progress display is best-effort; ignore UI errors.
                                 pass
 
             return results


### PR DESCRIPTION
## Summary

Addresses the higher-severity CodeQL code quality (preview) alerts on
the codebase. Almost entirely non-behavioral (documenting/clarifying
intentionally swallowed exceptions, etc.); one small intentional
behavior fix is called out below.

## Findings addressed

| CodeQL rule | Severity | Action |
|-------------|----------|--------|
| `py/missing-call-to-init` | Error | `DummyProgressTracker` now calls `ProgressTracker.__init__()` and then neutralizes Rich, removing the duplicated base-class field assignments. |
| `py/implicit-string-concatenation-in-list` | Warning (4) | The four wrapped message lines in `github2gerrit_detector.py` now use explicit `+` concatenation so intent is unambiguous. |
| `py/unnecessary-pass` | Warning (2) | Dropped redundant `pass` statements that followed other statements (`cli.py`, `github_async.py`, `merge_manager.py`). |
| `py/empty-except` | Note (29) | Added explanatory comments to the comment-less bare `except` blocks documenting why each exception is intentionally swallowed (best-effort UI/teardown/cleanup paths). |
| `py/unused-import` | Note (3) | Replaced the redundant-alias re-exports in `github2gerrit_detector.py` with a plain import plus an explicit `__all__`. |

## Copilot review follow-ups

- Narrowed the two Retry-After handlers in `github_async.py` so the `try`/`except` wraps only the `float()` parse, not the subsequent `await asyncio.sleep()` / throttling call. (Note: the reported `CancelledError`-suppression risk does not apply — the project targets Python `>=3.10`, where `asyncio.CancelledError` derives from `BaseException` and is not caught by `except Exception`.)
- Corrected a misleading "429 responses" comment (primary rate limits may surface as 403 or 429) and renamed the parsed locals to `retry_after_delay`.
- **Small intentional behavior fix:** on the primary rate-limit path, `Retry-After` is now parsed up front so an unparseable value (e.g. an HTTP-date) falls back to the reset/backoff branch instead of triggering an immediate retry. Previously an unparseable `Retry-After` skipped any wait before retrying.

## Validation

- Full test suite: `987 passed` (`uv run pytest`).
- `pyflakes src/` clean; `mypy src/dependamerge/github_async.py` clean.
- All modules compile; no new diagnostics introduced.

## Not yet addressed (lower-severity notes)

Deferred for a follow-up so their exact CodeQL locations can be
confirmed against the security UI before touching them:

- Unused global variable (5)
- Unused local variable (3)
- Statement has no effect (1)
- Explicit returns mixed with implicit (fall through) returns (1)