### PR TITLE
Fix: Resolve actual default branch in block diagnosis

### DIFF
--- a/src/dependamerge/github_async.py
+++ b/src/dependamerge/github_async.py
@@ -1961,36 +1961,55 @@ class GitHubAsync:
         # Detect missing/pending required status checks (e.g. stale pre-commit.ci)
         missing_required_checks: list[str] = []
         pending_required_checks: list[str] = []
-        # Default base branch; the block below refines it from the PR data
-        # and the fallback at the end of this method reuses it to classify
-        # what kind of rule is guarding the branch.
-        base_branch = "main"
+        # Resolve the PR's actual base branch.  It drives both the
+        # required status-check lookup and the final guard-kind
+        # classification, so a wrong value (e.g. assuming "main" on a repo
+        # that defaults to "master") produces a misleading block reason.
+        # Prefer the PR's own base ref; if that cannot be read, fall back
+        # to the repository's real default branch rather than a hardcoded
+        # name, and only give up (leaving it ``None``) when neither is
+        # available.
+        base_branch: str | None = None
         try:
-            # Determine the base branch for this PR
             pr_data = await self.get(f"/repos/{owner}/{repo}/pulls/{number}")
-            base_branch = (
-                pr_data.get("base", {}).get("ref", "main")
-                if isinstance(pr_data, dict)
-                else "main"
-            )
-            required_checks = await self.get_required_status_checks(
-                owner, repo, base_branch
-            )
-            for check in required_checks:
-                ctx = check.get("context", "")
-                if not ctx:
-                    continue
-                if ctx in reported_check_names:
-                    # Check has been reported — distinguish pending from completed
-                    if ctx not in completed_check_names and ctx in pending_check_names:
-                        pending_required_checks.append(ctx)
-                else:
-                    # Never reported via either API — truly missing
-                    missing_required_checks.append(ctx)
-        except Exception as req_err:
+            if isinstance(pr_data, dict):
+                ref = pr_data.get("base", {}).get("ref")
+                if isinstance(ref, str) and ref:
+                    base_branch = ref
+        except Exception as pr_err:
             self.log.debug(
-                f"Could not check required status checks for {owner}/{repo}#{number}: {req_err}"
+                f"Could not read base branch for {owner}/{repo}#{number}: {pr_err}"
             )
+
+        if base_branch is None:
+            base_branch = await self._resolve_default_branch(owner, repo)
+
+        # Only inspect required status checks when we know which branch to
+        # query; an assumed branch would yield checks for the wrong ref.
+        if base_branch is not None:
+            try:
+                required_checks = await self.get_required_status_checks(
+                    owner, repo, base_branch
+                )
+                for check in required_checks:
+                    ctx = check.get("context", "")
+                    if not ctx:
+                        continue
+                    if ctx in reported_check_names:
+                        # Check reported — distinguish pending from completed
+                        if (
+                            ctx not in completed_check_names
+                            and ctx in pending_check_names
+                        ):
+                            pending_required_checks.append(ctx)
+                    else:
+                        # Never reported via either API — truly missing
+                        missing_required_checks.append(ctx)
+            except Exception as req_err:
+                self.log.debug(
+                    f"Could not check required status checks for "
+                    f"{owner}/{repo}#{number}: {req_err}"
+                )
 
         # Prioritize blocking conditions by specificity
         # Most specific blockers first
@@ -2042,6 +2061,16 @@ class GitHubAsync:
         # rulesets), determine what kind of rule actually guards the branch
         # and keep the wording non-committal: we know the branch is guarded,
         # not that a specific condition is failing.
+        if base_branch is None:
+            # The base branch could not be resolved, so no branch-specific
+            # inspection ran.  Say exactly that rather than implying we
+            # looked for protection rules and found none.
+            return (
+                "Blocked for an undetermined reason "
+                "(GitHub reports the PR as blocked, but the PR's base "
+                "branch could not be determined, so its protection rules "
+                "and required checks could not be inspected)"
+            )
         kind = await self._detect_branch_protection_kind(owner, repo, base_branch)
         if kind == "ruleset":
             return (
@@ -2057,6 +2086,29 @@ class GitHubAsync:
             "required reviews, or visible protection rules were found; "
             "the repository may use rulesets this token cannot read)"
         )
+
+    async def _resolve_default_branch(self, owner: str, repo: str) -> str | None:
+        """Return the repository's actual default branch, or ``None``.
+
+        Many repositories default to ``master`` rather than ``main``, so
+        callers must never assume a name.  This reads the authoritative
+        ``default_branch`` field from the repository metadata and returns
+        ``None`` when it cannot be determined (the repo is unreadable or
+        the field is absent), letting callers degrade gracefully instead
+        of operating on a wrong branch.
+        """
+        try:
+            repo_data = await self.get(f"/repos/{owner}/{repo}")
+        except Exception as e:
+            self.log.debug(
+                "Could not resolve default branch for %s/%s: %s", owner, repo, e
+            )
+            return None
+        if isinstance(repo_data, dict):
+            default_branch = repo_data.get("default_branch")
+            if isinstance(default_branch, str) and default_branch:
+                return default_branch
+        return None
 
     async def _detect_branch_protection_kind(
         self, owner: str, repo: str, branch: str

--- a/tests/test_base_branch_resolution.py
+++ b/tests/test_base_branch_resolution.py
@@ -1,0 +1,144 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 The Linux Foundation
+
+"""Tests for base-branch resolution in block-reason analysis.
+
+Many repositories use ``master`` (not ``main``) as their default branch.
+``analyze_block_reason`` previously hardcoded ``main`` as both the initial
+value and the fallback for the PR's base branch, so when the PR base ref
+could not be read it would inspect required status checks and classify the
+guarding rule for the *wrong* branch — producing a misleading block reason
+on ``master`` repositories.
+
+It now prefers the PR's own base ref, falls back to the repository's real
+default branch, and only gives up (skipping branch-specific inspection)
+when neither can be determined.
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from dependamerge.github_async import GitHubAsync
+
+
+def _block_reason_router(*, pr_data, repo_data=None, reviews=None):
+    """Route ``analyze_block_reason``'s GETs.
+
+    The PR is approved with no failing/required checks so the method
+    reaches the final guard-kind classification, where the resolved base
+    branch is used.
+    """
+    reviews = reviews if reviews is not None else [{"state": "APPROVED", "user": {}}]
+
+    async def _get(url: str):
+        if url.endswith("/reviews"):
+            return reviews
+        if url.endswith("/comments"):
+            return []
+        if "/check-runs" in url:
+            return {"check_runs": []}
+        if url.endswith("/status"):
+            return {"statuses": []}
+        if url == "/repos/owner/repo":
+            if repo_data is None:
+                raise RuntimeError("403 Forbidden")
+            return repo_data
+        if url.endswith("/pulls/123"):
+            if pr_data is None:
+                raise RuntimeError("404 Not Found")
+            return pr_data
+        return {}
+
+    return _get
+
+
+class TestResolveDefaultBranch:
+    @pytest.mark.asyncio
+    async def test_returns_actual_default_branch(self) -> None:
+        async with GitHubAsync(token="t") as api:
+            api.get = AsyncMock(return_value={"default_branch": "master"})  # type: ignore[method-assign]
+            assert await api._resolve_default_branch("owner", "repo") == "master"
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_field_absent(self) -> None:
+        async with GitHubAsync(token="t") as api:
+            api.get = AsyncMock(return_value={})  # type: ignore[method-assign]
+            assert await api._resolve_default_branch("owner", "repo") is None
+
+    @pytest.mark.asyncio
+    async def test_returns_none_on_error(self) -> None:
+        async with GitHubAsync(token="t") as api:
+            api.get = AsyncMock(side_effect=RuntimeError("403 Forbidden"))  # type: ignore[method-assign]
+            assert await api._resolve_default_branch("owner", "repo") is None
+
+
+class TestAnalyzeBlockReasonBaseBranch:
+    @pytest.mark.asyncio
+    async def test_uses_pr_base_ref_not_assumed_main(self) -> None:
+        """The PR's own base ref (e.g. master) drives guard detection."""
+        async with GitHubAsync(token="t") as api:
+            api.get = _block_reason_router(pr_data={"base": {"ref": "master"}})  # type: ignore[method-assign]
+            api.get_required_status_checks = AsyncMock(return_value=[])  # type: ignore[method-assign]
+
+            with patch.object(
+                api,
+                "_detect_branch_protection_kind",
+                new_callable=AsyncMock,
+                return_value="ruleset",
+            ) as mock_kind:
+                result = await api.analyze_block_reason("owner", "repo", 123, "abc123")
+
+            assert "ruleset" in result.lower()
+            mock_kind.assert_awaited_once_with("owner", "repo", "master")
+            api.get_required_status_checks.assert_awaited_once_with(
+                "owner", "repo", "master"
+            )
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_repo_default_branch(self) -> None:
+        """When the PR base ref is unreadable, use the repo default branch."""
+        async with GitHubAsync(token="t") as api:
+            # PR data has no usable base ref; repo defaults to master.
+            router = _block_reason_router(
+                pr_data={}, repo_data={"default_branch": "master"}
+            )
+            api.get = router  # type: ignore[method-assign]
+            api.get_required_status_checks = AsyncMock(return_value=[])  # type: ignore[method-assign]
+
+            with patch.object(
+                api,
+                "_detect_branch_protection_kind",
+                new_callable=AsyncMock,
+                return_value="protection",
+            ) as mock_kind:
+                result = await api.analyze_block_reason("owner", "repo", 123, "abc123")
+
+            assert "protection" in result.lower()
+            mock_kind.assert_awaited_once_with("owner", "repo", "master")
+            api.get_required_status_checks.assert_awaited_once_with(
+                "owner", "repo", "master"
+            )
+
+    @pytest.mark.asyncio
+    async def test_undetermined_when_branch_cannot_be_resolved(self) -> None:
+        """No PR ref and no readable repo metadata: skip branch inspection."""
+        async with GitHubAsync(token="t") as api:
+            api.get = _block_reason_router(pr_data=None, repo_data=None)  # type: ignore[method-assign]
+            api.get_required_status_checks = AsyncMock(return_value=[])  # type: ignore[method-assign]
+
+            with patch.object(
+                api,
+                "_detect_branch_protection_kind",
+                new_callable=AsyncMock,
+            ) as mock_kind:
+                result = await api.analyze_block_reason("owner", "repo", 123, "abc123")
+
+            # The guard-kind probe must not run against an assumed branch.
+            mock_kind.assert_not_awaited()
+            # Required-status inspection must also be skipped.
+            api.get_required_status_checks.assert_not_awaited()
+            # The message must say the branch could not be determined,
+            # not imply protection rules were inspected and found absent.
+            assert "undetermined" in result.lower()
+            assert "base" in result.lower() and "branch" in result.lower()


### PR DESCRIPTION
## Summary

`analyze_block_reason()` hardcoded `main` as both the initial value and
the fallback for a PR's base branch. Many repositories default to
`master` rather than `main`, so whenever the PR base ref could not be
read the method inspected required status checks and classified the
guarding rule for the **wrong** branch — producing a misleading block
reason (e.g. "Blocked by repository ruleset" derived from a non-existent
`main` branch on a `master` repository).

> This PR builds on the attempt-first / required-review-detection work
> that merged via #338; it carries only the additional base-branch fix.

## Change

- Stop assuming a branch name. Prefer the PR's own base ref; when that
  cannot be read, fall back to the repository's real `default_branch`
  (via a new reusable `_resolve_default_branch()` helper that reads the
  authoritative `GET /repos/{owner}/{repo}` metadata).
- When neither can be determined, leave the branch unknown and **skip**
  the branch-specific required-status and guard-kind inspection rather
  than asserting a guess. A distinct "base branch could not be
  determined" message is returned in that case, so the diagnostic does
  not imply protection rules were inspected and found absent.

## Validation

- `uv run ruff check` / `ruff format` (pinned v0.15.18) — clean
- `uv run mypy src/dependamerge/ tests/` — clean
- `uv run pytest tests/` — **1061 passed**, coverage 63.5% (gate 45%)
- New tests: `tests/test_base_branch_resolution.py` covering the helper
  and the three `analyze_block_reason()` resolution paths (PR base ref,
  default-branch fallback, and unresolved).

Co-authored-by: Claude 