### PR TITLE
Fix: Retry merge on base-branch-modified race

### DIFF
--- a/src/dependamerge/merge_manager.py
+++ b/src/dependamerge/merge_manager.py
@@ -3776,6 +3776,27 @@ class AsyncMergeManager:
                 # Enhanced error handling with specific status code checks
                 if "405" in error_msg and "Method Not Allowed" in error_msg:
                     # Don't log here - will be handled in failure summary
+                    if "base branch was modified" in error_msg.lower():
+                        # Pure concurrency race: in a same-repo batch a
+                        # sibling PR merged and advanced the base branch
+                        # between GitHub computing this PR's merge commit
+                        # and applying it, so GitHub returns 405 "Base
+                        # branch was modified. Review and try the merge
+                        # again."  It is always transient and unrelated to
+                        # the PR's own mergeability (no rebase or approval
+                        # is needed), so a short delay lets GitHub recompute
+                        # against the new base head, then we retry.
+                        if attempt < self.max_retries:
+                            retry_delay = 2.0 * (attempt + 1)
+                            self.log.info(
+                                f"Base branch moved under {pr_key} (concurrent "
+                                f"merge); waiting {retry_delay}s before retry "
+                                f"(attempt {attempt + 1}/{self.max_retries + 1})…"
+                            )
+                            await asyncio.sleep(retry_delay)
+                            continue
+                        else:
+                            break
                     if "behind" in error_msg.lower() and self.fix_out_of_date:
                         # Allow retry for behind PRs
                         pass

--- a/tests/test_transient_merge_errors.py
+++ b/tests/test_transient_merge_errors.py
@@ -71,6 +71,24 @@ def _make_405_exception() -> httpx.HTTPStatusError:
     )
 
 
+def _make_405_base_modified_exception() -> Exception:
+    """Create a 405 carrying GitHub's "Base branch was modified" body.
+
+    This mirrors the enhanced error string produced by
+    ``merge_pull_request``/``_validate_merge_result``: the original 405
+    status line plus GitHub's response body, which is what the retry
+    classifier in ``_merge_pr_with_retry`` string-matches.
+    """
+    return Exception(
+        "Failed to merge PR #39 in org/repo. Error: Client error "
+        "'405 Method Not Allowed' for url "
+        "'https://api.github.com/repos/org/repo/pulls/39/merge'. "
+        "GitHub: Base branch was modified. Review and try the merge again. "
+        "(PR state: open, mergeable: True, mergeable_state: behind) "
+        "[PR branch is behind base branch]"
+    )
+
+
 def _make_502_exception() -> httpx.HTTPStatusError:
     """Create a realistic 502 HTTPStatusError."""
     request = httpx.Request(
@@ -304,6 +322,77 @@ class TestTransient405Retry:
 
         assert result is True
         assert client.merge_pull_request.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_405_base_branch_modified_retries_and_succeeds(self):
+        """A "Base branch was modified" 405 is a transient race: retry.
+
+        The PR is ``behind`` and ``fix_out_of_date`` is off, so without the
+        dedicated base-modified handling this 405 would fall through to the
+        terminal ``else: break`` and report a false failure.  The race
+        clears on retry (a sibling merge advanced the base), so the second
+        attempt succeeds.
+        """
+        pr = _make_pr_info(mergeable_state="behind", mergeable=True)
+
+        mgr, client = make_merge_manager(
+            merge_method="merge",
+            max_retries=2,
+            concurrency=1,
+            fix_out_of_date=False,
+        )
+        mgr._pr_merge_methods["org/repo"] = "merge"
+
+        client.merge_pull_request = AsyncMock(
+            side_effect=[_make_405_base_modified_exception(), True]
+        )
+        # Re-fetch before the retry shows the PR still open (not merged).
+        client.get = AsyncMock(
+            return_value={
+                "mergeable": True,
+                "mergeable_state": "clean",
+                "state": "open",
+                "merged": False,
+            }
+        )
+
+        with patch("asyncio.sleep", new_callable=AsyncMock):
+            result = await mgr._merge_pr_with_retry(pr, "org", "repo")
+
+        assert result is True
+        assert client.merge_pull_request.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_405_base_branch_modified_exhausts_retries(self):
+        """A persistent base-modified 405 gives up after max_retries."""
+        pr = _make_pr_info(mergeable_state="behind", mergeable=True)
+
+        mgr, client = make_merge_manager(
+            merge_method="merge",
+            max_retries=2,
+            concurrency=1,
+            fix_out_of_date=False,
+        )
+        mgr._pr_merge_methods["org/repo"] = "merge"
+
+        client.merge_pull_request = AsyncMock(
+            side_effect=_make_405_base_modified_exception()
+        )
+        client.get = AsyncMock(
+            return_value={
+                "mergeable": True,
+                "mergeable_state": "behind",
+                "state": "open",
+                "merged": False,
+            }
+        )
+
+        with patch("asyncio.sleep", new_callable=AsyncMock):
+            result = await mgr._merge_pr_with_retry(pr, "org", "repo")
+
+        assert result is False
+        # Initial attempt + max_retries = 3 attempts total.
+        assert client.merge_pull_request.call_count == 3
 
 
 # -------------------------------------------------------------------


### PR DESCRIPTION
## Summary

In a repository-scoped batch, sibling pull requests merge in quick succession and each merge advances the base branch head. When GitHub computes a PR's merge commit against one base head but a sibling merge lands before it is applied, the merge endpoint returns **HTTP 405**:

> `Base branch was modified. Review and try the merge again.`

This is a pure **concurrency race**, not a property of the PR itself — no rebase or approval is required, and the same merge succeeds moments later once GitHub recomputes against the new base head.

The retry classifier in `_merge_pr_with_retry` did not recognise this message. Depending on the cached `mergeable_state`, the 405 could fall through to the terminal `else: break` path and report a **false merge failure** for a PR that was perfectly mergeable.

## Observed failure

Running a repo-scoped merge against `lfit/releng-reusable-workflows` (which has **no** required-review rule at org, repo, or branch-protection level — confirmed via the effective `rules/branches/main` endpoint returning `[]`), one PR was reported as failed:

```
❌ Failed: https://github.com/lfit/releng-reusable-workflows/pull/723
   Base branch was modified. Review and try the merge again.
```

...yet that PR had in fact merged (`merged_by` = the running token, `auto_merge: None`). The failure line was a false negative caused by the unrecognised transient race.

## Change

Recognise the `"Base branch was modified"` body as a transient race and retry it with a short backoff, evaluated **ahead of** the `mergeable_state`-based branches and **independent of** `fix_out_of_date` (no rebase is involved). Retries remain bounded by `max_retries`, so a genuinely stuck PR is not retried forever.

## Tests

`tests/test_transient_merge_errors.py`:
- `test_405_base_branch_modified_retries_and_succeeds` — a base-modified 405 on a `behind` PR with `fix_out_of_date=False` (a state that previously fell through to `break`) now retries and succeeds.
- `test_405_base_branch_modified_exhausts_retries` — a persistent base-modified 405 gives up after `initial + max_retries` attempts.

## Validation

- `ruff` (pinned 0.15.18) format + lint clean on changed files
- `mypy` clean
- Full suite: **1063 passed**, coverage 63.55%