### PR TITLE
Chore: Clear CodeQL code quality findings

### DIFF
--- a/scripts/demo_wait_ticker.py
+++ b/scripts/demo_wait_ticker.py
@@ -109,6 +109,9 @@ async def _drive_demo(manager: AsyncMergeManager) -> None:
         try:
             await ticker_task
         except asyncio.CancelledError:
+            # Expected: we just cancelled the ticker, so awaiting it
+            # re-raises the cancellation. Swallow it to allow a clean
+            # teardown of the demo.
             pass
 
 
@@ -151,6 +154,9 @@ async def _amain(plain: bool) -> int:
         try:
             tracker.stop()
         except Exception:
+            # Best-effort teardown: the demo is exiting regardless, so a
+            # failure to stop the progress tracker must not mask the
+            # outcome or raise from the ``finally`` block.
             pass
 
     print("[demo] finished")

--- a/src/dependamerge/cli.py
+++ b/src/dependamerge/cli.py
@@ -1149,7 +1149,6 @@ def _handle_repo_merge(
                 console.print("ℹ️  Excluding human PRs from merge.")
                 # Remove human PRs from the working set
                 repo_prs = automation_prs
-                human_prs = []
                 if not repo_prs:
                     console.print("❌ No automation PRs remain to merge.")
                     return

--- a/src/dependamerge/github_async.py
+++ b/src/dependamerge/github_async.py
@@ -11,6 +11,7 @@ import time
 from collections.abc import AsyncIterator, Awaitable, Callable
 from typing import (
     Any,
+    cast,
 )
 from urllib.parse import quote
 
@@ -165,7 +166,7 @@ async def _maybe_await(
         return
     result = cb(*args, **kwargs)
     if asyncio.iscoroutine(result):
-        await result
+        return await cast("Awaitable[None]", result)
 
 
 class GitHubAsync:

--- a/src/dependamerge/github_graphql.py
+++ b/src/dependamerge/github_graphql.py
@@ -20,6 +20,8 @@ __all__ = [
     "REPO_OPEN_PRS_PAGE",
     "ENABLE_AUTO_MERGE",
     "GET_BRANCH_PROTECTION",
+    "GET_PR_REVIEW_THREADS",
+    "RESOLVE_REVIEW_THREAD",
 ]
 
 # Lightweight query to list repositories without PR nodes for accurate counting.
@@ -230,21 +232,6 @@ query($owner: String!, $name: String!, $prsCursor: String, $prsPageSize: Int!, $
 }
 """
 
-# GraphQL mutations for managing review comments and reviews
-DISMISS_REVIEW_COMMENT = """
-mutation DismissReviewComment($commentId: ID!) {
-  dismissPullRequestReviewComment(input: {
-    pullRequestReviewCommentId: $commentId
-  }) {
-    pullRequestReviewComment {
-      id
-      state
-      author { login }
-    }
-  }
-}
-"""
-
 # GraphQL mutation to resolve a review thread
 RESOLVE_REVIEW_THREAD = """
 mutation ResolveReviewThread($threadId: ID!) {
@@ -289,21 +276,6 @@ query GetPullRequestReviewThreads($owner: String!, $name: String!, $number: Int!
           }
         }
       }
-    }
-  }
-}
-"""
-
-DISMISS_PULL_REQUEST_REVIEW = """
-mutation DismissPullRequestReview($reviewId: ID!, $message: String!) {
-  dismissPullRequestReview(input: {
-    pullRequestReviewId: $reviewId
-    message: $message
-  }) {
-    pullRequestReview {
-      id
-      state
-      author { login }
     }
   }
 }

--- a/src/dependamerge/gitreview.py
+++ b/src/dependamerge/gitreview.py
@@ -129,11 +129,6 @@ def derive_base_path(host: str) -> str | None:
     return _KNOWN_BASE_PATHS.get(host.lower().strip())
 
 
-# Keep a private alias so internal callers don't break if they were
-# referencing the underscore-prefixed name during development.
-_derive_gerrit_base_path = derive_base_path
-
-
 # ───────────────────────────────────────────────────────────────────────
 # Pure parser
 # ───────────────────────────────────────────────────────────────────────

--- a/src/dependamerge/merge_manager.py
+++ b/src/dependamerge/merge_manager.py
@@ -1352,7 +1352,6 @@ class AsyncMergeManager:
                     # also calls ``analyze_block_reason``) and either
                     # defer to auto-merge or surface a manual-merge
                     # error promptly.
-                    pre_block_reason = None
                     should_wait = False
 
                 if should_wait and pre_block_reason is not None:
@@ -4335,11 +4334,7 @@ class AsyncMergeManager:
         stuck_reported = False
         if pr_info.author != "dependabot[bot]" and not self.preview_mode:
             try:
-                (
-                    is_stuck,
-                    stuck_check,
-                    _stuck_age,
-                ) = await self._detect_stuck_required_check(pr_info)
+                detection = await self._detect_stuck_required_check(pr_info)
             except Exception as exc:
                 self.log.debug(
                     "_detect_stuck_required_check failed for %s#%s: %s",
@@ -4347,9 +4342,9 @@ class AsyncMergeManager:
                     pr_info.number,
                     exc,
                 )
-                is_stuck = False
-                stuck_check = None
-            if is_stuck:
+                detection = None
+            if detection is not None and detection[0]:
+                stuck_check = detection[1]
                 # markup=False: a check name may contain characters
                 # Rich would otherwise treat as markup.
                 self._console.print(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -118,6 +118,7 @@ class TestCLI:
                 return mock_pr
             elif pr_number == 5:
                 return similar_pr
+            return None
 
         mock_client.get_pull_request_info.side_effect = get_pr_info_side_effect
         mock_client.get_pr_status_details.return_value = "Ready to merge"

--- a/tests/test_gitreview.py
+++ b/tests/test_gitreview.py
@@ -6,7 +6,7 @@ Covers:
 - GitReviewInfo data model
 - parse_gitreview() — pure text parser
 - parse_gitreview_text() — backward-compatible alias
-- derive_base_path() / _derive_gerrit_base_path() — static known-host lookup
+- derive_base_path() — static known-host lookup
 - fetch_gitreview_from_github() — async GitHub API fetcher
 - Backward-compatible re-exports from github2gerrit_detector
 """
@@ -22,7 +22,6 @@ import pytest
 from dependamerge.gitreview import (
     DEFAULT_GERRIT_PORT,
     GitReviewInfo,
-    _derive_gerrit_base_path,
     derive_base_path,
     fetch_gitreview_from_github,
     parse_gitreview,
@@ -132,10 +131,6 @@ class TestDeriveBasePath:
 
     def test_empty_host(self) -> None:
         assert derive_base_path("") is None
-
-    def test_private_alias(self) -> None:
-        """_derive_gerrit_base_path is an alias for derive_base_path."""
-        assert _derive_gerrit_base_path is derive_base_path
 
 
 # -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Clears all outstanding findings from GitHub's preview **Code quality**
feature (powered by CodeQL) on `main` (`de4e3c9`). The work is split into
five atomic commits, one per CodeQL category.

## Findings addressed

| Commit | Finding (count) | Fix |
| ------ | --------------- | --- |
| Refactor: Resolve unused global CodeQL alerts | Unused global variable (5) | In `github_graphql.py`, `GET_PR_REVIEW_THREADS` and `RESOLVE_REVIEW_THREAD` are genuine exports (imported by `copilot_handler.py` via function-local imports) and are added to `__all__`; `DISMISS_REVIEW_COMMENT` and `DISMISS_PULL_REQUEST_REVIEW` are dead and removed. In `gitreview.py`, the private `_derive_gerrit_base_path` dev shim and its identity-only test are removed. |
| Refactor: Remove unused local variables | Unused local variable (3) | `cli.py`: drop dead `human_prs = []`. `merge_manager.py`: drop dead `pre_block_reason = None`, and rework the stuck-check failure path to a single nullable `detection` variable. |
| Docs(scripts): Explain empty except clauses | Empty except (2) | Add explanatory comments to the two `except` blocks in `scripts/demo_wait_ticker.py`. |
| Refactor: Return awaited result in _maybe_await | Statement has no effect (1) | `github_async.py`: `await result` becomes `return await cast("Awaitable[None]", result)`. |
| Test: Add explicit return to mock side effect | Explicit/implicit returns mixed (1) | `test_cli.py`: add explicit `return None` for the fall-through path. |

## Notes

- Two of the five "unused global" alerts (`GET_PR_REVIEW_THREADS`,
  `RESOLVE_REVIEW_THREAD`) are CodeQL false positives — they are used
  through function-local imports in `copilot_handler.py`. Exporting them
  via `__all__` clears the alert without breaking Copilot thread
  resolution.
- The `stuck_check` case needed a small restructure: simply deleting the
  dead `None` default (what CodeQL wants) made basedpyright flag a
  possibly-unbound read. The single-`detection`-variable rewrite
  satisfies both tools.

## Validation

- `uv run ruff check src/ tests/ scripts/` — clean
- `uv run mypy src/` — clean (30 source files)
- `uv run pytest` — 986 passed, 62.83% coverage
- Full pre-commit suite passed on every commit (ruff, mypy, basedpyright,
  reuse, codespell, pytest, gitlint).

No behaviour changes are intended; all fixes are maintainability/reliability
cleanups.