### PR TITLE
Refactor: Make _maybe_await returns explicit

### DIFF
--- a/src/dependamerge/github_async.py
+++ b/src/dependamerge/github_async.py
@@ -163,10 +163,11 @@ async def _maybe_await(
     cb: Callable[..., None | Awaitable[None]] | None, *args, **kwargs
 ) -> None:
     if cb is None:
-        return
+        return None
     result = cb(*args, **kwargs)
-    if asyncio.iscoroutine(result):
-        return await cast("Awaitable[None]", result)
+    if not asyncio.iscoroutine(result):
+        return None
+    return await cast("Awaitable[None]", result)
 
 
 class GitHubAsync:


### PR DESCRIPTION
## Summary

Clears the new CodeQL **Code quality** finding:

> Explicit returns mixed with implicit (fall through) returns —
> `src/dependamerge/github_async.py:162` (`_maybe_await`)

## Background

A prior cleanup (PR #331) changed `_maybe_await` from a bare
`await result` expression statement to `return await ...` in order to
clear the *"statement has no effect"* (ineffectual-statement) alert.

That fix inadvertently introduced a *mixed-returns* alert: the explicit
`return await ...` coexisted with a bare `return` (no value) and an
implicit fall-through that occurs when the callback result is not a
coroutine.

## Fix

Make every exit point an explicit return:

```python
async def _maybe_await(
    cb: Callable[..., None | Awaitable[None]] | None, *args, **kwargs
) -> None:
    if cb is None:
        return None
    result = cb(*args, **kwargs)
    if not asyncio.iscoroutine(result):
        return None
    return await cast("Awaitable[None]", result)
```

This removes the implicit fall-through and the bare `return`, so the
returns are consistent (no mixed implicit/explicit), while keeping the
awaited value inside a `return` statement so the earlier
ineffectual-statement fix still stands. Behaviour is unchanged — the
helper still returns `None`.

## Validation

- `uv run ruff check src/dependamerge/github_async.py` — clean
- `uv run mypy src/dependamerge/github_async.py` — clean
- `uv run basedpyright src/dependamerge/github_async.py` — 0 errors
- `uv run pytest tests/test_async_behavior.py tests/test_async_integration.py`
  — 36 passed
- Full pre-commit suite passed on the commit.