### PR TITLE
Refactor: Address AI code-quality findings

### DIFF
--- a/src/dependamerge/github_async.py
+++ b/src/dependamerge/github_async.py
@@ -180,13 +180,30 @@ class GitHubAsync:
     - Helpers for GraphQL and REST endpoints used by dependamerge
     """
 
+    # Default ceiling for concurrent in-flight requests. Used both as the
+    # constructor default and as the upper bound when adaptive tuning ramps
+    # concurrency back up after a period of throttling.
+    _DEFAULT_MAX_CONCURRENCY = 20
+
+    # Heuristic used by ``_get_recent_error_rate`` to estimate how many
+    # requests accompanied each observed error within the error window.
+    # We do not track total request counts, only errors, so we assume each
+    # error corresponds to roughly this many requests. With the current
+    # value of 10 the estimate is errors / (errors * 10), so any window
+    # containing at least one error yields an error_rate of ~0.1. A smaller
+    # number raises that estimate and reacts to errors more aggressively,
+    # while a larger number lowers it and tolerates more errors before
+    # throttling. Tune this if observed throttling behaviour is too eager
+    # or too lax.
+    _ESTIMATED_REQUESTS_PER_ERROR = 10
+
     def __init__(
         self,
         token: str | None = None,
         *,
         api_url: str = GITHUB_API,
         graphql_url: str = GITHUB_GQL,
-        max_concurrency: int = 20,
+        max_concurrency: int = _DEFAULT_MAX_CONCURRENCY,
         requests_per_second: float = 8.0,
         timeout: float = 20.0,
         user_agent: str = "dependamerge/async-client",
@@ -221,6 +238,11 @@ class GitHubAsync:
         self.api_url = api_url.rstrip("/")
         self.graphql_url = graphql_url
         self._max_concurrency = max_concurrency
+        # Remember the caller-configured ceiling so adaptive tuning ramps
+        # concurrency back up to *this* value (not the class default) after
+        # a period of throttling, mirroring how ``_base_rps`` bounds the RPS
+        # ramp-up.
+        self._base_max_concurrency = max_concurrency
         self.semaphore = asyncio.Semaphore(self._max_concurrency)
         self._base_rps = requests_per_second
         self._current_rps = requests_per_second
@@ -603,8 +625,10 @@ class GitHubAsync:
                         )
             else:
                 # Gradually increase limits when healthy, up to configured base values
-                if self._max_concurrency < 20:
-                    self._max_concurrency = min(20, self._max_concurrency + 1)
+                if self._max_concurrency < self._base_max_concurrency:
+                    self._max_concurrency = min(
+                        self._base_max_concurrency, self._max_concurrency + 1
+                    )
                     self.semaphore = asyncio.Semaphore(self._max_concurrency)
                 if self._current_rps < self._base_rps:
                     self._current_rps = min(self._base_rps, self._current_rps + 1.0)
@@ -772,30 +796,7 @@ class GitHubAsync:
                 f"Merge API error for PR #{number} in {owner}/{repo}: {error_type}: {error_msg}"
             )
 
-            # Extract the response body.  GitHub puts the *actual*
-            # reason here — ruleset violations, "Required workflows ...
-            # are not satisfied", required-check names, etc.  The
-            # ``HTTPStatusError`` text only carries the status line
-            # (e.g. "405 Method Not Allowed"), so without this the real
-            # cause is silently lost.  Whitespace/newlines are
-            # collapsed so the reason fits on a single status line.
-            github_detail = ""
-            response = getattr(e, "response", None)
-            if response is not None:
-                try:
-                    body = response.json()
-                    if isinstance(body, dict) and isinstance(
-                        body.get("message"), str
-                    ):
-                        github_detail = " ".join(body["message"].split())
-                except Exception:
-                    github_detail = ""
-                if not github_detail:
-                    try:
-                        raw = getattr(response, "text", "") or ""
-                        github_detail = " ".join(raw.split())[:500]
-                    except Exception:
-                        github_detail = ""
+            github_detail = self._extract_github_error_detail(e)
             if github_detail:
                 self.log.debug(
                     f"GitHub merge API response body for #{number}: {github_detail}"
@@ -806,80 +807,130 @@ class GitHubAsync:
             # but we still see an error from rate-limiting, network, or
             # JSON parsing), and the state adds context to the error we
             # raise.
-            try:
-                pr_data_response = await self.get(
-                    f"/repos/{owner}/{repo}/pulls/{number}"
+            return await self._validate_merge_result(
+                owner, repo, number, e, github_detail
+            )
+
+    @staticmethod
+    def _extract_github_error_detail(error: Exception) -> str:
+        """Extract GitHub's response-body message from a failed request.
+
+        GitHub puts the *actual* reason here — ruleset violations,
+        "Required workflows ... are not satisfied", required-check names,
+        etc.  The ``HTTPStatusError`` text only carries the status line
+        (e.g. "405 Method Not Allowed"), so without this the real cause is
+        silently lost.  Whitespace/newlines are collapsed so the reason
+        fits on a single status line.
+
+        Returns an empty string when no detail could be extracted.
+        """
+        response = getattr(error, "response", None)
+        if response is None:
+            return ""
+        try:
+            body = response.json()
+            if isinstance(body, dict) and isinstance(body.get("message"), str):
+                return " ".join(body["message"].split())
+        except Exception:
+            pass
+        try:
+            raw = getattr(response, "text", "") or ""
+            return " ".join(raw.split())[:500]
+        except Exception:
+            return ""
+
+    async def _validate_merge_result(
+        self,
+        owner: str,
+        repo: str,
+        number: int,
+        error: Exception,
+        github_detail: str,
+    ) -> bool:
+        """Re-check PR state after a merge attempt raised an exception.
+
+        The merge may have actually succeeded despite the exception (a race
+        where the API call lands but we still see an error from
+        rate-limiting, network, or JSON parsing).  When the PR is confirmed
+        merged, return ``True``.  Otherwise raise an enhanced exception that
+        preserves the original error text (its HTTP status line is
+        string-matched by ``_merge_pr_with_retry`` to classify retryable vs
+        terminal failures) and adds GitHub's actionable response body plus
+        PR-state context.
+        """
+        try:
+            pr_data_response = await self.get(f"/repos/{owner}/{repo}/pulls/{number}")
+            # PR data should always be a dict, not a list
+            pr_data = pr_data_response if isinstance(pr_data_response, dict) else {}
+
+            # Extract relevant state information
+            mergeable = pr_data.get("mergeable")
+            mergeable_state = pr_data.get("mergeable_state")
+            state = pr_data.get("state")
+            merged = pr_data.get("merged", False)
+            draft = pr_data.get("draft", False)
+
+            # Check if the merge actually succeeded despite the exception.
+            # This handles race conditions where the API succeeds but we get
+            # an exception due to rate limiting, network issues, JSON
+            # parsing, etc.
+            if state == "closed" and merged:
+                self.log.info(
+                    f"PR #{number} in {owner}/{repo} was successfully merged despite exception: {error}"
                 )
-                # PR data should always be a dict, not a list
-                pr_data = pr_data_response if isinstance(pr_data_response, dict) else {}
+                return True
 
-                # Extract relevant state information
-                mergeable = pr_data.get("mergeable")
-                mergeable_state = pr_data.get("mergeable_state")
-                state = pr_data.get("state")
-                merged = pr_data.get("merged", False)
-                draft = pr_data.get("draft", False)
+            # Enhanced error message.  Always keep the original error text —
+            # it carries the HTTP status line (e.g. "405 Method Not
+            # Allowed") that ``_merge_pr_with_retry`` string-matches to
+            # classify retryable vs terminal failures; dropping it made
+            # every blocked/ruleset 405 fall through to the generic retry
+            # path (3 attempts + sleeps).  Then *add* GitHub's response body
+            # (the actionable reason) when we captured it.
+            error_msg = (
+                f"Failed to merge PR #{number} in {owner}/{repo}. Error: {str(error)}."
+            )
+            if github_detail:
+                error_msg += f" GitHub: {github_detail}"
+            error_msg += (
+                f" (PR state: {state}, mergeable: {mergeable}, "
+                f"mergeable_state: {mergeable_state})"
+            )
 
-                # Check if the merge actually succeeded despite the exception
-                # This handles race conditions where the API succeeds but we get an exception
-                # due to rate limiting, network issues, JSON parsing, etc.
-                if state == "closed" and merged:
-                    self.log.info(
-                        f"PR #{number} in {owner}/{repo} was successfully merged despite exception: {e}"
-                    )
-                    return True
+            # Note common state-based causes for 405-style errors.
+            if mergeable_state == "blocked":
+                error_msg += " [blocked by branch protection / required checks]"
+            elif mergeable_state == "behind":
+                error_msg += " [PR branch is behind base branch]"
+            elif mergeable_state == "dirty":
+                error_msg += " [PR has merge conflicts]"
+            elif draft:
+                error_msg += " [cannot merge draft PR]"
+            elif state == "closed" and not merged:
+                error_msg += " [PR was closed without merging]"
+            elif state != "open":
+                error_msg += f" [PR is not open, state: {state}]"
 
-                # Enhanced error message.  Always keep the original
-                # error text — it carries the HTTP status line (e.g.
-                # "405 Method Not Allowed") that ``_merge_pr_with_retry``
-                # string-matches to classify retryable vs terminal
-                # failures; dropping it made every blocked/ruleset 405
-                # fall through to the generic retry path (3 attempts +
-                # sleeps).  Then *add* GitHub's response body (the
-                # actionable reason) when we captured it.
-                error_msg = (
+            raise Exception(error_msg) from error
+        except Exception as inner_e:
+            # The enhanced-error path raised successfully (the message
+            # starts with "Failed to merge PR") — propagate it unchanged.
+            # A bare ``raise`` preserves ``inner_e`` together with its
+            # existing ``__cause__`` (set to ``error`` above) and original
+            # traceback, whereas ``raise inner_e from error`` would rewrite
+            # the chaining.
+            if "Failed to merge PR" in str(inner_e):
+                raise
+            # Otherwise the PR-state re-fetch itself failed.  Still surface
+            # GitHub's response body (the actionable reason) when we
+            # captured it, rather than dropping back to the bare
+            # status-line ``HTTPStatusError``.
+            if github_detail:
+                raise Exception(
                     f"Failed to merge PR #{number} in {owner}/{repo}. "
-                    f"Error: {str(e)}."
-                )
-                if github_detail:
-                    error_msg += f" GitHub: {github_detail}"
-                error_msg += (
-                    f" (PR state: {state}, mergeable: {mergeable}, "
-                    f"mergeable_state: {mergeable_state})"
-                )
-
-                # Note common state-based causes for 405-style errors.
-                if mergeable_state == "blocked":
-                    error_msg += " [blocked by branch protection / required checks]"
-                elif mergeable_state == "behind":
-                    error_msg += " [PR branch is behind base branch]"
-                elif mergeable_state == "dirty":
-                    error_msg += " [PR has merge conflicts]"
-                elif draft:
-                    error_msg += " [cannot merge draft PR]"
-                elif state == "closed" and not merged:
-                    error_msg += " [PR was closed without merging]"
-                elif state != "open":
-                    error_msg += f" [PR is not open, state: {state}]"
-
-                raise Exception(error_msg) from e
-            except Exception as inner_e:
-                # The enhanced-error path raised successfully (the
-                # message starts with "Failed to merge PR") — propagate
-                # it unchanged.
-                if "Failed to merge PR" in str(inner_e):
-                    raise inner_e from e
-                # Otherwise the PR-state re-fetch itself failed.  Still
-                # surface GitHub's response body (the actionable reason)
-                # when we captured it, rather than dropping back to the
-                # bare status-line ``HTTPStatusError``.
-                if github_detail:
-                    raise Exception(
-                        f"Failed to merge PR #{number} in {owner}/{repo}. "
-                        f"Error: {str(e)}. GitHub: {github_detail}"
-                    ) from e
-                raise e from inner_e
-
+                    f"Error: {str(error)}. GitHub: {github_detail}"
+                ) from error
+            raise error from inner_e
 
     async def enable_auto_merge(
         self, pull_request_node_id: str, merge_method: str = "MERGE"
@@ -1022,12 +1073,17 @@ class GitHubAsync:
             per_page=100,
         ):
             if not isinstance(commits, list):
-                # Unexpected response shape — assume OK to avoid
-                # false positives. The API returned 200 OK but in
-                # an unexpected shape, which is distinct from a
-                # network/HTTP error and arguably means the page
-                # is empty.
-                return True, []
+                # Unexpected response shape: the API returned 200 OK but
+                # not the documented list of commits. We cannot determine
+                # signature status from this, so we must not pretend every
+                # commit is verified (the old fail-open ``(True, [])``
+                # default collided with the signature-preservation gate in
+                # ``rebase.py``). Surface the uncertainty to the caller.
+                raise RuntimeError(
+                    "Unexpected response shape from "
+                    f"/repos/{owner}/{repo}/pulls/{number}/commits: "
+                    f"expected a list, got {type(commits).__name__}"
+                )
 
             for commit_data in commits:
                 if not isinstance(commit_data, dict):
@@ -1085,8 +1141,7 @@ class GitHubAsync:
             # 404 → not enabled; other errors → continue checking rulesets
             if "404" not in str(e):
                 self.log.debug(
-                    "Error checking classic signature requirement for "
-                    "%s/%s:%s: %s",
+                    "Error checking classic signature requirement for %s/%s:%s: %s",
                     owner,
                     repo,
                     branch,
@@ -1149,9 +1204,7 @@ class GitHubAsync:
                     continue
                 # Check if this ruleset applies to our branch
                 conditions = detail.get("conditions", {})
-                if isinstance(
-                    conditions, dict
-                ) and not self._ruleset_applies_to_branch(
+                if isinstance(conditions, dict) and not self._ruleset_applies_to_branch(
                     conditions, branch, default_branch
                 ):
                     continue
@@ -1174,8 +1227,7 @@ class GitHubAsync:
                             return True
         except Exception as e:
             self.log.debug(
-                "Error checking rulesets for signature requirement on "
-                "%s/%s:%s: %s",
+                "Error checking rulesets for signature requirement on %s/%s:%s: %s",
                 owner,
                 repo,
                 branch,
@@ -1207,8 +1259,6 @@ class GitHubAsync:
         If the conditions dict is empty or missing ``ref_name`` the
         ruleset is assumed to apply (conservative).
         """
-        import fnmatch
-
         ref_name = conditions.get("ref_name", {})
         if not isinstance(ref_name, dict):
             return True  # No conditions — assume applies
@@ -1218,27 +1268,49 @@ class GitHubAsync:
 
         full_ref = f"refs/heads/{branch}"
 
-        def _matches(pattern: str) -> bool:
-            if pattern == "~ALL":
-                return True
-            if pattern == "~DEFAULT_BRANCH":
-                if default_branch is None:
-                    # Unknown default branch — conservatively assume match
-                    return True
-                return branch == default_branch
-            # Normalise bare branch names to full refs
-            pat = pattern if pattern.startswith("refs/") else f"refs/heads/{pattern}"
-            return fnmatch.fnmatchcase(full_ref, pat)
-
         # Must match at least one include pattern (if any are specified)
-        if include and not any(_matches(p) for p in include if isinstance(p, str)):
+        if include and not any(
+            GitHubAsync._ref_pattern_matches(p, branch, full_ref, default_branch)
+            for p in include
+            if isinstance(p, str)
+        ):
             return False
 
         # Must not match any exclude pattern
-        if any(_matches(p) for p in exclude if isinstance(p, str)):
+        if any(
+            GitHubAsync._ref_pattern_matches(p, branch, full_ref, default_branch)
+            for p in exclude
+            if isinstance(p, str)
+        ):
             return False
 
         return True
+
+    @staticmethod
+    def _ref_pattern_matches(
+        pattern: str,
+        branch: str,
+        full_ref: str,
+        default_branch: str | None,
+    ) -> bool:
+        """Check whether a single ruleset ref pattern matches *branch*.
+
+        Defined as a static helper method (rather than a closure inside
+        ``_ruleset_applies_to_branch``) so it is not re-created on every
+        call and can be reused across the include/exclude comprehensions.
+        """
+        import fnmatch
+
+        if pattern == "~ALL":
+            return True
+        if pattern == "~DEFAULT_BRANCH":
+            if default_branch is None:
+                # Unknown default branch — conservatively assume match
+                return True
+            return branch == default_branch
+        # Normalise bare branch names to full refs
+        pat = pattern if pattern.startswith("refs/") else f"refs/heads/{pattern}"
+        return fnmatch.fnmatchcase(full_ref, pat)
 
     async def get_required_status_checks(
         self, owner: str, repo: str, branch: str
@@ -1268,9 +1340,7 @@ class GitHubAsync:
 
         # Try rulesets first (org-level and repo-level)
         try:
-            rulesets = await self.get(
-                f"/repos/{owner}/{repo}/rulesets?per_page=100"
-            )
+            rulesets = await self.get(f"/repos/{owner}/{repo}/rulesets?per_page=100")
             if isinstance(rulesets, list):
                 for ruleset in rulesets:
                     if not isinstance(ruleset, dict):
@@ -1303,12 +1373,8 @@ class GitHubAsync:
                                 continue
                             if rule.get("type") == "required_status_checks":
                                 params = rule.get("parameters", {})
-                                for check in params.get(
-                                    "required_status_checks", []
-                                ):
-                                    if isinstance(check, dict) and check.get(
-                                        "context"
-                                    ):
+                                for check in params.get("required_status_checks", []):
+                                    if isinstance(check, dict) and check.get("context"):
                                         ctx = check["context"]
                                         if ctx not in seen_contexts:
                                             seen_contexts.add(ctx)
@@ -1500,7 +1566,11 @@ class GitHubAsync:
 
             try:
                 # Perform a lightweight check for each operation
-                if operation in ("approve", "merge", "close", "update_branch") and owner and repo:
+                if (
+                    operation in ("approve", "merge", "close", "update_branch")
+                    and owner
+                    and repo
+                ):
                     # Use the collaborator permission endpoint to verify
                     # the token has write access to this specific repo.
                     #
@@ -1562,13 +1632,9 @@ class GitHubAsync:
                     # success.
                     default_branch = "main"
                     try:
-                        repo_data = await self.get(
-                            f"/repos/{owner}/{repo}"
-                        )
+                        repo_data = await self.get(f"/repos/{owner}/{repo}")
                         if isinstance(repo_data, dict):
-                            default_branch = repo_data.get(
-                                "default_branch", "main"
-                            )
+                            default_branch = repo_data.get("default_branch", "main")
                     except Exception:
                         # Repo metadata fetch failed — token may lack
                         # access.  Let the error propagate to the outer
@@ -1792,14 +1858,18 @@ class GitHubAsync:
 
         if missing_required_checks:
             if len(missing_required_checks) == 1:
-                return f"Blocked by missing required status: {missing_required_checks[0]}"
+                return (
+                    f"Blocked by missing required status: {missing_required_checks[0]}"
+                )
             else:
                 names = ", ".join(missing_required_checks)
                 return f"Blocked by {len(missing_required_checks)} missing required statuses: {names}"
 
         if pending_required_checks:
             if len(pending_required_checks) == 1:
-                return f"Blocked by pending required check: {pending_required_checks[0]}"
+                return (
+                    f"Blocked by pending required check: {pending_required_checks[0]}"
+                )
             else:
                 names = ", ".join(pending_required_checks)
                 return f"Blocked by {len(pending_required_checks)} pending required checks: {names}"
@@ -1879,9 +1949,13 @@ class GitHubAsync:
         cutoff = current_time - self._error_window
         recent_errors = [e for t, e in self._error_history if t > cutoff]
 
-        # Estimate request rate (very rough heuristic)
-        # Assume we made approximately len(history) * 10 requests in the window
-        estimated_requests = max(len(recent_errors) * 10, 1)
+        # Estimate request rate (very rough heuristic): we only track
+        # errors, not total requests, so assume each error accompanied
+        # ``_ESTIMATED_REQUESTS_PER_ERROR`` requests in the window. See the
+        # constant's definition for the rationale and tuning guidance.
+        estimated_requests = max(
+            len(recent_errors) * self._ESTIMATED_REQUESTS_PER_ERROR, 1
+        )
         return len(recent_errors) / estimated_requests
 
     def _apply_retry_after_throttling(self, retry_after_seconds: float) -> None:

--- a/src/dependamerge/gitreview.py
+++ b/src/dependamerge/gitreview.py
@@ -147,6 +147,20 @@ def parse_gitreview(text: str) -> GitReviewInfo | None:
     * The ``[gerrit]`` section header itself is **not** required —
       the parser matches the key lines directly.
 
+    Inline comments are **not** supported. The ``.gitreview`` format
+    (as consumed by ``git-review``) is not a commented INI dialect, so
+    ``#`` and ``;`` are ordinary characters. Consequently:
+
+    * ``host=`` and ``project=`` capture the entire remainder of the
+      line as the value, so any trailing ``# comment`` becomes part of
+      the value (e.g. ``host=h # primary`` yields ``"h # primary"``).
+    * ``port=`` matches digits only, so a line carrying a trailing
+      comment fails to match and the parser falls back to
+      :data:`DEFAULT_GERRIT_PORT` rather than raising.
+
+    This mirrors ``git-review``'s own behaviour and is deliberately
+    distinct from the netrc parser, which *does* strip inline comments.
+
     Args:
         text: Raw text content of a ``.gitreview`` file.
 

--- a/src/dependamerge/merge_manager.py
+++ b/src/dependamerge/merge_manager.py
@@ -100,6 +100,11 @@ class MergeResult:
     pr_info: PullRequestInfo
     status: MergeStatus
     error: str | None = None
+    # Non-fatal note attached to a *successful* (or otherwise non-error)
+    # outcome — e.g. a preview MERGED result for a PR that is behind its
+    # base branch and would be rebased first. Kept separate from ``error``
+    # so a MERGED status never carries a contradictory error message.
+    warning: str | None = None
     attempts: int = 0
     duration: float = 0.0
 
@@ -1438,7 +1443,9 @@ class AsyncMergeManager:
                 elif pr_info.mergeable_state == "behind" and self.fix_out_of_date:
                     # For behind PRs with fix enabled, show warning with rebase info
                     result.status = MergeStatus.MERGED  # Would succeed after rebase
-                    result.error = "behind base branch"
+                    # Use ``warning`` (not ``error``) so the MERGED result
+                    # does not carry a contradictory error message.
+                    result.warning = "behind base branch"
                     if self.progress_tracker:
                         self.progress_tracker.merge_success()
                     self._console.print(

--- a/src/dependamerge/resolve_conflicts.py
+++ b/src/dependamerge/resolve_conflicts.py
@@ -181,15 +181,13 @@ class FixOrchestrator:
 
         base = data.get("base") or {}
         head = data.get("head") or {}
-        base_repo = (base.get("repo") or {}) or {}
-        head_repo = (head.get("repo") or {}) or {}
+        base_repo = base.get("repo") or {}
+        head_repo = head.get("repo") or {}
 
-        base_branch = (base.get("ref") or "") or ""
-        head_branch = (head.get("ref") or "") or ""
-        base_full = (
-            base_repo.get("full_name") or f"{owner}/{repo}"
-        ) or f"{owner}/{repo}"
-        head_full = (head_repo.get("full_name") or base_full) or base_full
+        base_branch = base.get("ref") or ""
+        head_branch = head.get("ref") or ""
+        base_full = base_repo.get("full_name") or f"{owner}/{repo}"
+        head_full = head_repo.get("full_name") or base_full
         base_clone = base_repo.get("clone_url") or f"https://github.com/{base_full}.git"
         head_clone = head_repo.get("clone_url") or base_clone
         is_fork = bool(head_repo.get("fork")) if head_repo else False

--- a/tests/test_behind_pr_handling.py
+++ b/tests/test_behind_pr_handling.py
@@ -66,9 +66,12 @@ class TestBehindPRHandling:
                 with patch.object(merge_manager, "_approve_pr", return_value=None):
                     result = await merge_manager._merge_single_pr(pr_info)
 
-        # Should succeed with indication that rebase would happen
+        # Should succeed with indication that rebase would happen.
+        # A MERGED result must not carry an ``error``; the behind-base
+        # note is surfaced via the dedicated ``warning`` field instead.
         assert result.status == MergeStatus.MERGED
-        assert result.error == "behind base branch"
+        assert result.error is None
+        assert result.warning == "behind base branch"
 
     @pytest.mark.asyncio
     async def test_preview_detects_behind_pr_with_fix_disabled(self):
@@ -260,11 +263,12 @@ class TestBehindPRHandling:
         assert result.status == MergeStatus.FAILED
         assert "Failed to rebase PR" in result.error
 
-        # Verify rebase was attempted
-        mock_client.update_branch.assert_called_once_with("org", "repo", 123)
-
-        # Verify merge was not attempted after rebase failure
+        # Rollback behaviour: a failed rebase must abort the flow before
+        # the merge step, so merge_pull_request is never called.
         mock_client.merge_pull_request.assert_not_called()
+
+        # Verify rebase was attempted exactly once
+        mock_client.update_branch.assert_called_once_with("org", "repo", 123)
 
     @pytest.mark.asyncio
     async def test_merge_requirements_check_for_behind_pr(self):
@@ -543,9 +547,12 @@ class TestBehindPRHandling:
         # Verify exactly one print call was made (single-line output)
         assert mock_console.print.call_count == 1
 
-        # Verify the output format includes warning and reason
+        # Verify the *semantic content* of the single-line preview rather
+        # than its exact structure/wording. This keeps the test robust to
+        # cosmetic output changes (reordering, relabelling, emoji tweaks):
+        # the line must be surfaced as a warning, identify the PR, and
+        # explain that it is behind its base branch.
         call_args = mock_console.print.call_args[0][0]
-        assert "⚠️" in call_args
-        assert "Rebase/merge:" in call_args
-        assert "behind base branch" in call_args
-        assert pr_info.html_url in call_args
+        assert "⚠️" in call_args  # surfaced as a warning
+        assert pr_info.html_url in call_args  # identifies the PR
+        assert "behind" in call_args.lower()  # explains the reason

--- a/tests/test_dependabot_recreate.py
+++ b/tests/test_dependabot_recreate.py
@@ -171,11 +171,17 @@ class TestCheckPrCommitSignatures:
 
     @pytest.mark.asyncio
     async def test_unexpected_response_shape(self):
-        """Non-list response should be treated as all verified."""
+        """Non-list response should raise rather than feign verification.
+
+        Returning ``(True, [])`` for an unexpected shape was misleading:
+        it claimed every commit was verified when the actual state was
+        unknown. The method now raises so callers can decide how to
+        handle the uncertainty explicitly.
+        """
         api = AsyncMock(spec=GitHubAsync)
         api.get_paginated = lambda *a, **kw: _async_gen({"unexpected": "dict"})
-        result = await GitHubAsync.check_pr_commit_signatures(api, "owner", "repo", 42)
-        assert result == (True, [])
+        with pytest.raises(RuntimeError, match="Unexpected response shape"):
+            await GitHubAsync.check_pr_commit_signatures(api, "owner", "repo", 42)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_gitreview.py
+++ b/tests/test_gitreview.py
@@ -512,10 +512,29 @@ class TestEdgeCases:
         assert info.is_valid is False
 
     def test_parse_captures_inline_comments_as_value(self) -> None:
-        """INI-style comments after values are NOT standard for .gitreview.
-        The parser should capture the full line after '=' and strip it,
-        so an inline comment becomes part of the value."""
+        """Inline comments are NOT supported for ``.gitreview``.
+
+        The parser captures the full line after ``=`` (minus surrounding
+        whitespace), so a trailing ``# comment`` becomes part of the
+        value. This is intentional — see ``parse_gitreview``'s docstring
+        for the rationale (``.gitreview`` is not a commented INI dialect).
+        """
         text = "[gerrit]\nhost=gerrit.example.org # primary\nport=29418\n"
         info = parse_gitreview(text)
         assert info is not None
         assert info.host == "gerrit.example.org # primary"
+
+    def test_inline_comment_on_port_falls_back_to_default(self) -> None:
+        """A trailing comment makes the consequence of no comment support
+        visible: because ``port=`` matches digits only, a commented port
+        line fails to match and the parser falls back to the default port
+        rather than raising. This is the same lack of comment support as
+        ``test_parse_captures_inline_comments_as_value``, surfaced on a
+        field whose stricter pattern rejects the malformed value.
+        """
+        text = "[gerrit]\nhost=gerrit.example.org\nport=29418 # primary\n"
+        info = parse_gitreview(text)
+        assert info is not None
+        assert info.host == "gerrit.example.org"
+        # The commented port line does not match ``\\d+$`` and is ignored.
+        assert info.port == DEFAULT_GERRIT_PORT

--- a/tests/test_stuck_check_detection.py
+++ b/tests/test_stuck_check_detection.py
@@ -209,6 +209,8 @@ class TestDetectStuckDcoCheckRuns:
         is_stuck, name, age = await mgr._detect_stuck_required_check(pr)
         assert is_stuck is False
         assert name is None
+        # Non-stuck outcomes always report a zero age (no candidate check).
+        assert age == 0.0
 
     @pytest.mark.asyncio
     async def test_stuck_non_dco_non_required_check_is_ignored(self) -> None:
@@ -241,6 +243,8 @@ class TestDetectStuckDcoCheckRuns:
         is_stuck, name, age = await mgr._detect_stuck_required_check(pr)
         assert is_stuck is False
         assert name is None
+        # Non-stuck outcomes always report a zero age (no candidate check).
+        assert age == 0.0
 
     @pytest.mark.asyncio
     async def test_detects_stuck_required_non_dco_check(self) -> None:
@@ -354,6 +358,8 @@ class TestDetectStuckDcoCheckRuns:
         is_stuck, name, age = await mgr._detect_stuck_required_check(pr)
         assert is_stuck is False
         assert name is None
+        # Non-stuck outcomes always report a zero age (floor blocks detection).
+        assert age == 0.0
 
     @pytest.mark.asyncio
     async def test_naive_pr_timestamp_does_not_crash(self) -> None:


### PR DESCRIPTION
## Summary

Addresses all the AI "Code quality" findings raised by the preview code-review
service across the async GitHub client, the conflict-resolution helper, and
three test files.

### `src/dependamerge/github_async.py`

- **Magic number `20`** — Introduce a named `_DEFAULT_MAX_CONCURRENCY`
  constant used by both the constructor default and the adaptive-tuning
  ramp-up bound, making the relationship explicit.
- **`merge_pull_request` complexity** — Extract the response-body
  extraction and PR-state validation into the `_extract_github_error_detail`
  and `_validate_merge_result` helpers, removing the deeply nested
  try/except blocks. Behaviour is preserved (the original error text, which
  carries the HTTP status line used for retry classification, is retained).
- **Misleading `(True, [])`** — `check_pr_commit_signatures` now raises on
  an unexpected response shape instead of silently claiming every commit is
  verified, so callers can handle the unknown state explicitly.
- **`_matches` closure** — Hoisted out of `_ruleset_applies_to_branch` into
  the static `_ref_pattern_matches` helper so it is not recreated on every
  call.
- **Error-rate magic number `10`** — Named and documented via the new
  `_ESTIMATED_REQUESTS_PER_ERROR` constant.

### `src/dependamerge/resolve_conflicts.py`

- Removed the redundant double `or {}` / `or ""` fallback chaining in
  `_fetch_one_pr`.

### Test files

- **`tests/test_behind_pr_handling.py`** — A preview `MERGED` result no
  longer carries a contradictory `error`: added a dedicated
  `MergeResult.warning` field and surface the behind-base note there.
  Moved the rollback (`merge not attempted`) assertion next to the failure
  check, and validate the single-line preview by semantic content instead
  of brittle exact-string matching.
- **`tests/test_stuck_check_detection.py`** — Added `age == 0.0` assertions
  to the three non-stuck cases for complete validation of the returned
  tuple.
- **`tests/test_gitreview.py` / `gitreview.py`** — Documented that inline
  comments are intentionally unsupported in `parse_gitreview`, and added a
  test showing the consequence (a commented `port` line falls back to the
  default port).

### Copilot review

Four findings raised across the review cycles (error-rate comment math,
exception-chaining via bare `raise`, helper docstring wording, and ramping
adaptive concurrency to the caller-configured `_base_max_concurrency`
instead of the class default) were all addressed and resolved. The final
review returned no new comments.

## Validation

- `ruff check` / `ruff format` — clean
- `mypy` — clean
- `pytest tests/` — 987 passed