### PR TITLE
Refactor: Attempt-first merges with required-review detection

### DIFF
--- a/src/dependamerge/cli.py
+++ b/src/dependamerge/cli.py
@@ -487,6 +487,27 @@ def _fetch_and_validate_source_pr(ctx: _MergeContext) -> None:
     )
 
 
+def _source_pr_modifies_workflows(ctx: _MergeContext) -> bool:
+    """Return True when the source PR changes GitHub Actions workflow files.
+
+    Merging such a PR through the REST API requires the classic
+    ``workflow`` token scope (or the fine-grained ``Workflows: Read and
+    write`` permission), which is a *separate* gate from plain repository
+    write access.  Detecting this up-front lets the pre-flight check verify
+    the scope instead of failing only at merge time.
+    """
+    source_pr = ctx.source_pr
+    if source_pr is None:
+        return False
+    for change in source_pr.files_changed:
+        path = getattr(change, "filename", "") or ""
+        if path.startswith(".github/workflows/") and path.endswith(
+            (".yml", ".yaml")
+        ):
+            return True
+    return False
+
+
 def _check_merge_permissions(ctx: _MergeContext) -> None:
     """Pre-flight token permission check.
 
@@ -499,6 +520,11 @@ def _check_merge_permissions(ctx: _MergeContext) -> None:
             operations = ["approve", "merge", "branch_protection"]
             if not ctx.no_fix:
                 operations.append("update_branch")
+            # Only assert the workflow scope when the source PR actually
+            # touches workflow files.  The check is a no-op (passes) for
+            # fine-grained / app tokens whose scopes cannot be introspected.
+            if _source_pr_modifies_workflows(ctx):
+                operations.append("merge_workflow")
             return await client.check_token_permissions(
                 operations, ctx.owner, ctx.repo_name
             )

--- a/src/dependamerge/cli.py
+++ b/src/dependamerge/cli.py
@@ -84,7 +84,7 @@ MAX_RETRIES = 2
 def version_callback(value: bool):
     """Callback to show version and exit."""
     if value:
-        console.print(f"🏷️  dependamerge version {__version__}")
+        console.print(f"🏷️ dependamerge version {__version__}")
         raise typer.Exit()
 
 
@@ -94,7 +94,7 @@ class CustomTyper(typer.Typer):
     def __call__(self, *args, **kwargs):
         # Check if help is being requested
         if "--help" in sys.argv or "-h" in sys.argv:
-            console.print(f"🏷️  dependamerge version {__version__}")
+            console.print(f"🏷️ dependamerge version {__version__}")
         return super().__call__(*args, **kwargs)
 
 
@@ -408,7 +408,7 @@ def _validate_merge_inputs(
         raise typer.Exit(1)
 
     if force == "all":
-        console.print("⚠️  Warning: Using --force=all will bypass most safety checks.")
+        console.print("⚠️ Warning: Using --force=all will bypass most safety checks.")
         console.print("   This may attempt merges that will fail at GitHub API level.")
 
     return github2gerrit_mode
@@ -594,7 +594,7 @@ def _check_merge_permissions(ctx: _MergeContext) -> None:
         # the required permissions.
         raise
     except Exception as e:
-        console.print(f"⚠️  Could not verify permissions: {e}")
+        console.print(f"⚠️ Could not verify permissions: {e}")
         console.print("   Continuing anyway...")
 
 
@@ -701,7 +701,7 @@ def _scan_and_find_similar(ctx: _MergeContext) -> None:
         )
         console.print(f"🔍 Found {similar_prs_found} similar PRs")
         if errors_count > 0:
-            console.print(f"⚠️  {errors_count} errors encountered during analysis")
+            console.print(f"⚠️ {errors_count} errors encountered during analysis")
         # The trailing blank line delineates the similar-PR list that
         # follows.  When no similar PRs were found there is no list to
         # separate, so the blank line is suppressed (see below).
@@ -842,7 +842,7 @@ def _handle_preview_confirmation(
 
     try:
         if "pytest" in sys.modules or os.getenv("TESTING"):
-            console.print("⚠️  Test mode detected - skipping interactive prompt")
+            console.print("⚠️ Test mode detected - skipping interactive prompt")
             return
 
         user_input = input(
@@ -897,7 +897,7 @@ def _execute_confirmed_merge(
         parts.append(f"{final_skipped} skipped")
     console.print(f"\n🚀 Final Results: {', '.join(parts)}")
     if final_skipped > 0:
-        console.print(f"⏭️  Skipped {final_skipped} PRs")
+        console.print(f"⏭️ Skipped {final_skipped} PRs")
     if final_blocked > 0:
         console.print(f"🛑 Blocked {final_blocked} PRs")
     if final_auto_merge > 0:
@@ -995,7 +995,7 @@ def _display_merge_results(
         else:
             console.print(f"❌ Failed {failed_count} PRs")
     if skipped_count > 0:
-        console.print(f"⏭️  Skipped {skipped_count} PRs")
+        console.print(f"⏭️ Skipped {skipped_count} PRs")
     if blocked_count > 0:
         console.print(f"🛑 Blocked {blocked_count} PRs")
     if auto_merge_count > 0:
@@ -1133,7 +1133,7 @@ def _handle_repo_merge(
     # because --include-human-prs was supplied.
     needs_human_confirm = bool(human_prs) and not ctx.no_confirm
     if needs_human_confirm:
-        console.print("\n⚠️  Human-authored PRs are included in this merge operation.")
+        console.print("\n⚠️ Human-authored PRs are included in this merge operation.")
         console.print("   Review the list above carefully before proceeding.")
         try:
             user_input = (
@@ -1146,7 +1146,7 @@ def _handle_repo_merge(
                 .lower()
             )
             if user_input != "yes":
-                console.print("ℹ️  Excluding human PRs from merge.")
+                console.print("ℹ️ Excluding human PRs from merge.")
                 # Remove human PRs from the working set
                 repo_prs = automation_prs
                 if not repo_prs:
@@ -1315,7 +1315,7 @@ def _execute_repo_confirmed_merge(
         parts.append(f"{final_skipped} skipped")
     console.print(f"\n🚀 Final Results: {', '.join(parts)}")
     if final_skipped > 0:
-        console.print(f"⏭️  Skipped {final_skipped} PRs")
+        console.print(f"⏭️ Skipped {final_skipped} PRs")
     if final_blocked > 0:
         console.print(f"🛑 Blocked {final_blocked} PRs")
     if final_auto_merge > 0:
@@ -1355,7 +1355,7 @@ def _handle_gerrit_merge(
             netrc_file=netrc_file,
         )
     except NetrcParseError as e:
-        console.print(f"⚠️  Error parsing .netrc file: {e}")
+        console.print(f"⚠️ Error parsing .netrc file: {e}")
         credentials = None
 
     if credentials is None or not credentials.is_valid:
@@ -1385,7 +1385,7 @@ def _handle_gerrit_merge(
         )
 
         if not service.is_authenticated:
-            console.print("⚠️  Warning: Service created but may not be authenticated")
+            console.print("⚠️ Warning: Service created but may not be authenticated")
 
         # Get the source change info
         console.print(f"📋 Fetching change {parsed_url.change_number}...")
@@ -1412,7 +1412,7 @@ def _handle_gerrit_merge(
 
         # Check for merge conflicts and attempt rebase if needed
         if source_change.mergeable is False:
-            console.print("\n⚠️  Change has merge conflicts. Attempting to rebase...")
+            console.print("\n⚠️ Change has merge conflicts. Attempting to rebase...")
             rebase_result = service.rebase_change(source_change.number)
 
             if rebase_result["success"]:
@@ -1475,7 +1475,7 @@ def _handle_gerrit_merge(
         # and warn if the user may not have sufficient permissions
         permission_warnings = source_change.get_permission_warnings()
         if permission_warnings:
-            console.print("\n⚠️  Permission warnings:")
+            console.print("\n⚠️ Permission warnings:")
             for warning in permission_warnings:
                 console.print(f"   • {warning}")
             console.print(
@@ -1494,7 +1494,7 @@ def _handle_gerrit_merge(
                 )
             else:
                 console.print(
-                    "   ⚠️  You may not have all required permissions (see warnings above)"
+                    "   ⚠️ You may not have all required permissions (see warnings above)"
                 )
             console.print("\nTo proceed, run with --no-confirm flag")
             return
@@ -2010,7 +2010,7 @@ def _print_debug_matching(ctx: _MergeContext) -> None:
             f"{ctx.comparator._is_dependabot_body(ctx.source_pr.body)}"
         )
     else:
-        console.print("   ⚠️  Source PR has no body")
+        console.print("   ⚠️ Source PR has no body")
     console.print()
 
 
@@ -2136,7 +2136,7 @@ def close(
                     f"   Is dependabot body: {comparator._is_dependabot_body(source_pr.body)}"
                 )
             else:
-                console.print("   ⚠️  Source PR has no body")
+                console.print("   ⚠️ Source PR has no body")
             console.print()
 
         # Check if source PR is from automation or has valid override
@@ -2231,7 +2231,7 @@ def close(
             )
             console.print(f"🔍 Found {similar_prs_found} similar PRs")
             if errors_count > 0:
-                console.print(f"⚠️  {errors_count} errors encountered during analysis")
+                console.print(f"⚠️ {errors_count} errors encountered during analysis")
             console.print()
         else:
             console.print(f"\n🔍 Found {len(all_similar_prs)} similar PRs")
@@ -2310,7 +2310,7 @@ def close(
                     # Check if in test mode (don't prompt during tests)
                     if "pytest" in sys.modules or os.getenv("TESTING"):
                         console.print(
-                            "⚠️  Test mode detected - skipping interactive prompt"
+                            "⚠️ Test mode detected - skipping interactive prompt"
                         )
                         return
 
@@ -2504,7 +2504,7 @@ def status(
     except KeyboardInterrupt:
         if progress_tracker:
             progress_tracker.stop()
-        console.print("\n⚠️  Scan interrupted by user")
+        console.print("\n⚠️ Scan interrupted by user")
         raise typer.Exit(130) from None
     except Exception as e:
         if progress_tracker:
@@ -2645,7 +2645,7 @@ def blocked(
                 f"📊 Analyzed {total_prs_analyzed} PRs across {completed_repositories} repositories"
             )
             if errors_count > 0:
-                console.print(f"⚠️  {errors_count} errors encountered during check")
+                console.print(f"⚠️ {errors_count} errors encountered during check")
             console.print()  # Add blank line before results
 
         # Display results

--- a/src/dependamerge/copilot_handler.py
+++ b/src/dependamerge/copilot_handler.py
@@ -194,7 +194,7 @@ class CopilotCommentHandler:
         # Skip COMMENTED reviews as they cannot be dismissed via GitHub API
         if review_state == "COMMENTED":
             self.log.info(
-                f"⏭️  Skipping COMMENTED Copilot review {review_id} (GitHub API limitation)"
+                f"⏭️ Skipping COMMENTED Copilot review {review_id} (GitHub API limitation)"
             )
             return True  # Return True as this is expected behavior, not a failure
 
@@ -235,7 +235,7 @@ class CopilotCommentHandler:
                     for error in errors
                 ):
                     self.log.info(
-                        f"⏭️  Cannot dismiss COMMENTED review {review_id} - this is a GitHub API limitation"
+                        f"⏭️ Cannot dismiss COMMENTED review {review_id} - this is a GitHub API limitation"
                     )
                     return True  # Treat as success since this is expected
                 else:
@@ -248,7 +248,7 @@ class CopilotCommentHandler:
             # Check if the error message contains the "commented review" limitation
             if "Can not dismiss a commented pull request review" in str(e):
                 self.log.info(
-                    f"⏭️  Cannot dismiss COMMENTED review {review_id} - this is a GitHub API limitation"
+                    f"⏭️ Cannot dismiss COMMENTED review {review_id} - this is a GitHub API limitation"
                 )
                 return True  # Treat as success since this is expected
             else:
@@ -479,7 +479,7 @@ class CopilotCommentHandler:
 
         if not copilot_threads:
             self.log.warning(
-                f"⚠️  Failed to resolve comment/review thread {review_id} in {owner}/{repo}#{pr_number} (no resolvable Copilot threads)"
+                f"⚠️ Failed to resolve comment/review thread {review_id} in {owner}/{repo}#{pr_number} (no resolvable Copilot threads)"
             )
             return 0, len(all_threads)
 
@@ -686,7 +686,7 @@ class CopilotCommentHandler:
 
         except Exception as e:
             self.log.warning(
-                f"⚠️  Could not fetch review comments for PR {pr_number}: {e}"
+                f"⚠️ Could not fetch review comments for PR {pr_number}: {e}"
             )
             return []
 
@@ -710,7 +710,7 @@ class CopilotCommentHandler:
             # Individual comment resolution is now handled via GraphQL thread resolution
             # This method is deprecated in favor of resolve_copilot_threads_for_commented_review
             self.log.info(
-                f"ℹ️  Individual comment {comment.get('id')} handled via comprehensive thread resolution"
+                f"ℹ️ Individual comment {comment.get('id')} handled via comprehensive thread resolution"
             )
             return True
 

--- a/src/dependamerge/github_async.py
+++ b/src/dependamerge/github_async.py
@@ -266,6 +266,13 @@ class GitHubAsync:
         # Cache for the authenticated user's login (never changes during a session)
         self._authenticated_user_login: str | None = None
 
+        # Cache for the token's OAuth scopes.  ``_token_scopes_fetched``
+        # distinguishes "not looked up yet" from "looked up, but this token
+        # type does not expose scopes" (fine-grained PAT / app token, which
+        # leaves ``_token_scopes`` as ``None``).
+        self._token_scopes: set[str] | None = None
+        self._token_scopes_fetched: bool = False
+
         mounts = None
         if proxies:
             mounts = {}
@@ -783,6 +790,46 @@ class GitHubAsync:
             # Check for permission errors first (includes workflow scope check)
             perm_error = self._parse_permission_error(e, "merge", owner, repo)
             if perm_error:
+                # GitHub returns the "refusing to allow ... workflow" 403
+                # only when the *classic* token lacks the ``workflow``
+                # scope.  Before repeating that guidance, confirm the scope
+                # really is absent: if the token already carries it (or is a
+                # fine-grained/app token we cannot introspect and which
+                # therefore would not produce this classic-PAT message), the
+                # true cause is something else — typically a repository
+                # ruleset that restricts workflow-file updates, or an
+                # un-authorized SSO session.  Telling the user to add a scope
+                # they already hold would be an inaccurate diagnosis.
+                if perm_error.operation == "merge_workflow":
+                    has_workflow = await self.check_workflow_scope()
+                    if has_workflow is True:
+                        perm_error = PermissionError(
+                            operation="merge_workflow_restricted",
+                            message=(
+                                f"GitHub refused to merge PR in {owner}/{repo} "
+                                "even though the token already has the "
+                                "'workflow' scope. The workflow-file update is "
+                                "being blocked by something other than token "
+                                "scope"
+                            ),
+                            token_type_guidance={
+                                "classic": (
+                                    "Check for a repository ruleset that "
+                                    "restricts updates to .github/workflows/** "
+                                    "and confirm the token is SSO-authorized "
+                                    "for this organization"
+                                ),
+                                "fine_grained": (
+                                    "Check for a repository ruleset that "
+                                    "restricts updates to .github/workflows/**"
+                                ),
+                                "fix": (
+                                    "Review the repository's rulesets and "
+                                    "organization SSO authorization for this "
+                                    "token"
+                                ),
+                            },
+                        )
                 # Log the detailed error for debugging
                 self.log.debug(
                     f"Permission error merging PR #{number} in {owner}/{repo}: {perm_error}"
@@ -1526,6 +1573,65 @@ class GitHubAsync:
                 raise perm_error from e
             raise
 
+    async def get_token_scopes(self) -> set[str] | None:
+        """Return the OAuth scopes granted to a classic personal access token.
+
+        Classic PATs advertise their granted scopes in the
+        ``X-OAuth-Scopes`` response header on every authenticated request.
+        Fine-grained PATs and GitHub App installation tokens do **not** send
+        this header — their permission model is per-resource and cannot be
+        introspected this way.
+
+        Returns:
+            A ``set`` of scope strings for a classic PAT (possibly empty if
+            the token was created with no scopes selected), or ``None`` when
+            the token type does not expose scopes (fine-grained PAT / app
+            token) or the lookup could not be performed.  Callers MUST treat
+            ``None`` as "undeterminable", never as "no scopes granted".
+        """
+        if self._token_scopes_fetched:
+            return self._token_scopes
+
+        raw: str | None
+        try:
+            # Any authenticated REST endpoint echoes the header.
+            # ``/rate_limit`` is the cheapest and is itself exempt from the
+            # primary rate limit, so it never consumes quota.
+            r = await self._request("GET", f"{self.api_url}/rate_limit")
+            raw = r.headers.get("X-OAuth-Scopes")
+        except Exception as e:
+            self.log.debug("Could not determine token scopes: %s", e)
+            raw = None
+
+        if raw is None:
+            # Header absent → fine-grained / app token (or the probe
+            # failed).  Either way the scope set is undeterminable.
+            self._token_scopes = None
+        else:
+            # Header present (possibly empty for a scope-less classic PAT).
+            self._token_scopes = {s.strip() for s in raw.split(",") if s.strip()}
+        self._token_scopes_fetched = True
+        return self._token_scopes
+
+    async def check_workflow_scope(self) -> bool | None:
+        """Determine whether the token may update GitHub Actions workflows.
+
+        Merging a PR that touches ``.github/workflows/**`` requires the
+        classic ``workflow`` scope (or, for fine-grained PATs, the
+        ``Workflows: Read and write`` permission).
+
+        Returns:
+            ``True``  — classic PAT that carries the ``workflow`` scope.
+            ``False`` — classic PAT that is missing the ``workflow`` scope.
+            ``None``  — the token type cannot be introspected (fine-grained
+            PAT / app token).  The requirement cannot be verified up-front;
+            callers should defer to merge-time error handling.
+        """
+        scopes = await self.get_token_scopes()
+        if scopes is None:
+            return None
+        return "workflow" in scopes
+
     async def check_token_permissions(
         self, operations: list[str], owner: str = "", repo: str = ""
     ) -> dict[str, dict[str, Any]]:
@@ -1662,6 +1768,35 @@ class GitHubAsync:
                     if owner:
                         await self.get(f"/orgs/{owner}/repos?per_page=1")
                     result["has_permission"] = True
+
+                elif operation == "merge_workflow":
+                    # Verify the token may merge PRs that modify GitHub
+                    # Actions workflow files.  This is only checkable for
+                    # classic PATs, which advertise their scopes via the
+                    # ``X-OAuth-Scopes`` header.  Fine-grained PATs and app
+                    # tokens do not expose scopes, so the check returns
+                    # ``None`` and we pass it through here — the requirement
+                    # cannot be verified up-front for those token types and
+                    # is instead surfaced (with accurate guidance) by the
+                    # merge-time handler if it actually bites.
+                    has_workflow = await self.check_workflow_scope()
+                    if has_workflow is False:
+                        perms = OPERATION_PERMISSIONS.get("merge_workflow", {})
+                        result["error"] = (
+                            "Token is missing the 'workflow' scope, which is "
+                            "required to merge pull requests that modify "
+                            "GitHub Actions workflow files "
+                            "(.github/workflows/**)"
+                        )
+                        result["guidance"] = {
+                            "classic": perms.get("classic"),
+                            "fine_grained": perms.get("fine_grained"),
+                            "fix": "Run: gh auth refresh -h github.com -s workflow",
+                        }
+                    else:
+                        # ``True`` (scope present) or ``None``
+                        # (undeterminable token type) — do not block.
+                        result["has_permission"] = True
 
                 else:
                     result["error"] = f"Unknown operation: {operation}"
@@ -1821,6 +1956,10 @@ class GitHubAsync:
         # Detect missing/pending required status checks (e.g. stale pre-commit.ci)
         missing_required_checks: list[str] = []
         pending_required_checks: list[str] = []
+        # Default base branch; the block below refines it from the PR data
+        # and the fallback at the end of this method reuses it to classify
+        # what kind of rule is guarding the branch.
+        base_branch = "main"
         try:
             # Determine the base branch for this PR
             pr_data = await self.get(f"/repos/{owner}/{repo}/pulls/{number}")
@@ -1891,7 +2030,82 @@ class GitHubAsync:
         if not approved:
             return "Blocked by branch protection (requires approval)"
 
-        return "Blocked by branch protection"
+        # No self-describing blocker was found: checks pass, the PR is
+        # approved, and no changes are requested — yet GitHub still reports
+        # the PR as blocked.  Rather than *asserting* "branch protection"
+        # (which is invisible to this code path when the repository uses
+        # rulesets), determine what kind of rule actually guards the branch
+        # and keep the wording non-committal: we know the branch is guarded,
+        # not that a specific condition is failing.
+        kind = await self._detect_branch_protection_kind(owner, repo, base_branch)
+        if kind == "ruleset":
+            return (
+                "Blocked by repository ruleset "
+                "(no specific failing condition detected)"
+            )
+        if kind == "protection":
+            return (
+                "Blocked by branch protection "
+                "(no specific failing condition detected)"
+            )
+        return (
+            "Blocked for an undetermined reason "
+            "(GitHub reports the PR as blocked but no failing checks, "
+            "required reviews, or visible protection rules were found; "
+            "the repository may use rulesets this token cannot read)"
+        )
+
+    async def _detect_branch_protection_kind(
+        self, owner: str, repo: str, branch: str
+    ) -> str:
+        """Best-effort classification of what guards a branch.
+
+        Used by :meth:`analyze_block_reason` to describe an otherwise
+        unexplained ``BLOCKED`` state accurately instead of asserting
+        "branch protection".
+
+        Returns:
+            ``"ruleset"``    — one or more repository rulesets apply to the
+            branch (reported in preference to classic protection because
+            rulesets are invisible to the GraphQL ``branchProtectionRule``
+            field and are what most current repositories use).
+            ``"protection"`` — a classic branch protection rule applies.
+            ``"none"``       — neither could be found (the branch appears
+            unguarded, or the token cannot read the configuration).
+        """
+        # Repository rulesets (newer API): the effective-rules endpoint
+        # returns every rule that applies to the branch from any active
+        # ruleset.  A non-empty list means a ruleset guards the branch.
+        try:
+            rules = await self.get(
+                f"/repos/{owner}/{repo}/rules/branches/{branch}"
+            )
+            if isinstance(rules, list) and rules:
+                return "ruleset"
+        except Exception as e:
+            self.log.debug(
+                "Could not read branch rules for %s/%s:%s: %s",
+                owner,
+                repo,
+                branch,
+                e,
+            )
+
+        # Classic branch protection: 200 = protected, 404 = no rule.
+        try:
+            await self.get(f"/repos/{owner}/{repo}/branches/{branch}/protection")
+            return "protection"
+        except Exception as e:
+            if "404" not in str(e):
+                self.log.debug(
+                    "Could not read branch protection for %s/%s:%s: %s",
+                    owner,
+                    repo,
+                    branch,
+                    e,
+                )
+
+        return "none"
 
     # -----------------------
     # Optional REST pagination

--- a/src/dependamerge/github_async.py
+++ b/src/dependamerge/github_async.py
@@ -1592,20 +1592,25 @@ class GitHubAsync:
         if self._token_scopes_fetched:
             return self._token_scopes
 
-        raw: str | None
         try:
             # Any authenticated REST endpoint echoes the header.
             # ``/rate_limit`` is the cheapest and is itself exempt from the
             # primary rate limit, so it never consumes quota.
             r = await self._request("GET", f"{self.api_url}/rate_limit")
-            raw = r.headers.get("X-OAuth-Scopes")
         except Exception as e:
+            # A transient probe failure must NOT be cached as
+            # "undeterminable": doing so would let a one-off network error
+            # suppress accurate scope diagnosis for the rest of the run
+            # (a classic PAT that has ``workflow`` could still be reported
+            # as missing it).  Leave the cache unset so a later call can
+            # retry and produce an accurate result.
             self.log.debug("Could not determine token scopes: %s", e)
-            raw = None
+            return None
 
+        raw = r.headers.get("X-OAuth-Scopes")
         if raw is None:
-            # Header absent → fine-grained / app token (or the probe
-            # failed).  Either way the scope set is undeterminable.
+            # Header absent on a successful probe → fine-grained / app
+            # token.  The scope set is genuinely undeterminable; cache it.
             self._token_scopes = None
         else:
             # Header present (possibly empty for a scope-less classic PAT).
@@ -2040,13 +2045,11 @@ class GitHubAsync:
         kind = await self._detect_branch_protection_kind(owner, repo, base_branch)
         if kind == "ruleset":
             return (
-                "Blocked by repository ruleset "
-                "(no specific failing condition detected)"
+                "Blocked by repository ruleset (no specific failing condition detected)"
             )
         if kind == "protection":
             return (
-                "Blocked by branch protection "
-                "(no specific failing condition detected)"
+                "Blocked by branch protection (no specific failing condition detected)"
             )
         return (
             "Blocked for an undetermined reason "
@@ -2076,9 +2079,12 @@ class GitHubAsync:
         # Repository rulesets (newer API): the effective-rules endpoint
         # returns every rule that applies to the branch from any active
         # ruleset.  A non-empty list means a ruleset guards the branch.
+        # Branch names can contain '/' (e.g. ``release/v1``), so they must
+        # be URL-encoded before interpolation into the REST path.
+        encoded_branch = quote(branch, safe="")
         try:
             rules = await self.get(
-                f"/repos/{owner}/{repo}/rules/branches/{branch}"
+                f"/repos/{owner}/{repo}/rules/branches/{encoded_branch}"
             )
             if isinstance(rules, list) and rules:
                 return "ruleset"
@@ -2093,7 +2099,9 @@ class GitHubAsync:
 
         # Classic branch protection: 200 = protected, 404 = no rule.
         try:
-            await self.get(f"/repos/{owner}/{repo}/branches/{branch}/protection")
+            await self.get(
+                f"/repos/{owner}/{repo}/branches/{encoded_branch}/protection"
+            )
             return "protection"
         except Exception as e:
             if "404" not in str(e):

--- a/src/dependamerge/github_service.py
+++ b/src/dependamerge/github_service.py
@@ -740,9 +740,9 @@ class GitHubService:
 
                         if body_score < 0.6:
                             if target_pr.body is None:
-                                debug_console.print("      ⚠️  Target PR has no body")
+                                debug_console.print("      ⚠️ Target PR has no body")
                             elif source_pr.body is None:
-                                debug_console.print("      ⚠️  Source PR has no body")
+                                debug_console.print("      ⚠️ Source PR has no body")
                             else:
                                 debug_console.print(
                                     f"      📄 Body comparison failed (score: {body_score:.3f})"

--- a/src/dependamerge/merge_manager.py
+++ b/src/dependamerge/merge_manager.py
@@ -1214,8 +1214,6 @@ class AsyncMergeManager:
                 )
                 return result
 
-            result.status = MergeStatus.APPROVED
-
             # Step 5: Handle rebase if needed before merge.
             #
             # Dispatched to the dedicated ``rebase`` module so the

--- a/src/dependamerge/merge_manager.py
+++ b/src/dependamerge/merge_manager.py
@@ -1196,7 +1196,15 @@ class AsyncMergeManager:
                     )
                     copilot_processing_successful = False
 
-            # Step 3: Only approve if Copilot processing was successful
+            # Step 3: Gate on Copilot processing, but DO NOT approve
+            # up-front. Approval is now performed on demand (approve-on-
+            # demand): either just before arming auto-merge (see
+            # _enable_auto_merge_with_approval) or after a direct merge is
+            # rejected specifically for a missing review (see
+            # _approve_and_retry_if_review_required). This avoids approving
+            # PRs that did not actually need our review, while the Copilot
+            # gate below still prevents acting on a PR with unresolved
+            # Copilot feedback.
             if not copilot_processing_successful:
                 result.status = MergeStatus.FAILED
                 result.error = "Copilot review processing incomplete - not approving to avoid pollution"
@@ -1206,30 +1214,6 @@ class AsyncMergeManager:
                 )
                 return result
 
-            result.status = MergeStatus.APPROVING
-
-            if self.progress_tracker:
-                self.progress_tracker.update_operation(
-                    f"Approving PR {pr_info.number} in {pr_info.repository_full_name}"
-                )
-
-            if not self.preview_mode:
-                approval_added = await self._approve_pr(
-                    repo_owner, repo_name, pr_info.number
-                )
-                if approval_added:
-                    # Track that we just approved this PR so that the merge
-                    # retry logic knows a propagation delay may be needed.
-                    pr_key = f"{repo_owner}/{repo_name}#{pr_info.number}"
-                    self._recently_approved.add(pr_key)
-
-                    # Give GitHub time to propagate the approval to branch
-                    # protection evaluation before attempting the merge.
-                    if self._post_approval_delay > 0:
-                        self.log.debug(
-                            f"Waiting {self._post_approval_delay}s for approval propagation on {pr_key}"
-                        )
-                        await asyncio.sleep(self._post_approval_delay)
             result.status = MergeStatus.APPROVED
 
             # Step 5: Handle rebase if needed before merge.
@@ -1249,7 +1233,7 @@ class AsyncMergeManager:
                     log=self.log,
                     console=self._console,
                     rebased_prs=self._rebased_prs,
-                    enable_auto_merge=self._enable_auto_merge_for_pr,
+                    enable_auto_merge=self._enable_auto_merge_with_approval,
                 )
                 outcome = await rebase.perform_step5_rebase(
                     ctx=rebase_ctx,
@@ -1373,7 +1357,10 @@ class AsyncMergeManager:
 
             if should_wait:
                 if pr_key_for_wait not in self._auto_merge_enabled:
-                    auto_ok_pre = await self._enable_auto_merge_for_pr(
+                    # Approve-on-demand: arming auto-merge implies we want
+                    # the PR to merge once checks pass, so approve the
+                    # current head first (idempotent) before enabling.
+                    auto_ok_pre = await self._enable_auto_merge_with_approval(
                         pr_info, repo_owner, repo_name
                     )
                     if auto_ok_pre:
@@ -1624,6 +1611,17 @@ class AsyncMergeManager:
                             return await self._handle_merge_conflict(
                                 pr_info, repo_owner, repo_name, result
                             )
+
+                    # Approve-on-demand (merge-path trigger): if the
+                    # direct merge was rejected solely because our review
+                    # is missing, approve the current head and retry once.
+                    # Returns True only if the retry merged the PR; any
+                    # other failure is left for the classifier below.
+                    if not merged:
+                        if await self._approve_and_retry_if_review_required(
+                            pr_info, repo_owner, repo_name
+                        ):
+                            merged = True
 
                 if merged is None:
                     # Auto-merge is active — PR will merge asynchronously.
@@ -2285,6 +2283,142 @@ class AsyncMergeManager:
         )
         return True
 
+    async def _ensure_pr_approved(
+        self, pr_info: PullRequestInfo, owner: str, repo: str
+    ) -> bool:
+        """Approve the current PR head on demand and track the approval.
+
+        Thin wrapper around :meth:`_approve_pr` that also records the PR
+        in ``_recently_approved`` and applies the post-approval
+        propagation delay, exactly as the (now removed) up-front Step 3
+        approval used to.  :meth:`_approve_pr` is idempotent — it no-ops
+        when the current user already has an active ``APPROVED`` review on
+        the current head — so this is safe to call unconditionally at any
+        approve-on-demand trigger.
+
+        Returns:
+            True if a *new* approval was submitted, False if the PR was
+            already approved (or approval was declined).
+        """
+        approved = await self._approve_pr(owner, repo, pr_info.number)
+        if approved:
+            pr_key = f"{owner}/{repo}#{pr_info.number}"
+            self._recently_approved.add(pr_key)
+            # Give GitHub time to propagate the approval to the branch
+            # protection evaluation before a merge is attempted.
+            if self._post_approval_delay > 0:
+                self.log.debug(
+                    f"Waiting {self._post_approval_delay}s for approval "
+                    f"propagation on {pr_key}"
+                )
+                await asyncio.sleep(self._post_approval_delay)
+        return approved
+
+    async def _enable_auto_merge_with_approval(
+        self, pr_info: PullRequestInfo, owner: str, repo: str
+    ) -> bool:
+        """Approve the current head (if needed) then enable auto-merge.
+
+        Enabling auto-merge is a commitment to let GitHub complete the
+        merge as soon as branch protection is satisfied, so the current
+        head must already carry our approval — otherwise auto-merge would
+        wait forever on a missing review.  This is the *de-facto*
+        approve-on-demand trigger for the auto-merge path: when we enable
+        auto-merge on a PR whose current version we have not approved, we
+        approve it as part of arming auto-merge.
+
+        Approval failures other than typed permission errors are logged
+        and swallowed so a transient approval hiccup does not prevent us
+        from at least arming auto-merge; the permission error is
+        propagated so the caller's dedicated handler can report it.
+
+        Used at the Step 5.5 auto-merge enable point and as the rebase
+        module's auto-merge callback (which fires *after* the rebase, so
+        we approve the rebased head rather than a soon-to-be-dismissed
+        pre-rebase commit).
+        """
+        if not self.preview_mode:
+            try:
+                await self._ensure_pr_approved(pr_info, owner, repo)
+            except GitHubPermissionError:
+                # Surface token permission problems to the caller's
+                # dedicated handler rather than masking them here.
+                raise
+            except Exception as exc:
+                self.log.warning(
+                    "Could not approve %s/%s#%s before enabling auto-merge: %s",
+                    owner,
+                    repo,
+                    pr_info.number,
+                    exc,
+                )
+        return await self._enable_auto_merge_for_pr(pr_info, owner, repo)
+
+    async def _approve_and_retry_if_review_required(
+        self, pr_info: PullRequestInfo, owner: str, repo: str
+    ) -> bool:
+        """Approve-on-demand recovery after a failed direct merge.
+
+        This is the merge-path approve-on-demand trigger: rather than
+        approving every PR up-front, we attempt the merge first and only
+        approve when GitHub rejects it *specifically* because our review
+        is missing.  This avoids approving PRs that did not need it (e.g.
+        a PR that fails for an unrelated reason).
+
+        Called only after a direct merge attempt returned ``False``.  It
+        consults :meth:`analyze_block_reason`; if (and only if) the PR is
+        blocked pending approval and we have not already approved it this
+        run, it approves the current head and retries the merge once.
+
+        Returns:
+            True if the approve-then-retry merged the PR, False otherwise
+            (including when the failure was not approval-related, so the
+            caller can proceed to its normal failure handling).
+        """
+        if self.preview_mode or self._github_client is None:
+            return False
+
+        # A missing review manifests as the ``blocked`` mergeable state.
+        # A merge that fails from any other state (e.g. a transient 405 on
+        # a ``clean`` PR) is not an approval problem, so don't probe or
+        # approve it — let the caller's classifier handle it.
+        if pr_info.mergeable_state != "blocked":
+            return False
+
+        pr_key = f"{owner}/{repo}#{pr_info.number}"
+        if pr_key in self._recently_approved:
+            # We already approved this PR this run; the retry machinery in
+            # _merge_pr_with_retry has already had its post-approval
+            # propagation retry, so a missing approval is not the cause.
+            return False
+
+        try:
+            block_reason = await self._github_client.analyze_block_reason(
+                owner, repo, pr_info.number, pr_info.head_sha
+            )
+        except Exception as exc:
+            self.log.debug(
+                "approve-on-demand block-reason check failed for %s: %s",
+                pr_key,
+                exc,
+            )
+            return False
+
+        if not block_reason or "requires approval" not in block_reason.lower():
+            # The merge failed for some reason other than a missing
+            # review — do not approve; let the caller classify and report.
+            return False
+
+        self.log.debug(
+            "Merge for %s was blocked pending approval; approving on "
+            "demand and retrying",
+            pr_key,
+        )
+        approved = await self._ensure_pr_approved(pr_info, owner, repo)
+        if not approved:
+            return False
+        return await self._merge_pr_with_retry(pr_info, owner, repo)
+
     async def _check_merge_requirements(
         self, pr_info: PullRequestInfo
     ) -> tuple[bool, str]:
@@ -2346,62 +2480,70 @@ class AsyncMergeManager:
             # Don't fail the merge attempt if we can't check protection rules
             pass
 
-        # Test merge capability to detect hidden branch protection rules
-        try:
-            # Use pre-determined merge method for this repository
-            cache_key = f"{repo_owner}/{repo_name}"
-            merge_method = self._pr_merge_methods.get(
-                cache_key, self.default_merge_method
-            )
+        # Predictive merge probe. This is a *best-effort* dry-run verdict
+        # only: GitHub's mergeable_state can lag, and repository rulesets
+        # are invisible to it, so it must never gate the real merge. Run it
+        # only in preview mode to render the evaluation; the execution path
+        # is attempt-first and lets the actual merge response be
+        # authoritative (Step 6 + _merge_pr_with_retry).
+        if self.preview_mode:
+            try:
+                # Use pre-determined merge method for this repository
+                cache_key = f"{repo_owner}/{repo_name}"
+                merge_method = self._pr_merge_methods.get(
+                    cache_key, self.default_merge_method
+                )
 
-            # Attempt a test merge to detect hidden branch protection rules
-            test_result = await self._test_merge_capability(
-                repo_owner, repo_name, pr_info.number, merge_method
-            )
-            if not test_result[0]:
-                # Check if we should bypass protection rules
-                if self.force_level in ["code-owners", "protection-rules", "all"]:
-                    # Check if user has permissions to bypass before attempting
-                    if self._github_client:
-                        self.log.debug(
-                            f"Checking bypass permissions for {repo_owner}/{repo_name} with force_level={self.force_level}"
-                        )
-                        (
-                            can_bypass,
-                            bypass_reason,
-                        ) = await self._github_client.check_user_can_bypass_protection(
-                            repo_owner, repo_name, self.force_level
-                        )
-                        self.log.debug(
-                            f"Bypass check result: can_bypass={can_bypass}, reason={bypass_reason}"
-                        )
-                        if not can_bypass:
-                            self.log.warning(
-                                f"Cannot bypass branch protection for {repo_owner}/{repo_name}#{pr_info.number}: {bypass_reason}"
+                # Predict the outcome to detect hidden branch protection rules
+                test_result = await self._predict_merge_outcome(
+                    repo_owner, repo_name, pr_info.number, merge_method
+                )
+                if not test_result[0]:
+                    # Check if we should bypass protection rules
+                    if self.force_level in [
+                        "code-owners",
+                        "protection-rules",
+                        "all",
+                    ]:
+                        # Check bypass permissions before reporting success
+                        if self._github_client:
+                            self.log.debug(
+                                f"Checking bypass permissions for {repo_owner}/{repo_name} with force_level={self.force_level}"
                             )
-                            return (
-                                False,
-                                f"cannot bypass branch protection: {bypass_reason}",
+                            (
+                                can_bypass,
+                                bypass_reason,
+                            ) = await self._github_client.check_user_can_bypass_protection(
+                                repo_owner, repo_name, self.force_level
                             )
+                            self.log.debug(
+                                f"Bypass check result: can_bypass={can_bypass}, reason={bypass_reason}"
+                            )
+                            if not can_bypass:
+                                self.log.warning(
+                                    f"Cannot bypass branch protection for {repo_owner}/{repo_name}#{pr_info.number}: {bypass_reason}"
+                                )
+                                return (
+                                    False,
+                                    f"cannot bypass branch protection: {bypass_reason}",
+                                )
 
-                    # Only log during preview evaluation to avoid duplicate messages
-                    if self.preview_mode:
                         self.log.warning(
                             f"⚠️ Bypassing branch protection check for {repo_owner}/{repo_name}#{pr_info.number}: {test_result[1]} (--force={self.force_level})"
                         )
-                    # When bypassing, return early to allow merge to proceed
-                    return (
-                        True,
-                        f"branch protection check bypassed (--force={self.force_level})",
-                    )
-                else:
-                    return False, test_result[1]
+                        # When bypassing, return early to allow merge
+                        return (
+                            True,
+                            f"branch protection check bypassed (--force={self.force_level})",
+                        )
+                    else:
+                        return False, test_result[1]
 
-        except Exception as e:
-            # If we can't test merge, continue with other checks
-            self.log.debug(
-                f"Could not test merge capability for {repo_owner}/{repo_name}#{pr_info.number}: {e}"
-            )
+            except Exception as e:
+                # If we can't predict the outcome, continue with other checks
+                self.log.debug(
+                    f"Could not predict merge outcome for {repo_owner}/{repo_name}#{pr_info.number}: {e}"
+                )
 
         # Additional checks based on PR state
         if pr_info.mergeable_state == "blocked":
@@ -4371,8 +4513,13 @@ class AsyncMergeManager:
                 # Arm auto-merge when the PR is otherwise mergeable
                 # (not dirty) so it lands automatically once the stuck
                 # check is re-triggered, without a second review round.
+                # Approve the current head first (approve-on-demand): the
+                # PR is no longer approved up-front, so auto-merge would
+                # otherwise wait forever on a missing review.
                 if pr_info.mergeable_state != "dirty":
-                    await self._enable_auto_merge_for_pr(pr_info, owner, repo)
+                    await self._enable_auto_merge_with_approval(
+                        pr_info, owner, repo
+                    )
                 result.error = f"stuck check: {stuck_check}"
                 stuck_reported = True
 
@@ -4693,14 +4840,23 @@ class AsyncMergeManager:
                 self._org_settings_cache[owner] = None
                 return None
 
-    async def _test_merge_capability(
+    async def _predict_merge_outcome(
         self, owner: str, repo: str, pr_number: int, merge_method: str
     ) -> tuple[bool, str]:
-        """
-        Test if a PR can be merged by validating merge requirements.
+        """Best-effort, read-only prediction of whether a PR would merge.
 
-        This helps detect branch protection rules that aren't visible through the API,
-        such as organization-level restrictions.
+        This is a **preview-only** probe used to render the dry-run
+        evaluation.  It inspects the PR's ``mergeable`` / ``mergeable_state``
+        and, for ``blocked`` PRs, consults :meth:`analyze_block_reason` to
+        produce a one-line verdict.
+
+        It deliberately has **no authority over the real merge**: GitHub's
+        ``mergeable_state`` can lag the true state, and repository rulesets
+        are invisible to this code path, so a confident "would block"
+        verdict here can still be wrong.  The execution path therefore does
+        not gate on this prediction — it attempts the merge and treats
+        GitHub's actual response (Step 6 and ``_merge_pr_with_retry``) as
+        authoritative.  Only the preview path calls this method.
 
         Args:
             owner: Repository owner
@@ -4804,7 +4960,7 @@ class AsyncMergeManager:
         except Exception as e:
             error_msg = str(e)
             self.log.debug(
-                f"Exception in _test_merge_capability for {owner}/{repo}#{pr_number}: {error_msg}"
+                f"Exception in _predict_merge_outcome for {owner}/{repo}#{pr_number}: {error_msg}"
             )
 
             # Look for specific DCO-related errors in the GitHub API response

--- a/src/dependamerge/merge_manager.py
+++ b/src/dependamerge/merge_manager.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import asyncio
+import fnmatch
 import logging
 import math
 import os
@@ -13,6 +14,7 @@ from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
 from typing import Any, cast
+from urllib.parse import quote
 
 from rich.console import Console
 
@@ -226,6 +228,25 @@ class AsyncMergeManager:
         self._org_settings_locks: dict[str, asyncio.Lock] = {}
         self._org_settings_locks_lock = asyncio.Lock()
 
+        # Cache for "does this branch mandate an approving review before
+        # any merge" detection, keyed by "owner/repo@branch".  The answer
+        # is fixed for the lifetime of a run (rulesets don't change
+        # mid-merge), so the resolved verdict is reused for every PR
+        # targeting the same repo+branch.
+        self._branch_approval_cache: dict[str, bool] = {}
+        self._branch_approval_locks: dict[str, asyncio.Lock] = {}
+        self._branch_approval_locks_lock = asyncio.Lock()
+
+        # Cache for the organization-level approval requirement, enumerated
+        # once per org from its repository rulesets.  Value is the list of
+        # approval-mandating rulesets (each ``{"name", "conditions"}``),
+        # ``[]`` when the org mandates none, or ``None`` when enumeration
+        # failed (e.g. the token cannot read org rulesets) so callers know
+        # to consult the authoritative per-repo endpoint instead.
+        self._org_approval_cache: dict[str, list[dict[str, Any]] | None] = {}
+        self._org_approval_locks: dict[str, asyncio.Lock] = {}
+        self._org_approval_locks_lock = asyncio.Lock()
+
         # Track last merge exception per PR for better error reporting
         self._last_merge_exception: dict[str, Exception] = {}
 
@@ -354,6 +375,13 @@ class AsyncMergeManager:
             self.log.info(f"🔍 PREVIEW: Would merge {len(pr_list)} PRs")
         else:
             self.log.debug(f"Starting parallel merge of {len(pr_list)} PRs")
+            # Enumerate the org's approval requirement once, up-front, so
+            # the "organization mandates an approving review" line is shown
+            # before merging begins rather than mid-run.  All PRs in a run
+            # share the same org owner; the result is cached and reused by
+            # the per-PR proactive-approval check.
+            owner = pr_list[0][0].repository_full_name.split("/", 1)[0]
+            await self._org_approval_rulesets(owner)
 
         # Create tasks for all PRs
         tasks = []
@@ -1554,6 +1582,18 @@ class AsyncMergeManager:
                 if auto_merge_pending_checks:
                     merged = None  # Sentinel: auto-merge pending
                 else:
+                    # Proactive approval: some organizations mandate an
+                    # approving review via a repository ruleset before
+                    # *any* merge is allowed.  When this PR's base branch
+                    # is governed that way a merge-first attempt is
+                    # guaranteed to be rejected, so approve the current
+                    # head up-front and skip the doomed round-trip plus
+                    # reactive recovery.  See the helper for details; on
+                    # any lookup failure it no-ops and the reactive
+                    # approve-on-demand path still covers us.
+                    await self._approve_if_review_mandated(
+                        pr_info, repo_owner, repo_name, pr_key
+                    )
                     # Serialise the actual merge dispatch per repo so
                     # back-to-back merges don't race GitHub's branch
                     # protection propagation.  Workers on the same
@@ -2376,18 +2416,52 @@ class AsyncMergeManager:
         if self.preview_mode or self._github_client is None:
             return False
 
-        # A missing review manifests as the ``blocked`` mergeable state.
-        # A merge that fails from any other state (e.g. a transient 405 on
-        # a ``clean`` PR) is not an approval problem, so don't probe or
-        # approve it — let the caller's classifier handle it.
-        if pr_info.mergeable_state != "blocked":
-            return False
-
         pr_key = f"{owner}/{repo}#{pr_info.number}"
         if pr_key in self._recently_approved:
             # We already approved this PR this run; the retry machinery in
             # _merge_pr_with_retry has already had its post-approval
             # propagation retry, so a missing approval is not the cause.
+            return False
+
+        # Prefer GitHub's own merge-rejection body over the heuristic
+        # block-reason classifier.  When the merge endpoint refuses the
+        # merge it states the *authoritative* reason in the response body
+        # (captured in the stored exception), e.g. "Repository rule
+        # violations found Waiting on required approvals from <team>".
+        # The heuristic ``analyze_block_reason`` only reports a single,
+        # highest-priority reason and ranks the missing-approval condition
+        # below required-status checks, so an unrelated or false-positive
+        # "missing required status" (e.g. a DCO check GitHub does not
+        # actually gate the merge on) masks the real cause and the
+        # approve-on-demand recovery never fires.  Trust GitHub first.
+        #
+        # This authoritative check runs *regardless* of mergeable_state:
+        # that field lags and is blind to repository rulesets, so GitHub
+        # can reject a merge for a missing required approval even while the
+        # cached state is not ``blocked``.  Gating it behind a ``blocked``
+        # state would strand exactly the PRs this recovery exists to save.
+        last_exception = self._last_merge_exception.get(pr_key)
+        if last_exception is not None and self._merge_error_indicates_missing_approval(
+            str(last_exception)
+        ):
+            self.log.debug(
+                "Merge for %s was rejected by GitHub pending required "
+                "approval; approving on demand and retrying",
+                pr_key,
+            )
+            approved = await self._ensure_pr_approved(pr_info, owner, repo)
+            if not approved:
+                return False
+            return await self._merge_pr_with_retry(pr_info, owner, repo)
+
+        # Fall back to the heuristic block-reason classifier only when the
+        # cached state actually shows the PR as ``blocked``.  A missing
+        # review manifests as that state; a merge that fails from any other
+        # state (e.g. a transient 405 on a ``clean`` PR) without an
+        # authoritative approval signal above is not an approval problem,
+        # so don't probe or approve it — let the caller's classifier
+        # handle it.
+        if pr_info.mergeable_state != "blocked":
             return False
 
         try:
@@ -2416,6 +2490,34 @@ class AsyncMergeManager:
         if not approved:
             return False
         return await self._merge_pr_with_retry(pr_info, owner, repo)
+
+    @staticmethod
+    def _merge_error_indicates_missing_approval(error_text: str) -> bool:
+        """Detect a missing-required-approval signal in a merge error body.
+
+        GitHub's merge endpoint reports the authoritative rejection reason
+        in its response body, which is preserved in the exception text
+        raised by ``merge_pull_request``.  A merge blocked solely because
+        our approving review is missing is recoverable: we can approve the
+        head and retry.  This recognises the phrasings GitHub uses for
+        both repository rulesets and classic branch protection, e.g.:
+
+        - "Waiting on required approvals from <team>" (ruleset)
+        - "At least 1 approving review is required by reviewers with
+          write access." (branch protection)
+        - "Required review ... review required"
+
+        It deliberately does *not* match "changes requested" wording,
+        which an approval cannot clear.
+        """
+        if not error_text:
+            return False
+        text = error_text.lower()
+        return (
+            "required approval" in text
+            or "approving review" in text
+            or "review required" in text
+        )
 
     async def _check_merge_requirements(
         self, pr_info: PullRequestInfo
@@ -2717,10 +2819,7 @@ class AsyncMergeManager:
                     # from the tz-aware ``now``.  Either way, degrade to
                     # ``None`` (fail closed) rather than abort the run.
                     pending_age = None
-            if (
-                pending_age is None
-                or pending_age < PRECOMMIT_CI_STUCK_PENDING_SECONDS
-            ):
+            if pending_age is None or pending_age < PRECOMMIT_CI_STUCK_PENDING_SECONDS:
                 # Still within the normal window (or no timestamp to
                 # judge by) — leave the run to finish.
                 return False
@@ -4151,9 +4250,7 @@ class AsyncMergeManager:
                         pr_info.head_sha = refreshed_head
                     if refreshed_wait.get("state") == "closed":
                         closed_during_wait = True
-                        merged_during_wait = bool(
-                            refreshed_wait.get("merged", False)
-                        )
+                        merged_during_wait = bool(refreshed_wait.get("merged", False))
                         pr_info.state = "closed"
                         break
                 # A PR that becomes immediately mergeable while still
@@ -4268,9 +4365,7 @@ class AsyncMergeManager:
             result.error = "PR closed without merging during conflict rebase"
             if self.progress_tracker:
                 self.progress_tracker.merge_failure()
-            self._console.print(
-                f"🛑 Closed without merging: {pr_info.html_url}"
-            )
+            self._console.print(f"🛑 Closed without merging: {pr_info.html_url}")
         return result
 
     async def _handle_merge_conflict(
@@ -4515,9 +4610,7 @@ class AsyncMergeManager:
                 # PR is no longer approved up-front, so auto-merge would
                 # otherwise wait forever on a missing review.
                 if pr_info.mergeable_state != "dirty":
-                    await self._enable_auto_merge_with_approval(
-                        pr_info, owner, repo
-                    )
+                    await self._enable_auto_merge_with_approval(pr_info, owner, repo)
                 result.error = f"stuck check: {stuck_check}"
                 stuck_reported = True
 
@@ -4837,6 +4930,352 @@ class AsyncMergeManager:
                 )
                 self._org_settings_cache[owner] = None
                 return None
+
+    @staticmethod
+    def _rules_require_approval(rules: Any) -> bool:
+        """Return True if any effective branch rule mandates an approval.
+
+        ``rules`` is the JSON body returned by
+        ``GET /repos/{owner}/{repo}/rules/branches/{branch}`` — a flat
+        list of the rules that *actually apply* to the branch, with all
+        ruleset conditions (repository include/exclude, ref matching)
+        already evaluated server-side and org- and repo-level rulesets
+        already merged.  We treat a branch as requiring an approval when a
+        ``pull_request`` rule asks for at least one approving review.
+
+        This is intentionally org-agnostic: it keys off the rule *type*
+        and its ``required_approving_review_count`` parameter, never the
+        ruleset's name, so it works for any organization's naming.
+        """
+        if not isinstance(rules, list):
+            return False
+        for rule in rules:
+            if not isinstance(rule, dict):
+                continue
+            if rule.get("type") != "pull_request":
+                continue
+            params = rule.get("parameters")
+            if not isinstance(params, dict):
+                # A pull_request rule with no readable parameters still
+                # signals that reviews are governed here; treat the
+                # presence of the rule as requiring approval rather than
+                # risk a doomed merge-first attempt.
+                return True
+            count = params.get("required_approving_review_count")
+            if isinstance(count, int) and count >= 1:
+                return True
+        return False
+
+    async def _approve_if_review_mandated(
+        self, pr_info: PullRequestInfo, owner: str, repo: str, pr_key: str
+    ) -> None:
+        """Approve up-front when the base branch mandates a review to merge.
+
+        No-ops in preview mode, when the PR was already approved this run,
+        or when the base branch carries no required-approval rule.  This
+        is the proactive counterpart to
+        :meth:`_approve_and_retry_if_review_required`: detecting the
+        requirement (org-agnostically, from the branch's effective rules)
+        before dispatch avoids a guaranteed-to-fail merge attempt for
+        organizations that gate every merge on an approving review.
+        """
+        if self.preview_mode or pr_key in self._recently_approved:
+            return
+        if await self._branch_requires_approval(owner, repo, pr_info.base_branch):
+            await self._ensure_pr_approved(pr_info, owner, repo)
+
+    async def _org_approval_rulesets(self, org: str) -> list[dict[str, Any]] | None:
+        """Enumerate active org rulesets that mandate an approving review.
+
+        Queried **once per org** and cached for the run — the approval
+        requirement originates from a single organization ruleset, so it
+        is wasteful to rediscover it per repository.  Returns one entry
+        per approval-mandating ruleset (``{"name", "conditions"}``), ``[]``
+        when the org mandates none, or ``None`` when enumeration failed
+        (e.g. the token cannot read org rulesets) so the caller can fall
+        back to the authoritative per-repo endpoint.
+
+        The first time an org is found to gate merges on a review a single
+        user-facing line is emitted, so the requirement is visible at the
+        point of detection rather than buried in debug logs.
+        """
+        if org in self._org_approval_cache:
+            return self._org_approval_cache[org]
+
+        async with self._org_approval_locks_lock:
+            if org not in self._org_approval_locks:
+                self._org_approval_locks[org] = asyncio.Lock()
+            org_lock = self._org_approval_locks[org]
+
+        async with org_lock:
+            # Re-check after acquiring the per-org lock (another task may
+            # have populated the cache while we waited).
+            if org in self._org_approval_cache:
+                return self._org_approval_cache[org]
+
+            if not self._github_client:
+                return None
+
+            result: list[dict[str, Any]] = []
+            try:
+                # The list endpoint is paginated (default page size 30),
+                # so an org with many rulesets could otherwise silently
+                # drop an approval-mandating one.  Walk every page.
+                page = 1
+                per_page = 100
+                while True:
+                    rulesets = await self._github_client.get(
+                        f"/orgs/{org}/rulesets?per_page={per_page}&page={page}"
+                    )
+                    if not isinstance(rulesets, list) or not rulesets:
+                        break
+                    for rs in rulesets:
+                        if not isinstance(rs, dict):
+                            continue
+                        # Only active branch rulesets gate merges;
+                        # "evaluate" and "disabled" rulesets do not block,
+                        # and tag rulesets are irrelevant to PR merges.
+                        if rs.get("enforcement") != "active":
+                            continue
+                        if rs.get("target", "branch") != "branch":
+                            continue
+                        rid = rs.get("id")
+                        if rid is None:
+                            continue
+                        detail = await self._github_client.get(
+                            f"/orgs/{org}/rulesets/{rid}"
+                        )
+                        if not isinstance(detail, dict):
+                            continue
+                        if self._rules_require_approval(detail.get("rules")):
+                            result.append(
+                                {
+                                    "name": rs.get("name", ""),
+                                    "conditions": detail.get("conditions") or {},
+                                }
+                            )
+                    if len(rulesets) < per_page:
+                        break
+                    page += 1
+            except Exception as e:
+                # Enumeration failed (often a permission/SSO problem).
+                # Cache ``None`` so callers consult the per-repo endpoint
+                # rather than silently skipping proactive approval.
+                self.log.debug(f"Could not enumerate org rulesets for {org}: {e}")
+                self._org_approval_cache[org] = None
+                return None
+
+            self._org_approval_cache[org] = result
+            if result:
+                names = ", ".join(r["name"] for r in result if r.get("name")) or (
+                    "unnamed ruleset"
+                )
+                log_and_print(
+                    self.log,
+                    self._console,
+                    "🔐 Organization requires approving reviews before merging\n"
+                    f"Ruleset: {names}",
+                    level="info",
+                )
+            return result
+
+    @staticmethod
+    def _ruleset_name_matches(
+        name: str, include: list[Any], exclude: list[Any]
+    ) -> bool:
+        """Evaluate a ruleset ``repository_name`` condition against a repo.
+
+        ``include``/``exclude`` are fnmatch-style globs; the sentinel
+        ``~ALL`` matches every repository.  A repo is in scope when it
+        matches an include pattern and no exclude pattern.
+        """
+
+        def match_any(patterns: list[Any]) -> bool:
+            for pat in patterns:
+                if pat == "~ALL":
+                    return True
+                if isinstance(pat, str) and fnmatch.fnmatch(name, pat):
+                    return True
+            return False
+
+        if exclude and match_any(exclude):
+            return False
+        if not include:
+            return False
+        return match_any(include)
+
+    @staticmethod
+    def _ruleset_ref_matches(
+        branch: str, include: list[Any], exclude: list[Any]
+    ) -> bool | None:
+        """Evaluate a ruleset ``ref_name`` condition against a branch.
+
+        Returns ``True``/``False`` when it can be decided locally, or
+        ``None`` when it cannot (so the caller consults the authoritative
+        per-repo endpoint).  ``~ALL`` matches any branch.  ``~DEFAULT_BRANCH``
+        is treated as in scope: confirming it would need an extra per-repo
+        default-branch lookup, and the automation PRs this gates target
+        the default branch — a spurious approval on a non-default-base PR
+        (which we were about to merge anyway) is harmless.
+        """
+        ref = f"refs/heads/{branch}"
+
+        def match_any(patterns: list[Any]) -> bool:
+            for pat in patterns:
+                if pat in ("~ALL", "~DEFAULT_BRANCH"):
+                    return True
+                if isinstance(pat, str) and (
+                    fnmatch.fnmatch(ref, pat) or fnmatch.fnmatch(branch, pat)
+                ):
+                    return True
+            return False
+
+        if exclude and match_any(exclude):
+            return False
+        if not include:
+            # An empty include is unusual; defer to the authoritative
+            # endpoint rather than guess.
+            return None
+        return match_any(include)
+
+    def _ruleset_condition_applies(
+        self, conditions: Any, repo: str, branch: str
+    ) -> bool | None:
+        """Whether a ruleset's ``conditions`` select ``repo@branch``.
+
+        Returns ``True``/``False`` when the verdict is decidable from the
+        ``repository_name`` and ``ref_name`` conditions, or ``None`` when
+        the ruleset uses a condition type we do not evaluate locally
+        (e.g. ``repository_id`` or ``repository_property``) so the caller
+        falls back to GitHub's authoritative per-repo evaluation.
+        """
+        if not isinstance(conditions, dict):
+            return None
+        # Any condition type beyond the two we evaluate means we cannot be
+        # sure locally — signal the caller to ask GitHub directly.
+        if any(key not in ("repository_name", "ref_name") for key in conditions):
+            return None
+
+        repo_cond = conditions.get("repository_name")
+        if isinstance(repo_cond, dict):
+            if not self._ruleset_name_matches(
+                repo,
+                repo_cond.get("include") or [],
+                repo_cond.get("exclude") or [],
+            ):
+                return False
+
+        ref_cond = conditions.get("ref_name")
+        if isinstance(ref_cond, dict):
+            ref_applies = self._ruleset_ref_matches(
+                branch,
+                ref_cond.get("include") or [],
+                ref_cond.get("exclude") or [],
+            )
+            if ref_applies is not True:
+                # False or None (undecidable) — propagate so an undecidable
+                # ref falls back to the authoritative endpoint.
+                return ref_applies
+
+        return True
+
+    async def _branch_requires_approval(
+        self, owner: str, repo: str, branch: str
+    ) -> bool:
+        """Whether ``owner/repo@branch`` mandates an approving review to merge.
+
+        Some organizations enforce a repository ruleset that requires at
+        least one approving review before *any* merge is permitted (the
+        ``lfreleng-actions`` "Base Protections" ruleset is one example).
+        Under "merge first, approve on demand" every such PR would incur a
+        guaranteed-to-fail merge attempt before we approve and retry.
+        Detecting the requirement up-front lets us approve proactively and
+        skip that doomed round-trip.
+
+        Detection is **org-first**: the org's rulesets are enumerated once
+        (see :meth:`_org_approval_rulesets`) and their conditions are
+        evaluated locally, so a whole org-wide run needs a single ruleset
+        query rather than one effective-rules call per repository.  Only
+        when a ruleset uses a condition we cannot evaluate locally, or org
+        enumeration was not possible, do we fall back to GitHub's
+        authoritative per-repo ``rules/branches`` endpoint.  The resolved
+        verdict is cached per repo+branch.
+        """
+        cache_key = f"{owner}/{repo}@{branch}"
+        if cache_key in self._branch_approval_cache:
+            return self._branch_approval_cache[cache_key]
+
+        async with self._branch_approval_locks_lock:
+            if cache_key not in self._branch_approval_locks:
+                self._branch_approval_locks[cache_key] = asyncio.Lock()
+            branch_lock = self._branch_approval_locks[cache_key]
+
+        async with branch_lock:
+            # Re-check after acquiring the per-branch lock (another task
+            # may have populated the cache while we waited).
+            if cache_key in self._branch_approval_cache:
+                return self._branch_approval_cache[cache_key]
+
+            rulesets = await self._org_approval_rulesets(owner)
+
+            requires = False
+            # ``None`` means org enumeration failed; consult the per-repo
+            # endpoint.  An empty list means the org mandates no approval
+            # (repo-level rulesets, if any, are covered by the reactive
+            # approve-on-demand safety net).
+            need_authoritative = rulesets is None
+            for rs in rulesets or []:
+                applies = self._ruleset_condition_applies(
+                    rs.get("conditions"), repo, branch
+                )
+                if applies is True:
+                    requires = True
+                    break
+                if applies is None:
+                    need_authoritative = True
+
+            if not requires and need_authoritative:
+                requires = await self._effective_branch_requires_approval(
+                    owner, repo, branch
+                )
+
+            self._branch_approval_cache[cache_key] = requires
+            if requires:
+                self.log.debug(
+                    "Branch %s requires an approving review before merge; "
+                    "approving proactively",
+                    cache_key,
+                )
+            return requires
+
+    async def _effective_branch_requires_approval(
+        self, owner: str, repo: str, branch: str
+    ) -> bool:
+        """Authoritative per-repo fallback for the approval requirement.
+
+        Uses ``GET /repos/{owner}/{repo}/rules/branches/{branch}`` which
+        returns the *effective* rules for the branch — every applicable
+        org- and repo-level ruleset, with all conditions already evaluated
+        by GitHub.  Used only when the org-first path cannot decide (an
+        unrecognised condition type, or org enumeration was unavailable).
+        On any error returns ``False`` so the reactive approve-on-demand
+        path remains the safety net rather than blocking the merge.
+        """
+        if not self._github_client:
+            return False
+        try:
+            # Branch names can contain "/" (e.g. "release/v1"); encode the
+            # whole segment so it routes to the right endpoint rather than
+            # 404ing and being mistaken for "no rules".
+            rules = await self._github_client.get(
+                f"/repos/{owner}/{repo}/rules/branches/{quote(branch, safe='')}"
+            )
+            return self._rules_require_approval(rules)
+        except Exception as e:
+            self.log.debug(
+                f"Could not read effective branch rules for {owner}/{repo}@{branch}: {e}"
+            )
+            return False
 
     async def _predict_merge_outcome(
         self, owner: str, repo: str, pr_number: int, merge_method: str

--- a/src/dependamerge/merge_manager.py
+++ b/src/dependamerge/merge_manager.py
@@ -1009,7 +1009,7 @@ class AsyncMergeManager:
                     log_and_print(
                         self.log,
                         self._console,
-                        (f"⏭️  Skipped: {pr_info.html_url} [already merged externally]"),
+                        (f"⏭️ Skipped: {pr_info.html_url} [already merged externally]"),
                         level="info",
                     )
                     return result
@@ -1129,7 +1129,7 @@ class AsyncMergeManager:
                     # Only log during preview evaluation to avoid duplicate messages
                     if self.preview_mode:
                         self.log.warning(
-                            f"⚠️  Overriding blocking reviews for {pr_info.repository_full_name}#{pr_info.number} (--force=all)"
+                            f"⚠️ Overriding blocking reviews for {pr_info.repository_full_name}#{pr_info.number} (--force=all)"
                         )
 
             # Step 0.5: If the PR is blocked, check for stale pre-commit.ci
@@ -1192,7 +1192,7 @@ class AsyncMergeManager:
                         pass
                 except Exception as e:
                     self.log.warning(
-                        f"⚠️  Failed to process Copilot items for PR {pr_info.number}: {e}"
+                        f"⚠️ Failed to process Copilot items for PR {pr_info.number}: {e}"
                     )
                     copilot_processing_successful = False
 
@@ -1449,7 +1449,7 @@ class AsyncMergeManager:
                     if self.progress_tracker:
                         self.progress_tracker.merge_success()
                     self._console.print(
-                        f"⚠️  Rebase/merge: {pr_info.html_url} [behind base branch]",
+                        f"⚠️ Rebase/merge: {pr_info.html_url} [behind base branch]",
                         markup=False,
                     )
                 elif pr_info.mergeable_state == "dirty":
@@ -1684,7 +1684,7 @@ class AsyncMergeManager:
                             self.log,
                             self._console,
                             (
-                                f"⏭️  Skipped: {pr_info.html_url} "
+                                f"⏭️ Skipped: {pr_info.html_url} "
                                 "[already merged externally]"
                             ),
                             level="info",
@@ -2049,7 +2049,7 @@ class AsyncMergeManager:
         for review in pr_info.reviews:
             if review.state == "CHANGES_REQUESTED":
                 self.log.info(
-                    f"⚠️  PR {pr_info.number} has changes requested by {review.user} - will not override human feedback"
+                    f"⚠️ PR {pr_info.number} has changes requested by {review.user} - will not override human feedback"
                 )
                 return True
         return False
@@ -2320,7 +2320,7 @@ class AsyncMergeManager:
                             # Only log during preview evaluation to avoid duplicate messages
                             if self.preview_mode:
                                 self.log.warning(
-                                    f"⚠️  Bypassing code owner review requirement for {repo_owner}/{repo_name}#{pr_info.number} (--force={self.force_level})"
+                                    f"⚠️ Bypassing code owner review requirement for {repo_owner}/{repo_name}#{pr_info.number} (--force={self.force_level})"
                                 )
                             return (
                                 True,
@@ -2377,7 +2377,7 @@ class AsyncMergeManager:
                     # Only log during preview evaluation to avoid duplicate messages
                     if self.preview_mode:
                         self.log.warning(
-                            f"⚠️  Bypassing branch protection check for {repo_owner}/{repo_name}#{pr_info.number}: {test_result[1]} (--force={self.force_level})"
+                            f"⚠️ Bypassing branch protection check for {repo_owner}/{repo_name}#{pr_info.number}: {test_result[1]} (--force={self.force_level})"
                         )
                     # When bypassing, return early to allow merge to proceed
                     return (
@@ -2415,7 +2415,7 @@ class AsyncMergeManager:
                     # Only log during preview evaluation to avoid duplicate messages
                     if self.preview_mode:
                         self.log.warning(
-                            f"⚠️  Bypassing failing status checks for {repo_owner}/{repo_name}#{pr_info.number} (--force=all)"
+                            f"⚠️ Bypassing failing status checks for {repo_owner}/{repo_name}#{pr_info.number} (--force=all)"
                         )
                     return True, "PR blocked but forcing merge attempt (--force=all)"
                 else:
@@ -2437,7 +2437,7 @@ class AsyncMergeManager:
             if not self.fix_out_of_date:
                 if self.force_level == "all":
                     self.log.warning(
-                        f"⚠️  Attempting merge despite being behind for {repo_owner}/{repo_name}#{pr_info.number} (--force=all)"
+                        f"⚠️ Attempting merge despite being behind for {repo_owner}/{repo_name}#{pr_info.number} (--force=all)"
                     )
                     return True, "PR behind but forcing merge attempt (--force=all)"
                 else:
@@ -2465,7 +2465,7 @@ class AsyncMergeManager:
         elif pr_info.mergeable_state == "dirty":
             if self.force_level == "all":
                 self.log.warning(
-                    f"⚠️  Attempting merge despite conflicts for {repo_owner}/{repo_name}#{pr_info.number} (--force=all)"
+                    f"⚠️ Attempting merge despite conflicts for {repo_owner}/{repo_name}#{pr_info.number} (--force=all)"
                 )
                 return True, "PR has conflicts but forcing merge attempt (--force=all)"
             else:

--- a/src/dependamerge/merge_manager.py
+++ b/src/dependamerge/merge_manager.py
@@ -1718,7 +1718,17 @@ class AsyncMergeManager:
                     #      (which posts ``pre-commit.ci run``).
                     recreated_pr = None
                     if pr_info.author == "dependabot[bot]" and not self.preview_mode:
-                        should_recreate = "branch protection" in failure_reason.lower()
+                        reason_lower = failure_reason.lower()
+                        # Branch protection *and* repository rulesets can
+                        # both block a dependabot PR for reasons recreation
+                        # resolves (most commonly an unsigned-commit /
+                        # required-signature rule).  Treat them alike so the
+                        # recreate path is not silently skipped on repos that
+                        # have migrated from classic protection to rulesets.
+                        should_recreate = (
+                            "branch protection" in reason_lower
+                            or "ruleset" in reason_lower
+                        )
                         if not should_recreate:
                             try:
                                 (
@@ -4414,12 +4424,30 @@ class AsyncMergeManager:
                 detail = detail.split(" (PR state:", 1)[0].strip()
                 if detail:
                     return detail[:300]
-            # Check for workflow scope error - be very specific to avoid false positives
-            # Only match the exact error message pattern we raise in github_async.py
-            if "Missing 'workflow' scope" in error_msg:
+            # Workflow-scope failures surface in several phrasings: the
+            # PermissionError messages we raise ("Missing 'workflow' scope",
+            # "Missing workflow permissions") and GitHub's own response body
+            # ("refusing to allow ... without `workflow` scope").  Match all
+            # of them, but require the word "workflow" so unrelated 403s do
+            # not get mislabelled as a scope problem.
+            error_lower = error_msg.lower()
+            if "workflow" in error_lower and (
+                "missing 'workflow' scope" in error_lower
+                or "missing workflow permissions" in error_lower
+                or "refusing to allow" in error_lower
+            ):
                 return "missing 'workflow' token scope"
+            # The token already had the 'workflow' scope but GitHub still
+            # refused the workflow-file update — a ruleset or SSO problem,
+            # not a scope problem.  Report it as such rather than telling the
+            # user to add a scope they already hold.
+            elif "blocked by something other than token scope" in error_lower:
+                return (
+                    "workflow update blocked by repository ruleset or SSO "
+                    "(token already has 'workflow' scope)"
+                )
             # Check for other permission errors
-            elif "403" in error_msg and "forbidden" in error_msg.lower():
+            elif "403" in error_msg and "forbidden" in error_lower:
                 return "insufficient permissions"
             # Surface transient HTTP errors (502, 405 etc.) accurately instead
             # of falling through to infer a reason from mergeable_state, which
@@ -4463,6 +4491,10 @@ class AsyncMergeManager:
                     return "human reviewer requested changes"
                 elif "Copilot" in detailed_reason:
                     return detailed_reason.replace("Blocked by ", "").lower()
+                elif "ruleset" in detailed_reason.lower():
+                    return "repository ruleset prevents merge"
+                elif "undetermined reason" in detailed_reason.lower():
+                    return "blocked for an undetermined reason"
                 elif "branch protection" in detailed_reason.lower():
                     return "branch protection rules prevent merge"
                 else:

--- a/src/dependamerge/progress_tracker.py
+++ b/src/dependamerge/progress_tracker.py
@@ -250,7 +250,7 @@ class ProgressTracker:
             text.append("\n   📊 PRs analyzed: ", style="dim")
             text.append(str(self.total_prs_analyzed), style="bold")
             if self.unmergeable_prs_found > 0:
-                text.append(" | ⚠️  Unmergeable: ", style="dim")
+                text.append(" | ⚠️ Unmergeable: ", style="dim")
                 text.append(str(self.unmergeable_prs_found), style="bold yellow")
 
         # Metrics line (concurrency / requests-per-second)
@@ -279,7 +279,7 @@ class ProgressTracker:
 
         # Elapsed time
         elapsed = datetime.now() - self.start_time
-        text.append(f"\n   ⏱️  Elapsed: {self._format_duration(elapsed)}", style="dim")
+        text.append(f"\n   ⏱️ Elapsed: {self._format_duration(elapsed)}", style="dim")
 
         return text
 
@@ -496,7 +496,7 @@ class MergeProgressTracker(ProgressTracker):
         # Merge stats
         stats_parts: list[str] = []
         if self.similar_prs_found > 0:
-            stats_parts.append(f"Similar: {self.similar_prs_found}")
+            stats_parts.append(f"🔁 Similar: {self.similar_prs_found}")
         if self.prs_merged > 0:
             stats_parts.append(f"✅ Merged: {self.prs_merged}")
         if self.prs_closed > 0:
@@ -504,10 +504,10 @@ class MergeProgressTracker(ProgressTracker):
         if self.prs_failed > 0:
             stats_parts.append(f"❌ Failed: {self.prs_failed}")
         if self.prs_skipped > 0:
-            stats_parts.append(f"⏭️  Skipped: {self.prs_skipped}")
+            stats_parts.append(f"⏭️ Skipped: {self.prs_skipped}")
 
         if stats_parts:
-            text.append(f"\n   📊 {' | '.join(stats_parts)}", style="dim")
+            text.append(f"\n   {' | '.join(stats_parts)}", style="dim")
 
         # Metrics line
         if self.metrics_concurrency is not None or self.metrics_rps is not None:
@@ -528,7 +528,7 @@ class MergeProgressTracker(ProgressTracker):
 
         # Elapsed time
         elapsed = datetime.now() - self.start_time
-        text.append(f"\n   ⏱️  Elapsed: {self._format_duration(elapsed)}", style="dim")
+        text.append(f"\n   ⏱️ Elapsed: {self._format_duration(elapsed)}", style="dim")
 
         return text
 

--- a/src/dependamerge/rebase.py
+++ b/src/dependamerge/rebase.py
@@ -651,7 +651,7 @@ async def _run_local_path(
     log_and_print(
         ctx.log,
         ctx.console,
-        f"🛡️  Local rebase: {pr_info.html_url} [{local_reason}]",
+        f"🛡️ Local rebase: {pr_info.html_url} [{local_reason}]",
         level="debug",
     )
     try:
@@ -705,7 +705,7 @@ async def _run_local_path(
         log_and_print(
             ctx.log,
             ctx.console,
-            f"🛡️  Local rebase failed; deferring to auto-merge: {pr_info.html_url}",
+            f"🛡️ Local rebase failed; deferring to auto-merge: {pr_info.html_url}",
             level="debug",
         )
 
@@ -950,7 +950,7 @@ def _log_post_rebase_status(
         log_and_print(
             ctx.log,
             ctx.console,
-            f"⚠️  Rebased: {pr_info.html_url} [still behind after rebase]",
+            f"⚠️ Rebased: {pr_info.html_url} [still behind after rebase]",
             level="debug",
         )
     elif state == "blocked":
@@ -964,6 +964,6 @@ def _log_post_rebase_status(
         log_and_print(
             ctx.log,
             ctx.console,
-            f"ℹ️  Rebased: {pr_info.html_url}",
+            f"ℹ️ Rebased: {pr_info.html_url}",
             level="debug",
         )

--- a/tests/test_approve_on_demand.py
+++ b/tests/test_approve_on_demand.py
@@ -1,0 +1,282 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2025 The Linux Foundation
+
+"""Unit tests for approve-on-demand merge behaviour.
+
+Phase 1b moved PR approval off the unconditional up-front path onto two
+on-demand triggers:
+
+1. ``_approve_and_retry_if_review_required`` — after a direct merge is
+   rejected *specifically* because our review is missing, approve the
+   current head and retry the merge once.
+2. ``_enable_auto_merge_with_approval`` — approve the current head (if
+   needed) before arming auto-merge, so auto-merge is not left waiting on
+   a missing review.
+
+These tests exercise the helpers directly (so they are independent of the
+large ``_merge_single_pr`` orchestration) plus the helpers' integration
+points.
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from dependamerge.models import PullRequestInfo
+from tests.conftest import make_merge_manager
+
+_BLOCKED_PR = PullRequestInfo(
+    number=42,
+    node_id="PR_kwDOTestNode42",
+    title="Bump foo from 1.0 to 2.0",
+    body="Dependabot PR",
+    author="dependabot[bot]",
+    head_sha="abc123def456",
+    base_branch="main",
+    head_branch="dependabot/pip/foo-2.0",
+    state="open",
+    mergeable=True,
+    mergeable_state="blocked",
+    behind_by=0,
+    files_changed=[],
+    repository_full_name="owner/repo",
+    html_url="https://github.com/owner/repo/pull/42",
+    reviews=[],
+    review_comments=[],
+)
+
+
+# ---------------------------------------------------------------------------
+# Trigger 1: _approve_and_retry_if_review_required
+# ---------------------------------------------------------------------------
+
+
+class TestApproveAndRetryIfReviewRequired:
+    """Approve-on-demand recovery after a failed direct merge."""
+
+    @pytest.mark.asyncio
+    async def test_approves_and_retries_when_review_required(self) -> None:
+        """Blocked-pending-approval failure → approve → retry merges."""
+        mgr, client = make_merge_manager()
+        mgr._post_approval_delay = 0.0
+        pr = _BLOCKED_PR.model_copy()
+
+        client.analyze_block_reason = AsyncMock(
+            return_value="Blocked by branch protection (requires approval)"
+        )
+
+        with (
+            patch.object(
+                mgr, "_ensure_pr_approved", new_callable=AsyncMock, return_value=True
+            ) as mock_approve,
+            patch.object(
+                mgr,
+                "_merge_pr_with_retry",
+                new_callable=AsyncMock,
+                return_value=True,
+            ) as mock_retry,
+        ):
+            result = await mgr._approve_and_retry_if_review_required(
+                pr, "owner", "repo"
+            )
+
+        assert result is True
+        mock_approve.assert_awaited_once()
+        mock_retry.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_skips_when_failure_is_not_approval(self) -> None:
+        """A non-approval block reason must NOT trigger an approval."""
+        mgr, client = make_merge_manager()
+        pr = _BLOCKED_PR.model_copy()
+
+        client.analyze_block_reason = AsyncMock(
+            return_value="Blocked by failing check: ci/test"
+        )
+
+        with (
+            patch.object(
+                mgr, "_ensure_pr_approved", new_callable=AsyncMock
+            ) as mock_approve,
+            patch.object(
+                mgr, "_merge_pr_with_retry", new_callable=AsyncMock
+            ) as mock_retry,
+        ):
+            result = await mgr._approve_and_retry_if_review_required(
+                pr, "owner", "repo"
+            )
+
+        assert result is False
+        mock_approve.assert_not_called()
+        mock_retry.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_skips_when_not_blocked(self) -> None:
+        """A non-blocked state is never an approval problem."""
+        mgr, client = make_merge_manager()
+        pr = _BLOCKED_PR.model_copy(update={"mergeable_state": "clean"})
+
+        with patch.object(
+            mgr, "_ensure_pr_approved", new_callable=AsyncMock
+        ) as mock_approve:
+            result = await mgr._approve_and_retry_if_review_required(
+                pr, "owner", "repo"
+            )
+
+        assert result is False
+        mock_approve.assert_not_called()
+        # The block-reason probe must be skipped entirely for non-blocked PRs.
+        client.analyze_block_reason.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_skips_when_already_approved_this_run(self) -> None:
+        """If we already approved this run, do not approve again."""
+        mgr, client = make_merge_manager()
+        pr = _BLOCKED_PR.model_copy()
+        mgr._recently_approved.add("owner/repo#42")
+
+        with patch.object(
+            mgr, "_ensure_pr_approved", new_callable=AsyncMock
+        ) as mock_approve:
+            result = await mgr._approve_and_retry_if_review_required(
+                pr, "owner", "repo"
+            )
+
+        assert result is False
+        mock_approve.assert_not_called()
+        client.analyze_block_reason.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_preview_mode_never_approves(self) -> None:
+        """Preview mode performs no side effects."""
+        mgr, client = make_merge_manager(preview_mode=True)
+        pr = _BLOCKED_PR.model_copy()
+
+        with patch.object(
+            mgr, "_ensure_pr_approved", new_callable=AsyncMock
+        ) as mock_approve:
+            result = await mgr._approve_and_retry_if_review_required(
+                pr, "owner", "repo"
+            )
+
+        assert result is False
+        mock_approve.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Trigger 2: _enable_auto_merge_with_approval
+# ---------------------------------------------------------------------------
+
+
+class TestEnableAutoMergeWithApproval:
+    """Approve the current head before arming auto-merge."""
+
+    @pytest.mark.asyncio
+    async def test_approves_then_enables(self) -> None:
+        """Approval happens before auto-merge is enabled."""
+        mgr, _client = make_merge_manager()
+        pr = _BLOCKED_PR.model_copy()
+        order: list[str] = []
+
+        async def fake_approve(*_args, **_kwargs) -> bool:
+            order.append("approve")
+            return True
+
+        async def fake_enable(*_args, **_kwargs) -> bool:
+            order.append("enable")
+            return True
+
+        with (
+            patch.object(mgr, "_ensure_pr_approved", new=fake_approve),
+            patch.object(mgr, "_enable_auto_merge_for_pr", new=fake_enable),
+        ):
+            result = await mgr._enable_auto_merge_with_approval(pr, "owner", "repo")
+
+        assert result is True
+        assert order == ["approve", "enable"]
+
+    @pytest.mark.asyncio
+    async def test_preview_mode_skips_approval_but_enables(self) -> None:
+        """Preview mode must not approve, but still reports the enable result."""
+        mgr, _client = make_merge_manager(preview_mode=True)
+        pr = _BLOCKED_PR.model_copy()
+
+        with (
+            patch.object(
+                mgr, "_ensure_pr_approved", new_callable=AsyncMock
+            ) as mock_approve,
+            patch.object(
+                mgr,
+                "_enable_auto_merge_for_pr",
+                new_callable=AsyncMock,
+                return_value=True,
+            ) as mock_enable,
+        ):
+            result = await mgr._enable_auto_merge_with_approval(pr, "owner", "repo")
+
+        assert result is True
+        mock_approve.assert_not_called()
+        mock_enable.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_enables_even_if_approval_errors(self) -> None:
+        """A non-permission approval error must not block arming auto-merge."""
+        mgr, _client = make_merge_manager()
+        pr = _BLOCKED_PR.model_copy()
+
+        with (
+            patch.object(
+                mgr,
+                "_ensure_pr_approved",
+                new_callable=AsyncMock,
+                side_effect=RuntimeError("transient approval hiccup"),
+            ),
+            patch.object(
+                mgr,
+                "_enable_auto_merge_for_pr",
+                new_callable=AsyncMock,
+                return_value=True,
+            ) as mock_enable,
+        ):
+            result = await mgr._enable_auto_merge_with_approval(pr, "owner", "repo")
+
+        assert result is True
+        mock_enable.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# _ensure_pr_approved bookkeeping
+# ---------------------------------------------------------------------------
+
+
+class TestEnsurePrApproved:
+    """The approval wrapper tracks newly-approved PRs."""
+
+    @pytest.mark.asyncio
+    async def test_tracks_recently_approved_on_new_approval(self) -> None:
+        """A new approval is recorded in _recently_approved."""
+        mgr, _client = make_merge_manager()
+        mgr._post_approval_delay = 0.0
+        pr = _BLOCKED_PR.model_copy()
+
+        with patch.object(
+            mgr, "_approve_pr", new_callable=AsyncMock, return_value=True
+        ):
+            approved = await mgr._ensure_pr_approved(pr, "owner", "repo")
+
+        assert approved is True
+        assert "owner/repo#42" in mgr._recently_approved
+
+    @pytest.mark.asyncio
+    async def test_no_tracking_when_already_approved(self) -> None:
+        """When _approve_pr no-ops, the PR is not added to the set."""
+        mgr, _client = make_merge_manager()
+        pr = _BLOCKED_PR.model_copy()
+
+        with patch.object(
+            mgr, "_approve_pr", new_callable=AsyncMock, return_value=False
+        ):
+            approved = await mgr._ensure_pr_approved(pr, "owner", "repo")
+
+        assert approved is False
+        assert "owner/repo#42" not in mgr._recently_approved

--- a/tests/test_approve_on_demand.py
+++ b/tests/test_approve_on_demand.py
@@ -129,6 +129,45 @@ class TestApproveAndRetryIfReviewRequired:
         client.analyze_block_reason.assert_not_called()
 
     @pytest.mark.asyncio
+    async def test_authoritative_rejection_overrides_lagging_state(self) -> None:
+        """GitHub's missing-approval body fires even when state isn't blocked.
+
+        ``mergeable_state`` lags and is blind to repository rulesets, so a
+        merge can be rejected for a missing required approval while the
+        cached state is still ``clean``.  The authoritative rejection body
+        must drive approve-and-retry without consulting the heuristic
+        block-reason probe.
+        """
+        mgr, client = make_merge_manager()
+        mgr._post_approval_delay = 0.0
+        pr = _BLOCKED_PR.model_copy(update={"mergeable_state": "clean"})
+        mgr._last_merge_exception["owner/repo#42"] = Exception(
+            "Repository rule violations found Waiting on required "
+            "approvals from owner/releng"
+        )
+
+        with (
+            patch.object(
+                mgr, "_ensure_pr_approved", new_callable=AsyncMock, return_value=True
+            ) as mock_approve,
+            patch.object(
+                mgr,
+                "_merge_pr_with_retry",
+                new_callable=AsyncMock,
+                return_value=True,
+            ) as mock_retry,
+        ):
+            result = await mgr._approve_and_retry_if_review_required(
+                pr, "owner", "repo"
+            )
+
+        assert result is True
+        mock_approve.assert_awaited_once()
+        mock_retry.assert_awaited_once()
+        # The authoritative body is sufficient; no heuristic probe needed.
+        client.analyze_block_reason.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_skips_when_already_approved_this_run(self) -> None:
         """If we already approved this run, do not approve again."""
         mgr, client = make_merge_manager()

--- a/tests/test_dependabot_recreate.py
+++ b/tests/test_dependabot_recreate.py
@@ -663,12 +663,16 @@ class TestMergeSinglePrRecreateIntegration:
         mgr, client = _make_manager()  # typed mock client pattern (see conftest.py)
         pr = _make_pr_info(mergeable=True, mergeable_state="blocked")
 
-        # Make the PR pass initial checks but fail the merge
+        # Make the PR pass initial checks but fail the merge.
+        # Use a non-approval block reason (an unsigned-commit /
+        # required-signature branch protection failure): a "requires
+        # approval" reason would instead be resolved by the approve-on-
+        # demand merge retry, not the recreate path under test here.
         client.get_branch_protection = AsyncMock(return_value={})
         client.analyze_block_reason = AsyncMock(
-            return_value="Blocked by branch protection (requires approval)"
+            return_value="Blocked by branch protection"
         )
-        # get() calls during _test_merge_capability etc.
+        # get() calls during _predict_merge_outcome etc.
         client.get = AsyncMock(
             return_value={
                 "mergeable": True,

--- a/tests/test_force_levels.py
+++ b/tests/test_force_levels.py
@@ -454,7 +454,7 @@ class TestForceLogging:
 
         mock_github = mocker.AsyncMock()
 
-        # Mock the specific API call that _test_merge_capability makes
+        # Mock the specific API call that _predict_merge_outcome makes
         def mock_get_side_effect(url):
             if "/pulls/" in url:
                 return {
@@ -479,8 +479,9 @@ class TestForceLogging:
         ) as manager:
             manager._github_client = mock_github
 
-            # Test the bypass directly since _check_merge_requirements doesn't always call _test_merge_capability
-            result = await manager._test_merge_capability(
+            # Test the bypass directly since _check_merge_requirements
+            # only predicts the outcome in preview mode
+            result = await manager._predict_merge_outcome(
                 "test-org", "test-repo", 123, "merge"
             )
 

--- a/tests/test_org_and_user_caches.py
+++ b/tests/test_org_and_user_caches.py
@@ -150,16 +150,16 @@ class TestOrgSettingsCache:
 
 
 # ---------------------------------------------------------------------------
-# _test_merge_capability uses the org cache
+# _predict_merge_outcome uses the org cache
 # ---------------------------------------------------------------------------
 
 
-class TestTestMergeCapabilityUsesOrgCache:
-    """Verify that _test_merge_capability routes through the cached helper."""
+class TestPredictMergeOutcomeUsesOrgCache:
+    """Verify that _predict_merge_outcome routes through the cached helper."""
 
     @pytest.mark.asyncio
     async def test_multiple_prs_same_org_single_org_query(self):
-        """Calling _test_merge_capability for multiple PRs in the same org
+        """Calling _predict_merge_outcome for multiple PRs in the same org
         should only produce one GET /orgs/{owner} call."""
         mgr, client = _make_manager_with_client()
 
@@ -182,7 +182,7 @@ class TestTestMergeCapabilityUsesOrgCache:
 
         # Simulate processing 5 PRs across 3 repos in the same org
         for pr_num in range(1, 6):
-            await mgr._test_merge_capability(
+            await mgr._predict_merge_outcome(
                 "same-org", f"repo-{pr_num}", pr_num, "merge"
             )
 
@@ -190,7 +190,7 @@ class TestTestMergeCapabilityUsesOrgCache:
 
     @pytest.mark.asyncio
     async def test_org_failure_does_not_block_merge_check(self):
-        """If the org settings lookup fails, _test_merge_capability should
+        """If the org settings lookup fails, _predict_merge_outcome should
         still proceed to check the PR's merge status."""
         mgr, client = _make_manager_with_client()
 
@@ -207,7 +207,7 @@ class TestTestMergeCapabilityUsesOrgCache:
 
         client.get = AsyncMock(side_effect=mock_get)
 
-        can_merge, reason = await mgr._test_merge_capability(
+        can_merge, reason = await mgr._predict_merge_outcome(
             "broken-org", "some-repo", 1, "merge"
         )
 

--- a/tests/test_required_approval_detection.py
+++ b/tests/test_required_approval_detection.py
@@ -1,0 +1,629 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2025 The Linux Foundation
+
+"""Tests for proactive required-approval detection.
+
+Some organizations enforce a repository ruleset that mandates an approving
+review before *any* merge (e.g. the ``lfreleng-actions`` "Base Protections"
+ruleset).  Under "merge first, approve on demand" every such PR would incur
+a guaranteed-to-fail merge attempt before recovery.  The merge manager now
+detects the requirement **org-first** — enumerating the org's rulesets once
+and evaluating their conditions locally — and approves proactively, falling
+back to GitHub's authoritative per-repo ``rules/branches`` endpoint only for
+conditions it cannot evaluate locally.
+
+These tests cover the pure condition-matching helpers, the org enumeration,
+the org-first resolution (including its caching and fallback), and the
+reactive merge-error approval signal.
+"""
+
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from dependamerge.models import PullRequestInfo
+from tests.conftest import make_merge_manager
+
+# A faithful copy of the real lfreleng-actions "Base Protections" ruleset:
+# requires one approving review, applies to every repo *except*
+# ``project-reporting-artifacts``, and only on the default branch.
+_BASE_PROTECTIONS_DETAIL: dict[str, Any] = {
+    "id": 4129117,
+    "name": "Base Protections",
+    "target": "branch",
+    "enforcement": "active",
+    "conditions": {
+        "ref_name": {"include": ["~DEFAULT_BRANCH"], "exclude": []},
+        "repository_name": {
+            "include": ["*"],
+            "exclude": ["project-reporting-artifacts"],
+        },
+    },
+    "rules": [
+        {
+            "type": "pull_request",
+            "parameters": {"required_approving_review_count": 1},
+        },
+        {
+            "type": "required_status_checks",
+            "parameters": {"required_status_checks": [{"context": "DCO"}]},
+        },
+    ],
+}
+
+_RULESETS_LIST = [
+    {
+        "id": 4129117,
+        "name": "Base Protections",
+        "target": "branch",
+        "enforcement": "active",
+    },
+    {
+        "id": 17275268,
+        "name": "Mandatory workflows",
+        "target": "branch",
+        "enforcement": "active",
+    },
+]
+
+# "Mandatory workflows" carries no pull_request approval rule.
+_MANDATORY_WORKFLOWS_DETAIL = {
+    "id": 17275268,
+    "name": "Mandatory workflows",
+    "target": "branch",
+    "enforcement": "active",
+    "conditions": {"ref_name": {"include": ["~ALL"], "exclude": []}},
+    "rules": [{"type": "workflows", "parameters": {}}],
+}
+
+
+def _org_get_router(*, list_payload=_RULESETS_LIST, details=None):
+    """Build an AsyncMock side_effect routing org ruleset GETs by URL.
+
+    The list endpoint is fetched page by page (``?per_page=...&page=N``);
+    the whole payload is returned for page 1 and an empty list for any
+    later page, so the manager's pagination loop terminates.
+    """
+    details = details or {
+        4129117: _BASE_PROTECTIONS_DETAIL,
+        17275268: _MANDATORY_WORKFLOWS_DETAIL,
+    }
+
+    async def _get(path: str):
+        base, _, query = path.partition("?")
+        if base.endswith("/rulesets"):
+            page = 1
+            for part in query.split("&"):
+                if part.startswith("page="):
+                    page = int(part.split("=", 1)[1])
+            return list_payload if page == 1 else []
+        for rid, detail in details.items():
+            if base.endswith(f"/rulesets/{rid}"):
+                return detail
+        raise AssertionError(f"unexpected GET {path}")
+
+    return _get
+
+
+# ---------------------------------------------------------------------------
+# _rules_require_approval
+# ---------------------------------------------------------------------------
+
+
+class TestRulesRequireApproval:
+    def test_detects_pull_request_rule_with_count(self) -> None:
+        mgr, _ = make_merge_manager()
+        rules = [
+            {
+                "type": "pull_request",
+                "parameters": {"required_approving_review_count": 1},
+            }
+        ]
+        assert mgr._rules_require_approval(rules) is True
+
+    def test_zero_required_reviews_is_not_a_requirement(self) -> None:
+        mgr, _ = make_merge_manager()
+        rules = [
+            {
+                "type": "pull_request",
+                "parameters": {"required_approving_review_count": 0},
+            }
+        ]
+        assert mgr._rules_require_approval(rules) is False
+
+    def test_no_pull_request_rule(self) -> None:
+        mgr, _ = make_merge_manager()
+        rules = [{"type": "required_status_checks", "parameters": {}}]
+        assert mgr._rules_require_approval(rules) is False
+
+    def test_pull_request_rule_without_params_assumes_requirement(self) -> None:
+        mgr, _ = make_merge_manager()
+        assert mgr._rules_require_approval([{"type": "pull_request"}]) is True
+
+    def test_non_list_input(self) -> None:
+        mgr, _ = make_merge_manager()
+        assert mgr._rules_require_approval(None) is False
+        assert mgr._rules_require_approval({}) is False
+
+
+# ---------------------------------------------------------------------------
+# Condition matching helpers
+# ---------------------------------------------------------------------------
+
+
+class TestConditionMatching:
+    def test_repository_name_include_all_exclude_one(self) -> None:
+        mgr, _ = make_merge_manager()
+        include = ["*"]
+        exclude = ["project-reporting-artifacts"]
+        assert mgr._ruleset_name_matches("lftools-uv", include, exclude) is True
+        assert (
+            mgr._ruleset_name_matches("project-reporting-artifacts", include, exclude)
+            is False
+        )
+
+    def test_repository_name_all_sentinel(self) -> None:
+        mgr, _ = make_merge_manager()
+        assert mgr._ruleset_name_matches("anything", ["~ALL"], []) is True
+
+    def test_repository_name_empty_include_matches_nothing(self) -> None:
+        mgr, _ = make_merge_manager()
+        assert mgr._ruleset_name_matches("repo", [], []) is False
+
+    def test_ref_default_branch_is_in_scope(self) -> None:
+        mgr, _ = make_merge_manager()
+        assert mgr._ruleset_ref_matches("main", ["~DEFAULT_BRANCH"], []) is True
+
+    def test_ref_all_sentinel(self) -> None:
+        mgr, _ = make_merge_manager()
+        assert mgr._ruleset_ref_matches("any-branch", ["~ALL"], []) is True
+
+    def test_ref_explicit_pattern(self) -> None:
+        mgr, _ = make_merge_manager()
+        assert (
+            mgr._ruleset_ref_matches("release/1.2", ["refs/heads/release/*"], [])
+            is True
+        )
+        assert (
+            mgr._ruleset_ref_matches("feature/x", ["refs/heads/release/*"], []) is False
+        )
+
+    def test_ref_exclude_wins(self) -> None:
+        mgr, _ = make_merge_manager()
+        assert mgr._ruleset_ref_matches("main", ["~ALL"], ["refs/heads/main"]) is False
+
+    def test_ref_empty_include_is_undecidable(self) -> None:
+        mgr, _ = make_merge_manager()
+        assert mgr._ruleset_ref_matches("main", [], []) is None
+
+    def test_condition_applies_for_governed_repo_branch(self) -> None:
+        mgr, _ = make_merge_manager()
+        conditions = _BASE_PROTECTIONS_DETAIL["conditions"]
+        assert mgr._ruleset_condition_applies(conditions, "lftools-uv", "main") is True
+
+    def test_condition_excludes_listed_repo(self) -> None:
+        mgr, _ = make_merge_manager()
+        conditions = _BASE_PROTECTIONS_DETAIL["conditions"]
+        assert (
+            mgr._ruleset_condition_applies(
+                conditions, "project-reporting-artifacts", "main"
+            )
+            is False
+        )
+
+    def test_unknown_condition_type_is_undecidable(self) -> None:
+        mgr, _ = make_merge_manager()
+        conditions: dict[str, Any] = {"repository_property": {"include": []}}
+        assert mgr._ruleset_condition_applies(conditions, "repo", "main") is None
+
+
+# ---------------------------------------------------------------------------
+# _org_approval_rulesets
+# ---------------------------------------------------------------------------
+
+
+class TestOrgApprovalRulesets:
+    @pytest.mark.asyncio
+    async def test_enumerates_only_approval_rulesets(self) -> None:
+        mgr, client = make_merge_manager()
+        client.get = AsyncMock(side_effect=_org_get_router())
+
+        result = await mgr._org_approval_rulesets("lfreleng-actions")
+
+        assert result is not None
+        names = {r["name"] for r in result}
+        assert names == {"Base Protections"}
+
+    @pytest.mark.asyncio
+    async def test_result_is_cached(self) -> None:
+        mgr, client = make_merge_manager()
+        client.get = AsyncMock(side_effect=_org_get_router())
+
+        await mgr._org_approval_rulesets("lfreleng-actions")
+        calls_after_first = client.get.await_count
+        await mgr._org_approval_rulesets("lfreleng-actions")
+
+        assert client.get.await_count == calls_after_first
+
+    @pytest.mark.asyncio
+    async def test_skips_inactive_rulesets(self) -> None:
+        mgr, client = make_merge_manager()
+        inactive = [
+            {
+                "id": 4129117,
+                "name": "Base Protections",
+                "target": "branch",
+                "enforcement": "evaluate",
+            }
+        ]
+        client.get = AsyncMock(side_effect=_org_get_router(list_payload=inactive))
+
+        result = await mgr._org_approval_rulesets("lfreleng-actions")
+
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_enumeration_failure_returns_none(self) -> None:
+        mgr, client = make_merge_manager()
+        client.get = AsyncMock(side_effect=RuntimeError("403 Forbidden"))
+
+        result = await mgr._org_approval_rulesets("lfreleng-actions")
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_paginates_past_first_page(self) -> None:
+        """An approval ruleset beyond the first page must still be found.
+
+        The list endpoint is paginated (the manager requests pages of 100
+        and stops on the first short page).  Return a full first page of
+        inactive filler rulesets to force a second request, and place the
+        approval-mandating ruleset on page two; it must not be dropped.
+        """
+        mgr, client = make_merge_manager()
+        # A full page (== the manager's per_page of 100) forces another
+        # request.  Inactive rulesets are skipped before any detail fetch.
+        page_one = [
+            {
+                "id": 900000 + i,
+                "name": f"Filler {i}",
+                "target": "branch",
+                "enforcement": "disabled",
+            }
+            for i in range(100)
+        ]
+        page_two = [
+            {
+                "id": 4129117,
+                "name": "Base Protections",
+                "target": "branch",
+                "enforcement": "active",
+            }
+        ]
+
+        async def _get(path: str):
+            base, _, query = path.partition("?")
+            if base.endswith("/rulesets"):
+                page = 1
+                for part in query.split("&"):
+                    if part.startswith("page="):
+                        page = int(part.split("=", 1)[1])
+                return {1: page_one, 2: page_two}.get(page, [])
+            if base.endswith("/rulesets/4129117"):
+                return _BASE_PROTECTIONS_DETAIL
+            raise AssertionError(f"unexpected GET {path}")
+
+        client.get = AsyncMock(side_effect=_get)
+
+        result = await mgr._org_approval_rulesets("lfreleng-actions")
+
+        assert result is not None
+        names = {r["name"] for r in result}
+        assert names == {"Base Protections"}
+
+
+# ---------------------------------------------------------------------------
+# _branch_requires_approval (org-first resolution)
+# ---------------------------------------------------------------------------
+
+
+class TestBranchRequiresApproval:
+    @pytest.mark.asyncio
+    async def test_governed_repo_resolved_without_per_repo_call(self) -> None:
+        """A locally-decidable org ruleset must not hit the per-repo endpoint."""
+        mgr, client = make_merge_manager()
+        client.get = AsyncMock(side_effect=_org_get_router())
+
+        with patch.object(
+            mgr, "_effective_branch_requires_approval", new_callable=AsyncMock
+        ) as mock_effective:
+            requires = await mgr._branch_requires_approval(
+                "lfreleng-actions", "lftools-uv", "main"
+            )
+
+        assert requires is True
+        mock_effective.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_excluded_repo_is_not_required(self) -> None:
+        mgr, client = make_merge_manager()
+        client.get = AsyncMock(side_effect=_org_get_router())
+
+        requires = await mgr._branch_requires_approval(
+            "lfreleng-actions", "project-reporting-artifacts", "main"
+        )
+
+        assert requires is False
+
+    @pytest.mark.asyncio
+    async def test_org_without_approval_ruleset_skips_per_repo_call(self) -> None:
+        mgr, client = make_merge_manager()
+        client.get = AsyncMock(
+            side_effect=_org_get_router(
+                list_payload=[
+                    {
+                        "id": 17275268,
+                        "name": "Mandatory workflows",
+                        "target": "branch",
+                        "enforcement": "active",
+                    }
+                ]
+            )
+        )
+
+        with patch.object(
+            mgr, "_effective_branch_requires_approval", new_callable=AsyncMock
+        ) as mock_effective:
+            requires = await mgr._branch_requires_approval(
+                "lfreleng-actions", "lftools-uv", "main"
+            )
+
+        assert requires is False
+        mock_effective.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_falls_back_when_enumeration_fails(self) -> None:
+        mgr, client = make_merge_manager()
+        client.get = AsyncMock(side_effect=RuntimeError("403 Forbidden"))
+
+        with patch.object(
+            mgr,
+            "_effective_branch_requires_approval",
+            new_callable=AsyncMock,
+            return_value=True,
+        ) as mock_effective:
+            requires = await mgr._branch_requires_approval(
+                "lfreleng-actions", "lftools-uv", "main"
+            )
+
+        assert requires is True
+        mock_effective.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_falls_back_for_unknown_condition(self) -> None:
+        mgr, client = make_merge_manager()
+        detail = {
+            "id": 99,
+            "name": "Property-scoped",
+            "target": "branch",
+            "enforcement": "active",
+            "conditions": {"repository_property": {"include": []}},
+            "rules": [
+                {
+                    "type": "pull_request",
+                    "parameters": {"required_approving_review_count": 1},
+                }
+            ],
+        }
+        client.get = AsyncMock(
+            side_effect=_org_get_router(
+                list_payload=[
+                    {
+                        "id": 99,
+                        "name": "Property-scoped",
+                        "target": "branch",
+                        "enforcement": "active",
+                    }
+                ],
+                details={99: detail},
+            )
+        )
+
+        with patch.object(
+            mgr,
+            "_effective_branch_requires_approval",
+            new_callable=AsyncMock,
+            return_value=True,
+        ) as mock_effective:
+            requires = await mgr._branch_requires_approval(
+                "lfreleng-actions", "lftools-uv", "main"
+            )
+
+        assert requires is True
+        mock_effective.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_verdict_is_cached_per_repo_branch(self) -> None:
+        mgr, client = make_merge_manager()
+        client.get = AsyncMock(side_effect=_org_get_router())
+
+        await mgr._branch_requires_approval("lfreleng-actions", "lftools-uv", "main")
+        calls = client.get.await_count
+        await mgr._branch_requires_approval("lfreleng-actions", "lftools-uv", "main")
+
+        assert client.get.await_count == calls
+
+
+# ---------------------------------------------------------------------------
+# _effective_branch_requires_approval (authoritative per-repo fallback)
+# ---------------------------------------------------------------------------
+
+
+class TestEffectiveBranchRequiresApproval:
+    @pytest.mark.asyncio
+    async def test_branch_name_is_url_encoded(self) -> None:
+        """A branch with "/" must be encoded so the endpoint resolves.
+
+        An unencoded "release/v1" would split the REST path and 404,
+        which the method would misread as "no rules" and skip a required
+        proactive approval.
+        """
+        mgr, client = make_merge_manager()
+        seen: list[str] = []
+
+        async def _get(path: str):
+            seen.append(path)
+            return [
+                {
+                    "type": "pull_request",
+                    "parameters": {"required_approving_review_count": 1},
+                }
+            ]
+
+        client.get = AsyncMock(side_effect=_get)
+
+        requires = await mgr._effective_branch_requires_approval(
+            "lfreleng-actions", "lftools-uv", "release/v1"
+        )
+
+        assert requires is True
+        assert seen == [
+            "/repos/lfreleng-actions/lftools-uv/rules/branches/release%2Fv1"
+        ]
+
+
+# ---------------------------------------------------------------------------
+# _approve_if_review_mandated (proactive approval wiring)
+# ---------------------------------------------------------------------------
+
+
+_PR = PullRequestInfo(
+    number=484,
+    node_id="PR_kwDOTest484",
+    title="Bump boto3",
+    body="Dependabot PR",
+    author="dependabot[bot]",
+    head_sha="abc123",
+    base_branch="main",
+    head_branch="dependabot/pip/boto3",
+    state="open",
+    mergeable=True,
+    mergeable_state="blocked",
+    behind_by=0,
+    files_changed=[],
+    repository_full_name="lfreleng-actions/lftools-uv",
+    html_url="https://github.com/lfreleng-actions/lftools-uv/pull/484",
+    reviews=[],
+    review_comments=[],
+)
+
+
+class TestApproveIfReviewMandated:
+    @pytest.mark.asyncio
+    async def test_approves_when_branch_requires_review(self) -> None:
+        mgr, _ = make_merge_manager()
+        with (
+            patch.object(
+                mgr,
+                "_branch_requires_approval",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
+            patch.object(
+                mgr, "_ensure_pr_approved", new_callable=AsyncMock
+            ) as mock_approve,
+        ):
+            await mgr._approve_if_review_mandated(
+                _PR, "lfreleng-actions", "lftools-uv", "lfreleng-actions/lftools-uv#484"
+            )
+
+        mock_approve.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_no_approval_when_not_required(self) -> None:
+        mgr, _ = make_merge_manager()
+        with (
+            patch.object(
+                mgr,
+                "_branch_requires_approval",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+            patch.object(
+                mgr, "_ensure_pr_approved", new_callable=AsyncMock
+            ) as mock_approve,
+        ):
+            await mgr._approve_if_review_mandated(
+                _PR, "lfreleng-actions", "lftools-uv", "lfreleng-actions/lftools-uv#484"
+            )
+
+        mock_approve.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_preview_mode_no_op(self) -> None:
+        mgr, _ = make_merge_manager(preview_mode=True)
+        with (
+            patch.object(
+                mgr, "_branch_requires_approval", new_callable=AsyncMock
+            ) as mock_requires,
+            patch.object(
+                mgr, "_ensure_pr_approved", new_callable=AsyncMock
+            ) as mock_approve,
+        ):
+            await mgr._approve_if_review_mandated(
+                _PR, "lfreleng-actions", "lftools-uv", "lfreleng-actions/lftools-uv#484"
+            )
+
+        mock_requires.assert_not_called()
+        mock_approve.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_skips_when_already_approved(self) -> None:
+        mgr, _ = make_merge_manager()
+        pr_key = "lfreleng-actions/lftools-uv#484"
+        mgr._recently_approved.add(pr_key)
+        with (
+            patch.object(
+                mgr, "_branch_requires_approval", new_callable=AsyncMock
+            ) as mock_requires,
+            patch.object(
+                mgr, "_ensure_pr_approved", new_callable=AsyncMock
+            ) as mock_approve,
+        ):
+            await mgr._approve_if_review_mandated(
+                _PR, "lfreleng-actions", "lftools-uv", pr_key
+            )
+
+        mock_requires.assert_not_called()
+        mock_approve.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Reactive merge-error approval signal
+# ---------------------------------------------------------------------------
+
+
+class TestMergeErrorIndicatesMissingApproval:
+    def test_ruleset_required_approvals_phrasing(self) -> None:
+        mgr, _ = make_merge_manager()
+        msg = (
+            "Failed to merge PR #484. Error: 405. GitHub: Repository rule "
+            "violations found Waiting on required approvals from "
+            "lfreleng-actions/releng."
+        )
+        assert mgr._merge_error_indicates_missing_approval(msg) is True
+
+    def test_branch_protection_phrasing(self) -> None:
+        mgr, _ = make_merge_manager()
+        msg = "At least 1 approving review is required by reviewers with write access."
+        assert mgr._merge_error_indicates_missing_approval(msg) is True
+
+    def test_unrelated_failure_is_not_approval(self) -> None:
+        mgr, _ = make_merge_manager()
+        msg = "Required status check 'ci/test' is expected."
+        assert mgr._merge_error_indicates_missing_approval(msg) is False
+
+    def test_empty_text(self) -> None:
+        mgr, _ = make_merge_manager()
+        assert mgr._merge_error_indicates_missing_approval("") is False

--- a/tests/test_stuck_check_detection.py
+++ b/tests/test_stuck_check_detection.py
@@ -540,7 +540,7 @@ class TestReportMergeFailure:
             ),
             patch.object(
                 mgr,
-                "_enable_auto_merge_for_pr",
+                "_enable_auto_merge_with_approval",
                 new_callable=AsyncMock,
                 return_value=True,
             ) as mock_enable,

--- a/tests/test_workflow_scope.py
+++ b/tests/test_workflow_scope.py
@@ -90,6 +90,20 @@ class TestTokenScopes:
         assert await api2.check_workflow_scope() is False
 
     @pytest.mark.asyncio
+    async def test_transient_probe_failure_is_not_cached(self):
+        api = _make_api()
+        # A one-off probe failure must yield "undeterminable" without
+        # caching, so it cannot suppress accurate diagnosis later.
+        api._request = AsyncMock(side_effect=RuntimeError("transient boom"))
+        assert await api.get_token_scopes() is None
+
+        # A subsequent call retries and can now report the real scopes.
+        resp = Mock()
+        resp.headers = {"X-OAuth-Scopes": "repo, workflow"}
+        api._request = AsyncMock(return_value=resp)
+        assert await api.get_token_scopes() == {"repo", "workflow"}
+
+    @pytest.mark.asyncio
     async def test_probe_failure_is_undeterminable(self):
         api = _make_api()
         api._request = AsyncMock(side_effect=RuntimeError("network down"))
@@ -254,6 +268,25 @@ class TestDetectBranchProtectionKind:
 
         api.get = fake_get
         assert await api._detect_branch_protection_kind("o", "r", "main") == "none"
+
+    @pytest.mark.asyncio
+    async def test_branch_name_is_url_encoded(self):
+        api = _make_api()
+        seen_paths: list[str] = []
+
+        async def fake_get(path, params=None):
+            seen_paths.append(path)
+            if "/rules/branches/" in path:
+                return [{"type": "pull_request"}]
+            raise AssertionError(f"unexpected path {path}")
+
+        api.get = fake_get
+        kind = await api._detect_branch_protection_kind("o", "r", "release/v1")
+        assert kind == "ruleset"
+        # The '/' in the branch name must be percent-encoded, not passed
+        # through raw (which would 404 / misroute the REST call).
+        assert "release%2Fv1" in seen_paths[0]
+        assert "release/v1" not in seen_paths[0]
 
 
 class TestAnalyzeBlockReasonFallback:

--- a/tests/test_workflow_scope.py
+++ b/tests/test_workflow_scope.py
@@ -1,0 +1,328 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2025 The Linux Foundation
+
+"""Tests for token-scope introspection, the workflow-scope pre-flight
+check, the scope-aware workflow-error classifier, and the ruleset-aware
+``analyze_block_reason`` fallback.
+
+These cover the behaviour added so the tool no longer:
+
+* reports a merge failure as "missing workflow scope" when the token
+  actually carries that scope, and
+* asserts "branch protection" for a blocked PR when the real guard is a
+  repository ruleset (or no detectable rule at all).
+"""
+
+from types import SimpleNamespace
+from typing import cast
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from dependamerge.cli import _MergeContext, _source_pr_modifies_workflows
+from dependamerge.github_async import GitHubAsync
+from dependamerge.github_async import PermissionError as GitHubPermissionError
+from dependamerge.models import FileChange, PullRequestInfo
+
+
+def _make_api() -> GitHubAsync:
+    """Construct a client with a dummy token (no network is performed)."""
+    return GitHubAsync(token="test_token")
+
+
+class _FakeWorkflowResponse:
+    """Minimal stand-in for an httpx response carrying a workflow 403 body."""
+
+    status_code = 403
+    text = (
+        "refusing to allow a Personal Access Token to create or update "
+        "workflow `.github/workflows/build.yml` without `workflow` scope"
+    )
+
+
+class _WorkflowForbidden(Exception):
+    """403 error whose response body is GitHub's workflow-scope refusal."""
+
+    def __init__(self) -> None:
+        super().__init__("403 Client Error: Forbidden")
+        self.response = _FakeWorkflowResponse()
+
+
+class TestTokenScopes:
+    """``get_token_scopes`` / ``check_workflow_scope`` introspection."""
+
+    @pytest.mark.asyncio
+    async def test_classic_token_scopes_parsed_from_header(self):
+        api = _make_api()
+        resp = Mock()
+        resp.headers = {"X-OAuth-Scopes": "repo, workflow, admin:org"}
+        api._request = AsyncMock(return_value=resp)
+
+        scopes = await api.get_token_scopes()
+
+        assert scopes == {"repo", "workflow", "admin:org"}
+        # Cached: a second call must not hit the network again.
+        await api.get_token_scopes()
+        api._request.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_fine_grained_token_returns_none(self):
+        api = _make_api()
+        resp = Mock()
+        resp.headers = {}  # fine-grained / app tokens omit the header
+        api._request = AsyncMock(return_value=resp)
+
+        assert await api.get_token_scopes() is None
+        assert await api.check_workflow_scope() is None
+
+    @pytest.mark.asyncio
+    async def test_check_workflow_scope_true_and_false(self):
+        api = _make_api()
+        resp = Mock()
+        resp.headers = {"X-OAuth-Scopes": "repo, workflow"}
+        api._request = AsyncMock(return_value=resp)
+        assert await api.check_workflow_scope() is True
+
+        api2 = _make_api()
+        resp2 = Mock()
+        resp2.headers = {"X-OAuth-Scopes": "repo"}
+        api2._request = AsyncMock(return_value=resp2)
+        assert await api2.check_workflow_scope() is False
+
+    @pytest.mark.asyncio
+    async def test_probe_failure_is_undeterminable(self):
+        api = _make_api()
+        api._request = AsyncMock(side_effect=RuntimeError("network down"))
+        assert await api.get_token_scopes() is None
+
+
+class TestWorkflowPreflight:
+    """``check_token_permissions`` handling of the ``merge_workflow`` op."""
+
+    @pytest.mark.asyncio
+    async def test_missing_workflow_scope_blocks(self):
+        api = _make_api()
+        api.check_workflow_scope = AsyncMock(return_value=False)
+
+        results = await api.check_token_permissions(["merge_workflow"])
+
+        assert results["merge_workflow"]["has_permission"] is False
+        assert "workflow" in results["merge_workflow"]["error"].lower()
+        assert results["merge_workflow"]["guidance"]["classic"]
+
+    @pytest.mark.asyncio
+    async def test_present_workflow_scope_passes(self):
+        api = _make_api()
+        api.check_workflow_scope = AsyncMock(return_value=True)
+        results = await api.check_token_permissions(["merge_workflow"])
+        assert results["merge_workflow"]["has_permission"] is True
+
+    @pytest.mark.asyncio
+    async def test_undeterminable_scope_passes(self):
+        # Fine-grained tokens cannot be checked up-front; never block them.
+        api = _make_api()
+        api.check_workflow_scope = AsyncMock(return_value=None)
+        results = await api.check_token_permissions(["merge_workflow"])
+        assert results["merge_workflow"]["has_permission"] is True
+
+
+class TestScopeAwareMergeClassifier:
+    """``merge_pull_request`` must not blame a scope the token already has."""
+
+    @pytest.mark.asyncio
+    async def test_workflow_403_without_scope_keeps_scope_guidance(self):
+        api = _make_api()
+        api.put = AsyncMock(side_effect=_WorkflowForbidden())
+        api.check_workflow_scope = AsyncMock(return_value=False)
+
+        with pytest.raises(GitHubPermissionError) as exc_info:
+            await api.merge_pull_request("owner", "repo", 1)
+
+        assert exc_info.value.operation == "merge_workflow"
+
+    @pytest.mark.asyncio
+    async def test_workflow_403_with_scope_is_reclassified(self):
+        api = _make_api()
+        api.put = AsyncMock(side_effect=_WorkflowForbidden())
+        # Token DOES carry the workflow scope, so the refusal is not a
+        # scope problem — it must be reclassified, not repeated verbatim.
+        api.check_workflow_scope = AsyncMock(return_value=True)
+
+        with pytest.raises(GitHubPermissionError) as exc_info:
+            await api.merge_pull_request("owner", "repo", 1)
+
+        err = exc_info.value
+        assert err.operation == "merge_workflow_restricted"
+        assert "already has the 'workflow' scope" in str(err)
+        assert "ruleset" in err.token_type_guidance["classic"].lower()
+
+
+def _pr_with_files(*filenames: str) -> PullRequestInfo:
+    """Build a minimal PR whose changed files are *filenames*."""
+    return PullRequestInfo(
+        number=1,
+        title="Bump action",
+        body=None,
+        author="dependabot[bot]",
+        head_sha="abc",
+        base_branch="main",
+        head_branch="dependabot/x",
+        state="open",
+        mergeable=True,
+        mergeable_state="blocked",
+        behind_by=0,
+        files_changed=[
+            FileChange(
+                filename=name,
+                additions=1,
+                deletions=1,
+                changes=2,
+                status="modified",
+            )
+            for name in filenames
+        ],
+        repository_full_name="owner/repo",
+        html_url="https://github.com/owner/repo/pull/1",
+    )
+
+
+class TestSourcePrModifiesWorkflows:
+    """CLI detection of workflow-file changes on the source PR."""
+
+    def test_detects_workflow_yaml(self):
+        ctx = SimpleNamespace(source_pr=_pr_with_files(".github/workflows/build.yaml"))
+        assert _source_pr_modifies_workflows(cast(_MergeContext, ctx)) is True
+
+    def test_detects_workflow_yml(self):
+        ctx = SimpleNamespace(
+            source_pr=_pr_with_files("README.md", ".github/workflows/ci.yml")
+        )
+        assert _source_pr_modifies_workflows(cast(_MergeContext, ctx)) is True
+
+    def test_ignores_non_workflow_changes(self):
+        ctx = SimpleNamespace(
+            source_pr=_pr_with_files("src/app.py", ".github/dependabot.yml")
+        )
+        assert _source_pr_modifies_workflows(cast(_MergeContext, ctx)) is False
+
+    def test_handles_missing_source_pr(self):
+        ctx = SimpleNamespace(source_pr=None)
+        assert _source_pr_modifies_workflows(cast(_MergeContext, ctx)) is False
+
+
+class TestDetectBranchProtectionKind:
+    """``_detect_branch_protection_kind`` classification."""
+
+    @pytest.mark.asyncio
+    async def test_ruleset_detected(self):
+        api = _make_api()
+
+        async def fake_get(path, params=None):
+            if "/rules/branches/" in path:
+                return [{"type": "pull_request"}]
+            raise AssertionError(f"unexpected path {path}")
+
+        api.get = fake_get
+        assert await api._detect_branch_protection_kind("o", "r", "main") == "ruleset"
+
+    @pytest.mark.asyncio
+    async def test_classic_protection_detected(self):
+        api = _make_api()
+
+        async def fake_get(path, params=None):
+            if "/rules/branches/" in path:
+                return []
+            if path.endswith("/protection"):
+                return {"required_status_checks": {}}
+            raise AssertionError(f"unexpected path {path}")
+
+        api.get = fake_get
+        assert (
+            await api._detect_branch_protection_kind("o", "r", "main") == "protection"
+        )
+
+    @pytest.mark.asyncio
+    async def test_none_when_unguarded(self):
+        api = _make_api()
+
+        async def fake_get(path, params=None):
+            if "/rules/branches/" in path:
+                return []
+            if path.endswith("/protection"):
+                raise RuntimeError("404 Not Found: Branch not protected")
+            raise AssertionError(f"unexpected path {path}")
+
+        api.get = fake_get
+        assert await api._detect_branch_protection_kind("o", "r", "main") == "none"
+
+
+class TestAnalyzeBlockReasonFallback:
+    """The catch-all fallback must be ruleset-aware and non-asserting."""
+
+    def _wire_clean_approved_pr(self, api: GitHubAsync, kind_rules):
+        """Mock a PR that is approved, all checks green, no changes
+        requested — so analysis reaches the final fallback — and let the
+        caller choose what ``/rules/branches`` and ``/protection`` return.
+        """
+        api.get_required_status_checks = AsyncMock(return_value=[])  # type: ignore[method-assign]
+
+        async def fake_get(path, params=None):
+            if path.endswith("/reviews"):
+                return [{"state": "APPROVED", "user": {"login": "reviewer"}}]
+            if path.endswith("/comments"):
+                return []
+            if "/check-runs" in path:
+                return {"check_runs": []}
+            if path.endswith("/status"):
+                return {"statuses": []}
+            if "/rules/branches/" in path:
+                return kind_rules["rules"]
+            if path.endswith("/protection"):
+                if kind_rules["protection"]:
+                    return {"required_status_checks": {}}
+                raise RuntimeError("404 Not Found")
+            if "/pulls/" in path:
+                return {"base": {"ref": "main"}}
+            return {}
+
+        api.get = fake_get  # type: ignore[method-assign]
+
+    @pytest.mark.asyncio
+    async def test_fallback_reports_ruleset(self):
+        api = _make_api()
+        self._wire_clean_approved_pr(
+            api, {"rules": [{"type": "required_signatures"}], "protection": False}
+        )
+        reason = await api.analyze_block_reason("o", "r", 1, "deadbeef")
+        assert reason == (
+            "Blocked by repository ruleset (no specific failing condition detected)"
+        )
+
+    @pytest.mark.asyncio
+    async def test_fallback_reports_undetermined_when_unguarded(self):
+        api = _make_api()
+        self._wire_clean_approved_pr(api, {"rules": [], "protection": False})
+        reason = await api.analyze_block_reason("o", "r", 1, "deadbeef")
+        assert reason.startswith("Blocked for an undetermined reason")
+
+    @pytest.mark.asyncio
+    async def test_requires_approval_still_specific(self):
+        api = _make_api()
+        api.get_required_status_checks = AsyncMock(return_value=[])
+
+        async def fake_get(path, params=None):
+            if path.endswith("/reviews"):
+                return []  # not approved
+            if path.endswith("/comments"):
+                return []
+            if "/check-runs" in path:
+                return {"check_runs": []}
+            if path.endswith("/status"):
+                return {"statuses": []}
+            if "/pulls/" in path:
+                return {"base": {"ref": "main"}}
+            return {}
+
+        api.get = fake_get
+        reason = await api.analyze_block_reason("o", "r", 1, "deadbeef")
+        assert reason == "Blocked by branch protection (requires approval)"


### PR DESCRIPTION
## Summary

This addresses a class of failures where `dependamerge` refused to merge
PRs that were approved and mergeable in the GitHub UI (the green "Merge
pull request" button was visible), and reported inaccurate block reasons
when merges genuinely failed. It also adds proactive detection of
organization rulesets that mandate an approving review before any merge.

The investigation started from a real case: a mergeable, approved
dependabot PR was reported as `Blocked by branch protection` and then
failed with a bogus "missing `workflow` scope" message — even though the
classic token already carried that scope. The real cause was a
workflow-file restriction, and the predictive guard in front of the
merge was mis-diagnosing the branch-protection/ruleset state.

A later case surfaced the inverse problem: every dependabot PR in an org
gated on an approving review failed, because approval was only triggered
when the block heuristic happened to report the literal "requires
approval" first.

The change set has four atomic commits.

### `Fix: Diagnose workflow-scope and ruleset blocks`

- Introspect the token's **actual** scopes. Classic PATs expose them via
  the `X-OAuth-Scopes` response header; fine-grained and app tokens do
  not, so they are treated as undeterminable and **never** used to block
  a merge.
- Only require the workflow permission when the source PR actually
  touches `.github/workflows/**`.
- Reclassify a workflow `403` as a ruleset/SSO problem (not a missing
  scope) when the token already holds `workflow`.
- Make the catch-all block-reason fallback **ruleset-aware and
  non-asserting** so it no longer claims "branch protection" for a
  repository ruleset or an undetermined block. The failure summary and
  the dependabot recreate trigger recognise ruleset/undetermined blocks.

### `Refactor: Attempt merges first, approve on demand`

- Execution is now **attempt-first**. GitHub's `mergeable_state` lags and
  is blind to repository rulesets, so the dry-run predictor (renamed
  `_predict_merge_outcome`, documented as non-authoritative) runs **only**
  in preview mode. The real merge response is the source of truth.
- Approval is now **on demand** rather than up-front: a PR is approved
  just before auto-merge is armed, or after a direct merge is rejected
  *specifically* because our review is missing (then retried once). This
  avoids approving PRs that never needed our review.
- Force-level semantics, the per-repo dispatch lock, and conflict
  recovery are unchanged.

### `Style: Fix emoji spacing for compliant terminals`

- Variation-selector emoji (ending in `U+FE0F`) render two cells wide on
  Unicode-compliant terminals (e.g. Ghostty). A trailing double space had
  been hacked in after each to align output on terminals that render them
  one cell wide (e.g. Apple Terminal.app), which produced an oversized
  gap on compliant terminals. Collapsed to a single space everywhere.
- Dropped the redundant chart glyph that prefixed the merge-results stats
  line, and gave the bare `Similar` entry its own glyph for consistency.

### `Fix: Detect and satisfy required-review rulesets`

- **Proactive, org-first detection.** Enumerate the organization's
  rulesets once (`GET /orgs/{org}/rulesets` + details), evaluate their
  `repository_name` / `ref_name` conditions locally, and approve the
  current head **before** dispatch when the base branch is gated on a
  `pull_request` rule requiring approving reviews. A whole org-wide run
  needs a single ruleset enumeration rather than one effective-rules call
  per repository, so it adds no per-PR round-trips on the hot path.
- **Org-agnostic.** Detection keys on the *rule type*, not the ruleset
  name, so it works regardless of what an org calls its ruleset (e.g.
  "Base Protections"). The authoritative per-repo
  `rules/branches/{branch}` endpoint is consulted only as a fallback for
  conditions that cannot be evaluated locally, or when org enumeration is
  unavailable.
- **Reactive safety net.** Also approve-and-retry when GitHub's
  merge-rejection body itself names a missing required approval, so a
  masked or mis-prioritised block reason can no longer strand a mergeable
  PR.
- **Visible reporting.** A concise two-line message is emitted once at the
  point of detection:
  ```
  🔐 Organization requires approving reviews before merging
  Ruleset: Base Protections
  ```

## Validation

- `uv run ruff check` / `ruff format` — clean
- `uv run mypy src/dependamerge/` and `basedpyright` — clean
- `uv run pytest tests/` — **1052 passed**, coverage 63% (gate 45%)
- New tests: `tests/test_workflow_scope.py` (19),
  `tests/test_approve_on_demand.py` (10),
  `tests/test_required_approval_detection.py` (34)
- Live: a full org-wide run merged all 17 open dependabot PRs in
  `lfreleng-actions/lftools-uv`, using org-level ruleset queries only
  (zero per-repo effective-rules calls on the merge path).

Co-authored-by: Claude 