### PR TITLE
Test: Fix codespell spelling in test name

### DIFF
--- a/tests/test_stuck_check_detection.py
+++ b/tests/test_stuck_check_detection.py
@@ -476,7 +476,7 @@ class TestDetectStuckDcoRobustness:
         assert age == 0.0
 
     @pytest.mark.asyncio
-    async def test_unparseable_timestamps_return_safe_default(self) -> None:
+    async def test_unparsable_timestamps_return_safe_default(self) -> None:
         mgr, client = _make_manager()
         pr = _make_pr_info()
 


### PR DESCRIPTION
## Summary

Pre-emptive codespell fix. `codespell` flags `unparseable` as a
misspelling of `unparsable`. There is one remaining occurrence in the
test suite — the method name
`test_unparseable_timestamps_return_safe_default` in
`tests/test_stuck_check_detection.py`. The pre-commit `codespell` hook
scopes to changed files, so it hasn't fired yet, but it will the next
time this file is touched.

This renames the method to use the codespell-approved spelling.

## Notes

- The method is only referenced by pytest discovery; there are no other
  call sites, so no further changes are required.
- Behavior is unchanged — purely a rename.

## Validation

- `codespell tests/test_stuck_check_detection.py` clean.
- `uv run pytest tests/test_stuck_check_detection.py -k unparsable` passes.