### PR TITLE
Feat: Add org/owner-wide bulk merge support

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,39 @@ or Gerrit based on the URL pattern.
 - **Interactive Mode by Default**: Preview what changes will apply, then
   optionally proceed with merge
 
+### Org/Owner-Wide Bulk Merging
+
+Pass a bare owner URL (e.g. `https://github.com/lfreleng-actions`) to merge
+every in-scope automation pull request across an entire GitHub organisation
+or user account in one command.
+
+- **Owner-Wide Scope**: Enumerates every repository owned by the
+  organisation or user, then bulk merges their open automation PRs
+  (`dependabot`, `pre-commit`, `renovate`, and other recognised bots)
+- **Organisation or User**: Detects the account type (org vs user)
+  automatically at runtime; the same URL works for both
+- **Archived and Fork Exclusion**: Skips archived repositories, and
+  **excludes fork repositories by default** (owner-wide merges target
+  the owner's own repositories, not mirrored forks)
+- **Striped Sequencing**: Schedules merges so that **at most one PR per
+  repository runs at a time** while distinct repositories run
+  concurrently. This spreads ("stripes") work across repositories and
+  structurally avoids the data-replication races that otherwise arise
+  when two same-repository PRs land back-to-back — without injected
+  delays or random retries
+- **Resilient Enumeration**: The run reports and skips a transient
+  failure scanning one repository, then continues with the repositories
+  it scanned
+- **Grouped Preview**: The preview lists candidate PRs grouped by repository
+  for readability, then prompts for a confirmation token before merging
+- **Human PR Safety**: The run excludes human-authored PRs by default;
+  passing `--include-human-prs` brings them into scope behind an explicit
+  confirmation prompt covering the entire owner
+
+> **Note**: Owner-wide merging supports `github.com` alone for now.
+> GitHub Enterprise Server support exists in scaffold form but remains
+> disabled.
+
 ### General Features
 
 - **Rich CLI Output**: Beautiful terminal output with progress indicators and
@@ -433,12 +466,12 @@ machine gerrit.opendaylight.org login myuser password anothertoken
 
 **CLI options:**
 
-| Option | Description |
-| ------ | ----------- |
-| `--no-netrc` | Disable .netrc file lookup |
-| `--netrc-file PATH` | Use a specific .netrc file |
-| `--netrc-optional` | Do not fail if .netrc file is missing (default) |
-| `--netrc-required` | Require a .netrc file and fail if missing |
+| Option              | Description                                     |
+| ------------------- | ----------------------------------------------- |
+| `--no-netrc`        | Disable .netrc file lookup                      |
+| `--netrc-file PATH` | Use a specific .netrc file                      |
+| `--netrc-optional`  | Do not fail if .netrc file is missing (default) |
+| `--netrc-required`  | Require a .netrc file and fail if missing       |
 
 By default, `.netrc` lookup is optional (`--netrc-optional`): if no `.netrc`
 file exists, the tool continues and falls back to environment variables.
@@ -942,6 +975,30 @@ dependamerge merge https://github.com/owner/repo/pull/123/files/diff
 
 This enhancement allows you to copy URLs directly from GitHub's PR pages
 without worrying about the specific tab you're viewing.
+
+The `merge` command also accepts repository and owner (organisation or
+user) URLs, selecting the operation scope from the URL shape:
+
+```bash
+# Single PR
+dependamerge merge https://github.com/owner/repo/pull/123
+
+# Whole repository (all open automation PRs)
+dependamerge merge https://github.com/owner/repo
+dependamerge merge https://github.com/owner/repo/pulls
+
+# Whole owner: every repository of an organisation or user
+dependamerge merge https://github.com/owner
+dependamerge merge https://github.com/owner/
+dependamerge merge https://github.com/orgs/owner
+dependamerge merge https://github.com/orgs/owner/repositories
+```
+
+| URL shape                          | Scope      |
+| ---------------------------------- | ---------- |
+| `.../owner/repo/pull/123`          | single PR  |
+| `.../owner/repo`                   | repository |
+| `.../owner` or `.../orgs/owner`    | owner-wide |
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -179,6 +179,14 @@ or user account in one command.
   structurally avoids the data-replication races that otherwise arise
   when two same-repository PRs land back-to-back — without injected
   delays or random retries
+- **Drain Ordering**: Orders repositories with the most PRs first (they
+  take longest to drain), and merges PRs oldest-number-first within a
+  repository to match the order dependabot expects to rebase
+- **Self-Rebase Awareness**: Detects when dependabot has begun rebasing a
+  sibling PR (the "Dependabot is rebasing this PR" banner), holds that PR
+  in a background wait, and lets auto-merge land it rather than failing it
+  or firing a redundant rebase macro. A global `--max-wait` ceiling bounds
+  the whole run
 - **Resilient Enumeration**: The run reports and skips a transient
   failure scanning one repository, then continues with the repositories
   it scanned
@@ -698,6 +706,15 @@ dependamerge merge https://github.com/owner/repo/pull/123 \
   for detailed documentation
 - `--token TEXT`: GitHub token (alternative to GITHUB_TOKEN env var)
 - `--override TEXT`: SHA hash for extra security validation
+
+**Owner-Wide Options:**
+
+- `--max-wait SECONDS`: Global wall-clock ceiling for an owner-wide run
+  (default: 900, 15 minutes). Clamps every per-PR auto-merge wait so the
+  run cannot hang on slow CI. Set `--max-wait 0` for fire-and-forget:
+  approve, arm auto-merge, report each PR as pending, and return at once
+  without blocking (GitHub completes the merges after the tool exits).
+  Applies to owner-wide runs; single-PR and single-repo modes ignore it.
 
 **Gerrit Environment Variables:**
 

--- a/docs/ORG_WIDE_BULK_MERGE.md
+++ b/docs/ORG_WIDE_BULK_MERGE.md
@@ -16,7 +16,7 @@ merges every in-scope automation pull request across an entire GitHub
 organisation (or user account):
 
 ```bash
-dependamerge https://github.com/lfreleng-actions/
+dependamerge merge https://github.com/lfreleng-actions/
 ```
 
 This hybridises the two existing bulk modes:
@@ -62,8 +62,13 @@ shape continues to establish the scope:
 | `…/owner/repo`                                | whole repo  |
 | `…/owner` (and `…/orgs/owner[/repositories]`) | whole owner |
 
-Routing in `merge()` gains a third fallback after `parse_change_url`
-(single PR) and `parse_repo_url` (repo): `parse_org_url` (owner). If all
+Routing in `merge()` tries three parsers in order: `parse_change_url`
+(single PR) first, then `parse_org_url` (owner), then `parse_repo_url`
+(repo). Routing tries owner parsing ahead of repo parsing so the
+canonical `…/orgs/owner` form does not mis-parse as `owner="orgs"`.
+`parse_org_url` is strict — it accepts a bare owner or the
+`orgs/owner[/repositories]` forms and rejects everything else, so a
+two-segment `owner/repo` URL falls through to `parse_repo_url`. If all
 three fail, routing surfaces the most relevant error.
 
 ## URL parsing
@@ -283,7 +288,7 @@ parity** and no org-specific special-casing.
 - Document the striping / single-flight sequencing behaviour at a high
   level.
 - Update the `merge` command help/docstring and Usage examples to show
-  `dependamerge https://github.com/<owner>`.
+  `dependamerge merge https://github.com/<owner>`.
 
 ## Reused components
 

--- a/docs/ORG_WIDE_BULK_MERGE.md
+++ b/docs/ORG_WIDE_BULK_MERGE.md
@@ -161,8 +161,9 @@ Implementation reuse:
   body is **factored out of `fetch_repo_open_prs` into a shared private
   helper**, so `fetch_repo_open_prs` and `fetch_owner_open_prs` share one
   implementation with no duplicated node-to-`PullRequestInfo` logic.
-- Automation classification stays in the single shared `AUTOMATION_TOOLS`
-  substring check already used by both repo mode and `fetch_repo_open_prs`.
+- Automation classification stays in the single shared bot-identity
+  predicate (`bot_identity.is_automation_author`) used by both repo mode
+  and `fetch_repo_open_prs`.
 
 ### Resilience
 
@@ -201,6 +202,75 @@ No sleeps and no random retries — the single-flight + round-robin
 ordering is the avoidance mechanism. This complements, and sits above,
 the existing `_get_merge_dispatch_lock(owner, repo)`, which serialises
 the final `merge_pull_request` API call alone.
+
+### Merge ordering
+
+Before the scheduler runs, the tool orders the flat PR list with the key
+`(-pr_count_for_repo, repo_full_name, pr_number)`:
+
+- **Repositories with the most in-scope PRs come first.** A repo with a
+  long PR queue takes the longest to drain (each merge can leave the next
+  sibling `behind` or `dirty` and trigger a rebase plus a CI wait), so
+  starting it earliest gives it the most wall-clock head start.
+- **Ascending PR number within a repo.** Dependabot raises PRs in number
+  order; merging the oldest first matches the order dependabot expects to
+  rebase, which reduces the chance a later PR invalidates an earlier one.
+
+The grouped listing and the merge list both derive from this order, so
+the preview mirrors the sequence the tool will follow.
+
+## Wait model and dependabot self-rebase
+
+When a sibling PR merges, dependabot frequently rebases the remaining
+open PRs in that repo on its own. While it does, it rewrites the PR body
+to include a "Dependabot is rebasing this PR" banner, then re-runs CI.
+A PR caught mid-rebase is transiently `dirty`/`behind` and would fail a
+naive immediate merge.
+
+The owner-wide path handles this structurally:
+
+1. **Detect the in-progress rebase.** `_dependabot_is_rebasing(body)`
+   recognises the banner so the conflict handler does not fire a
+   redundant `@dependabot rebase` macro on a PR that is already rebasing.
+2. **Approve and arm auto-merge**, then let the striped per-repo worker
+   wait for the merge to land in the background while other repos
+   progress. Because one serial worker owns each repo, the next sibling
+   does not start until the current PR settles.
+3. **Bound the whole run** with `--max-wait`.
+
+### The `--max-wait` flag
+
+`--max-wait SECONDS` sets a global wall-clock ceiling on an owner-wide
+run (default **900s**, 15 minutes). It clamps every per-PR auto-merge
+wait so the run cannot hang indefinitely waiting on slow CI across a
+large owner.
+
+- `--max-wait 0` opts into pure fire-and-forget: the tool approves each
+  PR, arms auto-merge, reports `AUTO_MERGE_PENDING`, and returns at once
+  without blocking. Use this when GitHub should finish the merges after
+  the tool exits.
+- The flag applies to owner-wide (`stripe=True`) runs. The single-PR and
+  single-repo modes ignore it.
+
+## Identity handling
+
+GitHub reports the same App actor under two login forms: REST returns the
+suffixed `dependabot[bot]`, GraphQL returns the bare `dependabot`. A
+login-equality gate written for one form misclassifies the
+other. The owner-wide path surfaced this because its enumeration runs
+through GraphQL.
+
+All bot/automation/Copilot identity logic routes through one shared
+module, `bot_identity`:
+
+- `canonical_bot_login(login, __typename)` normalises a GraphQL `Bot`
+  actor to the REST form at the data boundary, so the rest of the
+  codebase sees one canonical login.
+- `normalize_bot_login`, `is_dependabot`, `is_copilot`, and
+  `is_automation_author` compare logins irrespective of the `[bot]`
+  suffix, so a stray non-canonical value cannot disable identity-specific
+  handling (dependabot rebase/recreate, Copilot review dismissal,
+  automation classification).
 
 ### Placement
 
@@ -298,7 +368,7 @@ parity** and no org-specific special-casing.
 | ---------------------------- | ------------------------------------------------------- |
 | Repo fan-out / pagination    | `scan_organization` structure, `_iter_org_repositories` |
 | Per-repo PR fetch + filter   | shared helper extracted from `fetch_repo_open_prs`      |
-| Automation classification    | `AUTOMATION_TOOLS` substring check                      |
+| Automation classification    | `bot_identity.is_automation_author` predicate           |
 | Per-repo merge serialisation | `_get_merge_dispatch_lock`                              |
 | Live mergeability refresh    | `repo_scoped` path in `AsyncMergeManager`               |
 | Merge orchestration          | `_run_parallel_merge` / `merge_prs_parallel`            |

--- a/docs/ORG_WIDE_BULK_MERGE.md
+++ b/docs/ORG_WIDE_BULK_MERGE.md
@@ -1,0 +1,304 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- SPDX-FileCopyrightText: 2026 The Linux Foundation -->
+
+# Org/Owner-Wide Bulk Merging — Design
+
+Tracking issue:
+[#342](https://github.com/lfreleng-actions/dependamerge/issues/342)
+
+GHE follow-up:
+[#343](https://github.com/lfreleng-actions/dependamerge/issues/343)
+
+## Summary
+
+Add a third scope to the `merge` command so that a bare owner URL bulk
+merges every in-scope automation pull request across an entire GitHub
+organisation (or user account):
+
+```bash
+dependamerge https://github.com/lfreleng-actions/
+```
+
+This hybridises the two existing bulk modes:
+
+- Like **repo merge**, no similarity correlation applies — author
+  markers identify automation PRs, rather than a match against a source
+  PR.
+- Like **repo merge**, merging one PR can change the merge state of
+  sibling PRs in the same repository (rebase needed, fresh conflict), so
+  the sequencing concerns of the in-repo path apply — now multiplied
+  across every repository in the owner.
+
+The novel work is a **striping scheduler** that spreads merge operations
+across repositories and guarantees at most one in-flight merge per
+repository, structurally avoiding the data-replication races that would
+otherwise force injected delays or random retries.
+
+## Scope of this design
+
+In scope:
+
+- New owner-scoped URL parsing and routing.
+- Runtime detection of organisation vs user accounts.
+- Enumeration of in-scope automation PRs across the owner.
+- A striped merge scheduler with per-repo single-flight.
+- Full parity with every existing per-PR behaviour and flag.
+- GHE scaffolding (carry `host`, centralise base-URL derivation) without
+  enabling GHE.
+
+Out of scope (deferred):
+
+- Actually enabling GitHub Enterprise hosts — tracked in #343.
+- Routing the existing single-repo flow through the striped scheduler.
+
+## Command surface
+
+The `merge` command grows a third scope; no new subcommand. The URL
+shape continues to establish the scope:
+
+| URL shape                                     | Scope       |
+| --------------------------------------------- | ----------- |
+| `…/owner/repo/pull/123`                       | single PR   |
+| `…/owner/repo`                                | whole repo  |
+| `…/owner` (and `…/orgs/owner[/repositories]`) | whole owner |
+
+Routing in `merge()` gains a third fallback after `parse_change_url`
+(single PR) and `parse_repo_url` (repo): `parse_org_url` (owner). If all
+three fail, routing surfaces the most relevant error.
+
+## URL parsing
+
+Add `parse_org_url` returning a new frozen dataclass `ParsedOrgUrl`:
+
+```text
+ParsedOrgUrl(source, host, owner, original_url)
+```
+
+Parsing rules (comprehensive, not simplified):
+
+- One path segment ⇒ owner scope (`…/owner`).
+- The canonical GitHub forms `…/orgs/owner` and
+  `…/orgs/owner/repositories` normalise to `owner`.
+- Trailing slashes are cosmetic and treated identically to their
+  slash-free form (paths are already `rstrip("/")`-ed).
+- Disambiguation by segment count: 1 ⇒ owner, 2 ⇒ repo, 3+ with `/pull/`
+  ⇒ single PR.
+
+The parsers keep separate, single-purpose contracts (`parse_change_url`,
+`parse_repo_url`, `parse_org_url`) rather than overloading one function.
+
+### Host support and the GHE scaffold
+
+The low-level transport (`GitHubAsync`) already accepts `api_url` and
+`graphql_url`, so GHE is not a transport problem. For this feature:
+
+- `ParsedOrgUrl` carries `host` as a first-class field. Retrofitting the
+  same onto `ParsedRepoUrl` / `ParsedUrl` is desirable for consistency.
+- A single centralised helper `derive_api_urls(host) -> (api_url,
+  graphql_url)` encodes the dotcom-vs-GHE base-URL rule in one place.
+  The github.com path flows through it and returns the existing
+  constants.
+- A single, well-commented guard that accepts `github.com` alone remains
+  at the parser layer — one place to relax when GHE lands. The rejection
+  message stays forward-looking ("GitHub Enterprise support is not yet
+  enabled"), never implying impossibility.
+
+This PR does **not** thread `host`-derived base URLs through
+`GitHubService` / `GitHubClient` / `AsyncMergeManager`; that is #343's
+job. The parsed objects already carry the `host` those constructors will
+consume.
+
+## Account-type detection (org vs user)
+
+The owner URL is identical for organisations and personal accounts, so
+runtime detection determines the account type, rather than the URL:
+
+- Try the `organization(login:)`-rooted repository query first
+  (`ORG_REPOS_ONLY` already exists).
+- If that field comes back `null` / `NOT_FOUND`, fall back to a new
+  `USER_REPOS_ONLY` query rooted at `user(login:)`. The `repositories`
+  connection exists on both `Organization` and `User`.
+- A cache holds the resolved account type so repeated pagination pages
+  do not re-probe.
+
+A small `_iter_owner_repositories(owner)` selects the correct query and
+yields repository nodes, mirroring the existing
+`_iter_org_repositories`.
+
+## Repository scope
+
+Per repository, in-scope filtering:
+
+- The enumerator skips **archived** repositories (already the
+  established behaviour of `_iter_org_repositories`).
+- The enumerator skips **forks** by default. The new owner-repos query
+  must add `isFork` to its node selection, because `ORG_REPOS_ONLY`
+  returns `nameWithOwner` and `isArchived` alone. The README documents
+  this. A future `--include-forks` flag could relax it.
+- Repositories with no open automation PRs naturally drop out — the
+  scheduler acts on the repos that yield PRs.
+- No upfront write/merge permission probe (too expensive org-wide).
+  Missing permissions surface through the existing per-PR merge-failure
+  handling, as repo mode behaves today.
+
+## PR enumeration
+
+Add `GitHubService.fetch_owner_open_prs(owner, *, only_automation=True)`
+returning `list[PullRequestInfo]` — the exact type the merge path
+consumes.
+
+Implementation reuse:
+
+- Repo fan-out structure (bounded concurrency via `_repo_semaphore`,
+  pagination, progress hooks) comes from the existing
+  `scan_organization` shape.
+- The per-repo "fetch PR pages + convert nodes + filter to automation"
+  body is **factored out of `fetch_repo_open_prs` into a shared private
+  helper**, so `fetch_repo_open_prs` and `fetch_owner_open_prs` share one
+  implementation with no duplicated node-to-`PullRequestInfo` logic.
+- Automation classification stays in the single shared `AUTOMATION_TOOLS`
+  substring check already used by both repo mode and `fetch_repo_open_prs`.
+
+### Resilience
+
+Per-repo error isolation mirrors `scan_organization`: a wrapper around
+each repo's fetch records a transient failure and lets enumeration
+continue. After enumeration a concise summary lists the repositories it
+could not read, with their errors, and the run proceeds with the PRs it
+gathered. Global rate-limit / secondary-rate-limit errors still
+propagate (the API layer owns backoff).
+
+## Striping scheduler (the core of the feature)
+
+Across an owner the flat PR list frequently contains two or more PRs in
+the same repository (for example dependabot and pre-commit-ci both
+opening PRs in one repo). Merging two PRs in the same repo back-to-back
+races GitHub's branch-protection / mergeability propagation. A naive
+`asyncio.gather` over the flat list would let the worker pool grab a
+handful of PRs from one repo at once, thrashing the refresh/retry path.
+
+The avoidance strategy is **structural, not timing-based**:
+
+1. **Group** the flat PR list by `repository_full_name`.
+2. **Round-robin interleave** across repos when building the work queue
+   so consecutive items target different repos: `repoA#1, repoB#1,
+   repoC#1, repoA#2, repoB#2, …`. This maximises the gap between two
+   merges in the same repo.
+3. **One in-flight PR per repo at a time.** While a repo's PR moves
+   through approve → rebase → merge → post-merge settle, no other PR from
+   that repo starts; workers pick up PRs from other repos instead.
+   Global concurrency stays bounded but spreads across distinct repos.
+4. **Live mergeability refresh before dispatch** (`repo_scoped` semantics)
+   so that when a repo's second PR starts, it re-reads state the first
+   PR's merge may have invalidated.
+
+No sleeps and no random retries — the single-flight + round-robin
+ordering is the avoidance mechanism. This complements, and sits above,
+the existing `_get_merge_dispatch_lock(owner, repo)`, which serialises
+the final `merge_pull_request` API call alone.
+
+### Placement
+
+The scheduler is a `stripe=True` parameter on
+`AsyncMergeManager.merge_prs_parallel`. When set, the round-robin +
+per-repo single-flight scheduler takes over from the flat
+`asyncio.gather` loop. It lives in `AsyncMergeManager` because it needs
+the per-repo state, the semaphore, the progress tracker, and the
+dispatch lock that already live there. The existing single-PR and repo
+flows stay untouched to keep the blast radius small.
+
+### Concurrency
+
+Global concurrency defaults to 10, effectively bounded by
+`min(10, number_of_distinct_repos_with_prs)` — single-flight-per-repo
+means more workers than repos cannot help. The underlying `GitHubAsync`
+owns request-level throttling (`max_concurrency=20`,
+`requests_per_second=8`, adaptive backoff), so the worker pool need not
+be conservative for rate-limit reasons. No new CLI flag.
+
+## CLI handler
+
+A thin `_handle_org_merge(parsed_org, ctx)` mirrors `_handle_repo_merge`:
+
+1. Guard host to github.com (the single GHE choke point).
+2. Initialise the GitHub client / token; reuse `_check_merge_permissions`.
+3. List automation PRs via `fetch_owner_open_prs`.
+4. Build the flat `(PullRequestInfo, None)` work list.
+5. Preview / merge via `_run_parallel_merge(..., stripe=True,
+   repo_scoped=True)`.
+
+The handler populates `_MergeContext` identically to the repo handler, so
+every per-PR behaviour and flag — GitHub2Gerrit detection/submission,
+`--force` levels, `--dismiss-copilot`, branch rebasing, per-repo
+merge-method resolution, `--include-human-prs` — applies with **full
+parity** and no org-specific special-casing.
+
+## User experience
+
+- **Two-phase progress**, reusing existing tracker mechanisms:
+  - Enumeration: "🔍 Scanning `<owner>` repositories for automation PRs"
+    using the repos fraction (the owner-repos enumerator publishes
+    `totalCount` on its first page).
+  - Merge: a fresh tracker with `set_total_prs(...)` and the "▶️ Merging
+    PRs" label; the striped scheduler's per-repo hooks
+    (`start_repository` / `complete_repository`) stay meaningful as PRs
+    span repos across the owner.
+- **Listing grouped by repository** — a header per repo with its PRs
+  beneath, plus per-repo automation/human counts and a grand total, so a
+  large owner-wide list stays scannable.
+- **Confirmation** reuses the preview-then-SHA pattern, with the token
+  derived from owner + mergeable count (for example
+  `org-merge:{owner}:{count}`), mirroring the existing `repo-merge:`
+  token. No arbitrary size cap — the preview shows full scope before any
+  merge, so the SHA gate suffices.
+- **`--include-human-prs`** works owner-wide for consistency, gated by
+  the same "type yes" human-PR confirmation, with a warning that human
+  PRs across the entire owner are in scope.
+- **Empty result** prints "No open automation PRs found in `<owner>`" and
+  exits 0.
+
+## Testing
+
+- `test_url_parser.py` — `parse_org_url` cases: bare `<owner>`, trailing
+  slash, `orgs/<owner>`, `…/orgs/<owner>/repositories`, non-github.com
+  rejection, and 1-vs-2-vs-3+ segment disambiguation.
+- `test_org_merge.py` (new) — mirrors `test_repo_merge.py`: owner
+  enumeration with org-path and user-path fallback (mocked
+  `organization=null`), fork/archived exclusion, automation filtering,
+  empty-owner messaging, per-repo error isolation, grouped listing.
+- `test_stripe_scheduler.py` (new) — the load-bearing guarantee:
+  round-robin interleave ordering and the invariant that **no two PRs
+  from the same repo are ever in flight simultaneously** under the
+  striped scheduler, asserted with a deterministic fake that records
+  concurrent in-flight repos and fails if any repo's count exceeds 1.
+- Shared-helper tests proving `fetch_owner_open_prs` and
+  `fetch_repo_open_prs` have no behavioural drift.
+
+## Documentation
+
+- New README "Features" subsection: "Org/Owner-Wide Bulk Merging".
+- Extend "Enhanced URL Support" with the `<owner>` / `orgs/<owner>` /
+  `…/repositories` forms.
+- Document fork + archived exclusion explicitly.
+- Document the striping / single-flight sequencing behaviour at a high
+  level.
+- Update the `merge` command help/docstring and Usage examples to show
+  `dependamerge https://github.com/<owner>`.
+
+## Reused components
+
+<!-- markdownlint-disable MD013 -->
+
+| Concern                      | Reused component                                        |
+| ---------------------------- | ------------------------------------------------------- |
+| Repo fan-out / pagination    | `scan_organization` structure, `_iter_org_repositories` |
+| Per-repo PR fetch + filter   | shared helper extracted from `fetch_repo_open_prs`      |
+| Automation classification    | `AUTOMATION_TOOLS` substring check                      |
+| Per-repo merge serialisation | `_get_merge_dispatch_lock`                              |
+| Live mergeability refresh    | `repo_scoped` path in `AsyncMergeManager`               |
+| Merge orchestration          | `_run_parallel_merge` / `merge_prs_parallel`            |
+| Progress display             | `MergeProgressTracker` (repos + PRs fractions)          |
+| Confirmation                 | preview-then-SHA pattern (`repo-merge` token)           |
+| Per-PR flags / behaviours    | `_MergeContext` → `AsyncMergeManager`                   |
+
+<!-- markdownlint-enable MD013 -->

--- a/docs/ORG_WIDE_BULK_MERGE.md
+++ b/docs/ORG_WIDE_BULK_MERGE.md
@@ -186,22 +186,28 @@ handful of PRs from one repo at once, thrashing the refresh/retry path.
 The avoidance strategy is **structural, not timing-based**:
 
 1. **Group** the flat PR list by `repository_full_name`.
-2. **Round-robin interleave** across repos when building the work queue
-   so consecutive items target different repos: `repoA#1, repoB#1,
-   repoC#1, repoA#2, repoB#2, …`. This maximises the gap between two
-   merges in the same repo.
-3. **One in-flight PR per repo at a time.** While a repo's PR moves
-   through approve → rebase → merge → post-merge settle, no other PR from
-   that repo starts; workers pick up PRs from other repos instead.
-   Global concurrency stays bounded but spreads across distinct repos.
+2. **Run one serial worker per repository.** A single worker owns each
+   repository's PRs and processes them strictly one at a time, in order.
+   All workers run concurrently under a shared semaphore that bounds
+   global concurrency, so progress spreads across distinct repos.
+3. **One in-flight PR per repo at a time.** Because a repo's PRs share a
+   single serial worker, while one PR moves through approve → rebase →
+   merge → post-merge settle, no other PR from that repo can start; the
+   semaphore admits PRs from *other* repos instead. (Any tendency for
+   consecutive admissions to alternate between repos — a round-robin
+   "striping" effect — emerges as a best-effort consequence of how
+   CPython wakes semaphore waiters; treat it as an optimisation, not a
+   guarantee, because correctness does not depend on it.)
 4. **Live mergeability refresh before dispatch** (`repo_scoped` semantics)
    so that when a repo's second PR starts, it re-reads state the first
    PR's merge may have invalidated.
 
-No sleeps and no random retries — the single-flight + round-robin
-ordering is the avoidance mechanism. This complements, and sits above,
-the existing `_get_merge_dispatch_lock(owner, repo)`, which serialises
-the final `merge_pull_request` API call alone.
+No sleeps and no random retries — the **single-flight-per-repository**
+invariant (each repo's serial worker) is the avoidance mechanism, and it
+holds regardless of the order in which the semaphore admits waiters. This
+complements, and sits above, the existing
+`_get_merge_dispatch_lock(owner, repo)`, which serialises the final
+`merge_pull_request` API call alone.
 
 ### Merge ordering
 

--- a/src/dependamerge/bot_identity.py
+++ b/src/dependamerge/bot_identity.py
@@ -1,0 +1,144 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 The Linux Foundation
+"""Shared helpers for reconciling GitHub bot/App actor identities.
+
+GitHub reports the *same* App actor under two different login forms
+depending on the API surface:
+
+- The REST API returns the suffixed form, e.g. ``dependabot[bot]``.
+- The GraphQL API returns the bare form for a ``Bot`` actor, e.g.
+  ``dependabot`` (the ``[bot]`` suffix is dropped).
+
+This split has historically been worked around ad-hoc in several
+places (the PR comparator, the Gerrit comparator, repo-merge automation
+detection).  Centralising it here gives every consumer one canonical
+form and one set of predicates, so a downstream equality check can never
+again silently misclassify a bot just because it arrived via GraphQL.
+
+Two layers are provided:
+
+- :func:`canonical_bot_login` normalises an actor login *to the REST
+  form* at the data boundary (where a GraphQL node is converted to an
+  internal model).  It is driven by the GraphQL ``__typename`` so it
+  applies uniformly to *every* App actor (dependabot, renovate,
+  pre-commit-ci, github-actions, copilot, …), not just one identity.
+- :func:`normalize_bot_login` and :func:`is_dependabot` compare logins
+  irrespective of the ``[bot]`` suffix, so a stray non-canonical value
+  cannot disable identity-specific handling.
+"""
+
+from __future__ import annotations
+
+BOT_SUFFIX = "[bot]"
+
+# GraphQL ``__typename`` value for an App/bot actor.
+_BOT_TYPENAME = "Bot"
+
+# Known automation-tool base logins (``[bot]``-stripped, lower-cased).
+# Membership is checked against the *normalised* login so both the REST
+# (``dependabot[bot]``) and GraphQL (``dependabot``) forms match.  Any
+# other App actor is still caught by the ``[bot]`` fallthrough in
+# :func:`is_automation_author`, so this set exists to recognise the
+# *bare* (GraphQL) forms of known tools, not to be exhaustive.
+_AUTOMATION_BOT_NAMES = frozenset(
+    {
+        "dependabot",
+        "renovate",
+        "pre-commit-ci",
+        "pre-commit",
+        "github-actions",
+        "allcontributors",
+        "copilot",
+        "github-copilot",
+    }
+)
+
+# Known GitHub Copilot actor logins (normalised).  Copilot reports under
+# several identities depending on the surface: the App author
+# (``Copilot`` / ``copilot[bot]`` / ``github-copilot[bot]``) and the
+# review actor (``copilot-pull-request-reviewer``).
+_COPILOT_NAMES = frozenset(
+    {
+        "copilot",
+        "github-copilot",
+        "copilot-pull-request-reviewer",
+    }
+)
+
+
+def canonical_bot_login(login: str | None, typename: str | None = None) -> str:
+    """Return ``login`` in the canonical REST form.
+
+    When ``typename`` identifies a GraphQL ``Bot`` actor whose login lacks
+    the ``[bot]`` suffix (the bare form GraphQL returns), append it so the
+    value matches the REST API form used throughout the codebase.  Every
+    other input is returned unchanged.
+
+    Args:
+        login: The actor login as returned by the API (may be ``None``).
+        typename: The GraphQL ``__typename`` for the actor, when known.
+            Only ``"Bot"`` triggers suffixing; this keeps the
+            normalisation actor-type driven rather than name-matching a
+            specific bot.
+
+    Returns:
+        The canonical login, or ``"unknown"`` when ``login`` is empty.
+    """
+    if not login:
+        return "unknown"
+    if typename == _BOT_TYPENAME and not login.endswith(BOT_SUFFIX):
+        return f"{login}{BOT_SUFFIX}"
+    return login
+
+
+def normalize_bot_login(login: str | None) -> str:
+    """Return a lower-cased login with any ``[bot]`` suffix removed.
+
+    Use this for comparisons that must treat ``dependabot`` and
+    ``dependabot[bot]`` (and any other suffixed/bare bot pair) as equal,
+    regardless of which API surface produced the value.
+    """
+    if not login:
+        return ""
+    normalized = login.lower()
+    if normalized.endswith(BOT_SUFFIX):
+        normalized = normalized[: -len(BOT_SUFFIX)]
+    return normalized
+
+
+def is_dependabot(author: str | None) -> bool:
+    """Return True when ``author`` is dependabot, in either login form.
+
+    Robust to the REST (``dependabot[bot]``) and GraphQL (``dependabot``)
+    forms so dependabot-specific recovery (rebase / recreate macros) is
+    never skipped because of a non-canonical login.
+    """
+    return normalize_bot_login(author) == "dependabot"
+
+
+def is_copilot(author: str | None) -> bool:
+    """Return True when ``author`` is a GitHub Copilot actor.
+
+    Matches every Copilot identity (App author and review actor) in both
+    the REST and GraphQL login forms, so Copilot-specific handling (review
+    dismissal, block-reason analysis) cannot be bypassed by a
+    non-canonical login.
+    """
+    return normalize_bot_login(author) in _COPILOT_NAMES
+
+
+def is_automation_author(author: str | None) -> bool:
+    """Return True when ``author`` is an automation/bot actor.
+
+    Recognises the known automation tools by their normalised base login
+    (so both ``dependabot`` and ``dependabot[bot]`` match) and, as a
+    fallthrough, treats *any* actor whose login carries the ``[bot]``
+    marker as automation.  The fallthrough preserves the historical
+    "anything ending in ``[bot]``" breadth so an unknown future bot is
+    still classified as automation.
+    """
+    if not author:
+        return False
+    if normalize_bot_login(author) in _AUTOMATION_BOT_NAMES:
+        return True
+    return author.lower().endswith(BOT_SUFFIX)

--- a/src/dependamerge/cli.py
+++ b/src/dependamerge/cli.py
@@ -1478,13 +1478,16 @@ def _handle_org_merge(
     """
     from .github_service import GitHubService
 
-    # The host is guaranteed to be github.com here: ``parse_org_url`` is
-    # the single github.com-only choke point (it rejects every other
+    # The host here is guaranteed to *match* github.com: ``parse_org_url``
+    # is the single github.com-only choke point (it rejects every other
     # host, including GHE, before a ``ParsedOrgUrl`` can reach this
-    # handler).  Enabling GHE (#343) means relaxing that one parser guard
-    # and threading ``derive_api_urls(host)`` through the service stack —
-    # deliberately not re-checked here so there is no second guard to
-    # drift out of sync.
+    # handler).  "Matches" is deliberate — ``parse_org_url`` accepts
+    # github.com and its subdomains (e.g. ``api.github.com``) via
+    # ``_host_matches``, so this is not an exact ``== "github.com"``
+    # guarantee.  Enabling GHE (#343) means relaxing that one parser
+    # guard and threading ``derive_api_urls(host)`` through the service
+    # stack — deliberately not re-checked here so there is no second
+    # guard to drift out of sync.
 
     # --- Initialise GitHub client & token ---
     ctx.github_client = GitHubClient(ctx.token)
@@ -2231,6 +2234,20 @@ def merge(
         verbose,
     )
 
+    # Reject negative --max-wait.  The documented contract is 0 =
+    # fire-and-forget and > 0 = wall-clock ceiling; a negative value has
+    # no defined meaning and would otherwise be silently coerced into a
+    # surprising "instant no-wait" run (max_wait <= 0).  Fail fast so the
+    # flag's behaviour stays aligned with its help text.  The isinstance
+    # guard tolerates direct Python calls to ``merge`` (e.g. in tests),
+    # where Typer's ``OptionInfo`` default object is passed unresolved.
+    if isinstance(max_wait, (int, float)) and max_wait < 0:
+        console.print(
+            "❌ Invalid --max-wait: must be 0 (fire-and-forget) or a "
+            "positive number of seconds"
+        )
+        raise typer.Exit(1)
+
     # --- Parse URL and route to the appropriate handler ---
     # Try as a specific PR/change URL first, then an owner-wide URL
     # (bare owner / orgs/owner), then a single repository URL.
@@ -2249,7 +2266,7 @@ def merge(
         # mis-parsed by parse_repo_url as owner="orgs", repo="owner".
         try:
             parsed_org = parse_org_url(pr_url)
-        except UrlParseError:
+        except UrlParseError as org_err:
             # Not an owner URL — try as a repository URL
             try:
                 parsed_repo = parse_repo_url(pr_url)
@@ -2260,19 +2277,32 @@ def merge(
                 # whereas parse_repo_url only talks about github.com.
                 from .url_parser import _host_matches
 
+                # Prepend scheme if missing so urlparse can extract the
+                # hostname.  Without a scheme, schemeless URLs like
+                # "gerrit.example.org/..." are parsed as a path with no
+                # hostname, causing the wrong error to be shown.
+                _norm = pr_url
+                if not _norm.startswith(("http://", "https://")):
+                    _norm = "https://" + _norm
                 try:
-                    # Prepend scheme if missing so urlparse can extract the
-                    # hostname.  Without a scheme, schemeless URLs like
-                    # "gerrit.example.org/..." are parsed as a path with no
-                    # hostname, causing the wrong error to be shown.
-                    _norm = pr_url
-                    if not _norm.startswith(("http://", "https://")):
-                        _norm = "https://" + _norm
                     host = urlparse(_norm).hostname or ""
                 except Exception:
                     host = ""
                 if host and not _host_matches(host.lower(), "github.com"):
-                    console.print(f"❌ Invalid URL: {change_err}")
+                    # Non-github host.  An owner-shaped path (``/orgs/owner``
+                    # or a single bare segment) most likely means the user
+                    # aimed an owner-wide URL at a non-github host (e.g.
+                    # GHE), so surface parse_org_url's actionable rejection
+                    # ("Owner-wide URL parsing is only supported for
+                    # github.com … use a direct PR URL") instead of the
+                    # generic parse_change_url "cannot determine platform"
+                    # message.  Any other shape (including Gerrit-style
+                    # URLs) keeps the platform-agnostic guidance.
+                    segs = [s for s in urlparse(_norm).path.split("/") if s]
+                    if segs and (segs[0] == "orgs" or len(segs) == 1):
+                        console.print(f"❌ Invalid URL: {org_err}")
+                    else:
+                        console.print(f"❌ Invalid URL: {change_err}")
                 else:
                     console.print(f"❌ Invalid URL: {repo_err}")
                 raise typer.Exit(1) from None

--- a/src/dependamerge/cli.py
+++ b/src/dependamerge/cli.py
@@ -70,10 +70,12 @@ from .progress_tracker import MergeProgressTracker, ProgressTracker
 from .resolve_conflicts import FixOptions, FixOrchestrator, PRSelection
 from .system_utils import get_default_workers
 from .url_parser import (
+    ParsedOrgUrl,
     ParsedRepoUrl,
     ParsedUrl,
     UrlParseError,
     parse_change_url,
+    parse_org_url,
     parse_repo_url,
 )
 
@@ -754,6 +756,7 @@ def _run_parallel_merge(
     concurrency: int = 10,
     leading_blank: bool = True,
     repo_scoped: bool = False,
+    stripe: bool = False,
 ) -> list[MergeResult]:
     """Execute a parallel merge (preview or real) and return results.
 
@@ -779,6 +782,11 @@ def _run_parallel_merge(
             dispatching the merge (a sibling merge can make a PR
             ``dirty`` / ``behind`` mid-batch).  Left False for org-wide
             runs.  See ``AsyncMergeManager._refresh_pr_mergeability``.
+        stripe: When True, the merge is scheduled with the striped
+            scheduler (one serial worker per repository, distinct repos
+            concurrent) so owner-wide batches never stack two merges on
+            the same repository at once.  See
+            ``AsyncMergeManager._run_striped``.
     """
 
     async def _do_merge():
@@ -804,7 +812,9 @@ def _run_parallel_merge(
                 console.print(
                     f"{prefix}🚀 Merging {len(prs_to_merge)} pull requests..."
                 )
-            return await merge_manager.merge_prs_parallel(prs_to_merge)
+            return await merge_manager.merge_prs_parallel(
+                prs_to_merge, stripe=stripe
+            )
 
     return asyncio.run(_do_merge())
 
@@ -1350,6 +1360,343 @@ def _execute_repo_confirmed_merge(
     _print_failed_pr_details(real_results)
 
 
+def _print_prs_grouped_by_repo(
+    prs: list[PullRequestInfo],
+) -> None:
+    """Print a PR list grouped by repository for owner-wide readability.
+
+    Emits a header per repository followed by its PRs indented beneath,
+    so a large owner-wide list stays scannable.  Repositories are listed
+    in sorted order; PRs within a repository are ordered by number.
+    """
+    by_repo: dict[str, list[PullRequestInfo]] = {}
+    for pr in prs:
+        by_repo.setdefault(pr.repository_full_name, []).append(pr)
+
+    for repo in sorted(by_repo):
+        repo_prs = sorted(by_repo[repo], key=lambda p: p.number)
+        console.print(f"\n📁 {repo} ({len(repo_prs)} PR(s))")
+        for pr in repo_prs:
+            console.print(f"  #{pr.number} {pr.title} (by {pr.author})")
+
+
+def _handle_org_merge(
+    parsed_org: ParsedOrgUrl,
+    ctx: _MergeContext,
+) -> None:
+    """Handle merge operation for an owner-scoped (org/user) URL.
+
+    Enumerates every in-scope automation PR across all of the owner's
+    non-archived, non-fork repositories, then bulk merges them with the
+    striped scheduler so no two merges stack on the same repository at
+    once.  The owner may be an organization or a personal user account;
+    the account type is detected at runtime during enumeration.
+
+    Args:
+        parsed_org: Parsed owner URL with the org/user login.
+        ctx: Shared merge context populated with CLI parameters.
+    """
+    from .github_service import GitHubService
+    from .url_parser import _host_matches
+
+    # --- Guard: owner-merge only supports github.com for now ---
+    # This mirrors the parser's github.com-only guard; GHE enablement
+    # is tracked separately (see derive_api_urls and the GHE issue).
+    if not _host_matches(parsed_org.host, "github.com"):
+        console.print(
+            "❌ Owner-scoped merge is currently only supported "
+            f"for github.com (got host: {parsed_org.host}).\n"
+            "   GitHub Enterprise support requires API base URL "
+            "configuration — use a direct PR URL instead."
+        )
+        raise typer.Exit(code=1)
+
+    # --- Initialise GitHub client & token ---
+    ctx.github_client = GitHubClient(ctx.token)
+    assert ctx.github_client.token is not None
+    ctx.token = ctx.github_client.token
+    ctx.owner = parsed_org.owner
+    ctx.repo_name = ""
+
+    console.print(
+        f"🔍 Owner mode: scanning {parsed_org.owner} for automation PRs..."
+    )
+
+    # --- Token permission check (reuse existing helper) ---
+    _check_merge_permissions(ctx)
+
+    # --- Progress tracker (enumeration phase: repos fraction) ---
+    if ctx.show_progress:
+        ctx.progress_tracker = MergeProgressTracker(
+            parsed_org.owner,
+            operation_label="Scanning repositories for automation PRs",
+            operation_icon="🔍",
+        )
+        ctx.progress_tracker.start()
+
+    # --- Enumerate automation PRs across the owner ---
+    only_automation = not ctx.include_human_prs
+
+    async def _fetch_prs() -> tuple[list[PullRequestInfo], list[str]]:
+        svc = GitHubService(
+            token=ctx.token,
+            progress_tracker=ctx.progress_tracker,
+        )
+        try:
+            return await svc.fetch_owner_open_prs(
+                parsed_org.owner,
+                only_automation=only_automation,
+            )
+        finally:
+            await svc.close()
+
+    try:
+        owner_prs, scan_errors = asyncio.run(_fetch_prs())
+    except Exception:
+        if ctx.progress_tracker:
+            ctx.progress_tracker.stop()
+        raise
+
+    if ctx.progress_tracker:
+        ctx.progress_tracker.stop()
+
+    # --- Surface per-repository scan failures (run continues) ---
+    if scan_errors:
+        error_count = len(scan_errors)
+        repo_noun = "repository" if error_count == 1 else "repositories"
+        console.print(
+            f"\n⚠️ {error_count} {repo_noun} could not be scanned:"
+        )
+        for err in scan_errors:
+            console.print(f"   - {err}")
+
+    if not owner_prs:
+        label = "automation " if only_automation else ""
+        console.print(f"❌ No open {label}PRs found in {parsed_org.owner}")
+        return
+
+    # --- Classify PRs as automation vs human ---
+    # Substring matching is consistent with
+    # GitHubService._is_automation_author / fetch_owner_open_prs.
+    def _is_auto(author: str | None) -> bool:
+        author_lower = (author or "").lower()
+        return any(tool in author_lower for tool in AUTOMATION_TOOLS)
+
+    automation_prs: list[PullRequestInfo] = []
+    human_prs: list[PullRequestInfo] = []
+    for pr in owner_prs:
+        if _is_auto(pr.author):
+            automation_prs.append(pr)
+        else:
+            human_prs.append(pr)
+
+    distinct_repos = {pr.repository_full_name for pr in owner_prs}
+    repo_count = len(distinct_repos)
+    repo_noun = "repository" if repo_count == 1 else "repositories"
+    console.print(
+        f"\n📊 Found {len(owner_prs)} open PR(s) across "
+        f"{repo_count} {repo_noun} in {parsed_org.owner}"
+    )
+    if automation_prs:
+        console.print(f"🤖 Automation PRs: {len(automation_prs)}")
+    if human_prs:
+        console.print(f"👤 Human PRs: {len(human_prs)}")
+
+    # Grouped-by-repository listing keeps a large owner-wide list scannable.
+    _print_prs_grouped_by_repo(owner_prs)
+
+    # --- Human PR confirmation gate ---
+    needs_human_confirm = bool(human_prs) and not ctx.no_confirm
+    if needs_human_confirm:
+        console.print(
+            "\n⚠️ Human-authored PRs across the entire owner "
+            f"'{parsed_org.owner}' are included in this merge operation."
+        )
+        console.print("   Review the list above carefully before proceeding.")
+        try:
+            user_input = (
+                typer.prompt(
+                    "Type 'yes' to include human PRs, or press Enter to skip them",
+                    default="",
+                    show_default=False,
+                )
+                .strip()
+                .lower()
+            )
+            if user_input != "yes":
+                console.print("ℹ️ Excluding human PRs from merge.")
+                owner_prs = automation_prs
+                if not owner_prs:
+                    console.print("❌ No automation PRs remain to merge.")
+                    return
+        except (KeyboardInterrupt, EOFError, typer.Abort):
+            console.print("\n❌ Merge cancelled by user.")
+            return
+
+    # --- Build the merge list (ComparisonResult is None for owner mode) ---
+    all_prs_to_merge: list[tuple[PullRequestInfo, ComparisonResult | None]] = [
+        (pr, None) for pr in owner_prs
+    ]
+
+    # Global concurrency 10, bounded by the distinct-repo count: the
+    # striped scheduler runs at most one PR per repo, so more workers
+    # than repositories cannot help.
+    final_distinct_repos = {pr.repository_full_name for pr in owner_prs}
+    concurrency = min(10, len(final_distinct_repos)) or 1
+
+    # --- Preview / merge using the striped scheduler ---
+    if ctx.show_progress:
+        ctx.progress_tracker = MergeProgressTracker(
+            parsed_org.owner,
+            operation_label="Merging PRs",
+            operation_icon="▶️",
+        )
+        ctx.progress_tracker.set_total_prs(len(all_prs_to_merge))
+        ctx.progress_tracker.start()
+
+    try:
+        merge_results = _run_parallel_merge(
+            ctx,
+            all_prs_to_merge,
+            preview=not ctx.no_confirm,
+            concurrency=concurrency,
+            # Owner-wide batches mix many repositories and often contain
+            # multiple PRs per repository; stripe to avoid stacking and
+            # repo_scoped to refresh live merge state before each dispatch.
+            repo_scoped=True,
+            stripe=True,
+        )
+    finally:
+        if ctx.show_progress and ctx.progress_tracker:
+            ctx.progress_tracker.stop()
+
+    if not merge_results:
+        console.print("❌ No PRs were processed")
+        return
+
+    merged_count = sum(1 for r in merge_results if r.status.value == "merged")
+
+    if not ctx.no_confirm:
+        _handle_org_preview_confirmation(
+            ctx,
+            parsed_org,
+            merge_results,
+            all_prs_to_merge,
+            merged_count,
+            len(merge_results),
+            concurrency,
+        )
+        return
+
+    _display_merge_results(merge_results, ctx.no_confirm)
+
+
+def _handle_org_preview_confirmation(
+    ctx: _MergeContext,
+    parsed_org: ParsedOrgUrl,
+    merge_results: list[MergeResult],
+    all_prs_to_merge: list[tuple[PullRequestInfo, ComparisonResult | None]],
+    merged_count: int,
+    total_to_merge: int,
+    concurrency: int,
+) -> None:
+    """Handle preview-then-confirm for owner-scoped merges.
+
+    Mirrors :func:`_handle_repo_preview_confirmation` but derives the
+    confirmation token from the owner login instead of a repository.
+    """
+    console.print(f"\nMergeable {merged_count}/{total_to_merge} PRs")
+
+    if merged_count == 0:
+        console.print("\n💡 No PRs are mergeable at this time.")
+        return
+
+    combined = f"org-merge:{parsed_org.owner}:{merged_count}"
+    confirm_hash = hashlib.sha256(combined.encode("utf-8")).hexdigest()[:16]
+
+    console.print()
+    console.print(f"To proceed with merging enter: {confirm_hash}")
+
+    try:
+        user_input = typer.prompt(
+            "Enter the string above to continue (or press Enter to cancel)",
+            default="",
+            show_default=False,
+        ).strip()
+
+        if user_input == confirm_hash:
+            _execute_org_confirmed_merge(
+                ctx, merge_results, all_prs_to_merge, concurrency
+            )
+        elif user_input == "":
+            console.print("❌ Merge cancelled by user.")
+        else:
+            console.print("❌ Invalid input. Merge cancelled.")
+    except (KeyboardInterrupt, EOFError, typer.Abort):
+        console.print("\n❌ Merge cancelled by user.")
+
+
+def _execute_org_confirmed_merge(
+    ctx: _MergeContext,
+    preview_results: list[MergeResult],
+    all_prs_to_merge: list[tuple[PullRequestInfo, ComparisonResult | None]],
+    concurrency: int,
+) -> None:
+    """Run the real owner-wide merge after user confirmation."""
+    mergeable_prs = [
+        all_prs_to_merge[i]
+        for i, result in enumerate(preview_results)
+        if result.status.value == "merged"
+    ]
+    merged_count = len(mergeable_prs)
+    console.print(f"\n🔨 Merging {merged_count} mergeable pull requests...")
+
+    if ctx.show_progress:
+        ctx.progress_tracker = MergeProgressTracker(
+            ctx.owner,
+            operation_label="Merging PRs",
+            operation_icon="▶️",
+        )
+        ctx.progress_tracker.set_total_prs(len(mergeable_prs))
+        ctx.progress_tracker.start()
+
+    try:
+        real_results = _run_parallel_merge(
+            ctx,
+            mergeable_prs,
+            preview=False,
+            concurrency=concurrency,
+            repo_scoped=True,
+            stripe=True,
+        )
+    finally:
+        if ctx.show_progress and ctx.progress_tracker:
+            ctx.progress_tracker.stop()
+
+    final_merged = sum(1 for r in real_results if r.status.value == "merged")
+    final_failed = sum(1 for r in real_results if r.status.value == "failed")
+    final_skipped = sum(1 for r in real_results if r.status.value == "skipped")
+    final_blocked = sum(1 for r in real_results if r.status.value == "blocked")
+    final_auto_merge = sum(
+        1 for r in real_results if r.status.value == "auto_merge_pending"
+    )
+    parts = [f"{final_merged} merged"]
+    if final_auto_merge > 0:
+        parts.append(f"{final_auto_merge} auto-merge pending")
+    parts.append(f"{final_failed} failed")
+    if final_skipped > 0:
+        parts.append(f"{final_skipped} skipped")
+    console.print(f"\n🚀 Final Results: {', '.join(parts)}")
+    if final_skipped > 0:
+        console.print(f"⏭️ Skipped {final_skipped} PRs")
+    if final_blocked > 0:
+        console.print(f"🛑 Blocked {final_blocked} PRs")
+    if final_auto_merge > 0:
+        console.print(f"⏳ Auto-merge pending for {final_auto_merge} PRs")
+
+    _print_failed_pr_details(real_results)
+
+
 def _handle_gerrit_merge(
     parsed_url: ParsedUrl,
     no_confirm: bool,
@@ -1580,7 +1927,7 @@ def _handle_gerrit_merge(
 def merge(
     pr_url: str = typer.Argument(
         ...,
-        help="GitHub PR URL, repository URL, or Gerrit change URL",
+        help="GitHub PR URL, repository URL, owner/org URL, or Gerrit change URL",
     ),
     no_confirm: bool = typer.Option(
         False,
@@ -1722,6 +2069,23 @@ def merge(
       https://github.com/owner/repo/
       https://github.com/owner/repo/pulls
 
+    For GitHub owner (organization or user) URLs, this command will:
+
+    1. Enumerate every non-archived, non-fork repository owned by the
+       organization or user (forks are excluded)
+
+    2. Fetch their open automation PRs (unless --include-human-prs)
+
+    3. Bulk merge them with a striped scheduler that processes at most
+       one PR per repository at a time, spreading work across
+       repositories to avoid racing GitHub's mergeability propagation
+
+    Owner URL formats accepted:
+      https://github.com/owner
+      https://github.com/owner/
+      https://github.com/orgs/owner
+      https://github.com/orgs/owner/repositories
+
     For Gerrit changes, this command will:
 
     1. Analyze the provided change
@@ -1764,40 +2128,50 @@ def merge(
     )
 
     # --- Parse URL and route to the appropriate handler ---
-    # Try as a specific PR/change URL first
+    # Try as a specific PR/change URL first, then an owner-wide URL
+    # (bare owner / orgs/owner), then a single repository URL.
     parsed_url: ParsedUrl | None = None
     parsed_repo: ParsedRepoUrl | None = None
+    parsed_org: ParsedOrgUrl | None = None
     change_err: UrlParseError | None = None
     try:
         parsed_url = parse_change_url(pr_url)
     except UrlParseError as e:
         change_err = e
-        # Not a PR URL — try as a repository URL
+        # Not a PR URL — try owner-wide before repository.  parse_org_url
+        # is strict (only a bare owner or the canonical orgs/owner forms),
+        # so a two-segment owner/repo URL falls through to parse_repo_url.
+        # Trying owner-wide first is required so /orgs/owner is not
+        # mis-parsed by parse_repo_url as owner="orgs", repo="owner".
         try:
-            parsed_repo = parse_repo_url(pr_url)
-        except UrlParseError as repo_err:
-            # Show the most relevant error: if the URL targets a
-            # non-github.com host the original parse_change_url error
-            # gives host-appropriate guidance (e.g. Gerrit tips),
-            # whereas parse_repo_url only talks about github.com.
-            from .url_parser import _host_matches
-
+            parsed_org = parse_org_url(pr_url)
+        except UrlParseError:
+            # Not an owner URL — try as a repository URL
             try:
-                # Prepend scheme if missing so urlparse can extract the
-                # hostname.  Without a scheme, schemeless URLs like
-                # "gerrit.example.org/..." are parsed as a path with no
-                # hostname, causing the wrong error to be shown.
-                _norm = pr_url
-                if not _norm.startswith(("http://", "https://")):
-                    _norm = "https://" + _norm
-                host = urlparse(_norm).hostname or ""
-            except Exception:
-                host = ""
-            if host and not _host_matches(host.lower(), "github.com"):
-                console.print(f"❌ Invalid URL: {change_err}")
-            else:
-                console.print(f"❌ Invalid URL: {repo_err}")
-            raise typer.Exit(1) from None
+                parsed_repo = parse_repo_url(pr_url)
+            except UrlParseError as repo_err:
+                # Show the most relevant error: if the URL targets a
+                # non-github.com host the original parse_change_url error
+                # gives host-appropriate guidance (e.g. Gerrit tips),
+                # whereas parse_repo_url only talks about github.com.
+                from .url_parser import _host_matches
+
+                try:
+                    # Prepend scheme if missing so urlparse can extract the
+                    # hostname.  Without a scheme, schemeless URLs like
+                    # "gerrit.example.org/..." are parsed as a path with no
+                    # hostname, causing the wrong error to be shown.
+                    _norm = pr_url
+                    if not _norm.startswith(("http://", "https://")):
+                        _norm = "https://" + _norm
+                    host = urlparse(_norm).hostname or ""
+                except Exception:
+                    host = ""
+                if host and not _host_matches(host.lower(), "github.com"):
+                    console.print(f"❌ Invalid URL: {change_err}")
+                else:
+                    console.print(f"❌ Invalid URL: {repo_err}")
+                raise typer.Exit(1) from None
 
     # --- Route: Gerrit change ---
     if parsed_url is not None and parsed_url.is_gerrit:
@@ -1811,6 +2185,73 @@ def merge(
             netrc_file=netrc_file,
             netrc_optional=netrc_optional,
         )
+        return
+
+    # --- Route: GitHub owner (org/user) bulk merge ---
+    if parsed_org is not None:
+        org_ctx = _MergeContext(
+            pr_url=parsed_org.original_url,
+            no_confirm=no_confirm,
+            similarity_threshold=similarity_threshold,
+            merge_method=merge_method,
+            token=token,
+            override=override,
+            no_fix=no_fix,
+            merge_timeout=merge_timeout,
+            show_progress=show_progress,
+            debug_matching=debug_matching,
+            dismiss_copilot=dismiss_copilot,
+            force=force,
+            verbose=verbose,
+            no_netrc=no_netrc,
+            netrc_file=netrc_file,
+            netrc_optional=netrc_optional,
+            github2gerrit_mode=github2gerrit_mode,
+            include_human_prs=include_human_prs,
+            rebase_local=rebase_local,
+        )
+        try:
+            _handle_org_merge(parsed_org, org_ctx)
+        except DependamergeError as exc:
+            if org_ctx.progress_tracker:
+                org_ctx.progress_tracker.stop()
+            exc.display_and_exit()
+        except (KeyboardInterrupt, SystemExit):
+            if org_ctx.progress_tracker:
+                org_ctx.progress_tracker.stop()
+            raise
+        except typer.Exit:
+            if org_ctx.progress_tracker:
+                org_ctx.progress_tracker.stop()
+            raise
+        except (
+            GitError,
+            RateLimitError,
+            SecondaryRateLimitError,
+            GraphQLError,
+        ) as exc:
+            if org_ctx.progress_tracker:
+                org_ctx.progress_tracker.stop()
+            if isinstance(exc, GitError):
+                converted_error = convert_git_error(exc)
+            else:
+                converted_error = convert_github_api_error(exc)
+            converted_error.display_and_exit()
+        except Exception as e:
+            if org_ctx.progress_tracker:
+                org_ctx.progress_tracker.stop()
+            if is_github_api_permission_error(e):
+                exit_for_github_api_error(exception=e)
+            elif is_network_error(e):
+                converted_error = convert_network_error(e)
+                converted_error.display_and_exit()
+            else:
+                exit_with_error(
+                    ExitCode.GENERAL_ERROR,
+                    message="❌ Error during owner-wide merge operation",
+                    details=str(e),
+                    exception=e,
+                )
         return
 
     # --- Route: GitHub repository (bulk per-repo merge) ---

--- a/src/dependamerge/cli.py
+++ b/src/dependamerge/cli.py
@@ -1153,6 +1153,17 @@ def _handle_repo_merge(
         console.print(f"❌ No open {label}PRs found in {parsed_repo.project}")
         return
 
+    # --- Order PRs oldest-first (ascending PR number) ---
+    # The GraphQL fetch returns PRs newest-first (CREATED_AT DESC), but
+    # merging within a repository must drain oldest-first.  Merging the
+    # newest PR ahead of an older sibling leaves the older one behind the
+    # base branch, forcing automation (e.g. dependabot) into an avoidable
+    # rebase-and-revalidate cycle that can block the batch.  Sorting here
+    # mirrors the within-repository key applied owner-wide by
+    # ``_owner_merge_order`` so both schemes sequence a repository's PRs
+    # identically; the preview list below is derived from this order too.
+    repo_prs = _repo_merge_order(repo_prs)
+
     # --- Classify PRs as automation vs human ---
     # Delegated to the shared bot-identity predicate so REST and GraphQL
     # login forms (e.g. "dependabot[bot]" vs "dependabot") classify
@@ -1375,6 +1386,24 @@ def _execute_repo_confirmed_merge(
         console.print(f"⏳ Auto-merge pending for {final_auto_merge} PRs")
 
     _print_failed_pr_details(real_results)
+
+
+def _repo_merge_order(
+    prs: list[PullRequestInfo],
+) -> list[PullRequestInfo]:
+    """Order a single repository's PRs for oldest-first merging.
+
+    Sorts ascending by PR number, i.e. in the order the automation raised
+    them (oldest first).  Merging the oldest PR first minimises the rebase
+    churn imposed on the newer siblings: each merge advances the base
+    branch, so a newer sibling merged ahead of an older one would leave
+    the older PR ``behind`` and trigger an avoidable rebase + CI wait.
+
+    This is the single-repository analogue of the within-repository key
+    used owner-wide by :func:`_owner_merge_order`, keeping both schemes'
+    intra-repository sequencing identical.
+    """
+    return sorted(prs, key=lambda p: p.number)
 
 
 def _owner_merge_order(

--- a/src/dependamerge/cli.py
+++ b/src/dependamerge/cli.py
@@ -777,11 +777,14 @@ def _run_parallel_merge(
             preceding similar-PR list.  Callers pass False when no
             list was printed (e.g. no similar PRs were found) so the
             output stays compact.
-        repo_scoped: When True, all PRs target a single repository, so
-            each worker refreshes its PR's live merge state just before
-            dispatching the merge (a sibling merge can make a PR
-            ``dirty`` / ``behind`` mid-batch).  Left False for org-wide
-            runs.  See ``AsyncMergeManager._refresh_pr_mergeability``.
+        repo_scoped: When True, each worker refreshes its PR's live
+            merge state just before dispatching the merge, because a
+            sibling merge in the same repository can make a PR ``dirty``
+            / ``behind`` mid-batch.  Enabled for both repo-scoped merges
+            (all PRs in one repository) and owner-wide striped merges
+            (which interleave repositories but serialise PRs within each
+            repository).  See
+            ``AsyncMergeManager._refresh_pr_mergeability``.
         stripe: When True, the merge is scheduled with the striped
             scheduler (one serial worker per repository, distinct repos
             concurrent) so owner-wide batches never stack two merges on
@@ -1397,19 +1400,14 @@ def _handle_org_merge(
         ctx: Shared merge context populated with CLI parameters.
     """
     from .github_service import GitHubService
-    from .url_parser import _host_matches
 
-    # --- Guard: owner-merge only supports github.com for now ---
-    # This mirrors the parser's github.com-only guard; GHE enablement
-    # is tracked separately (see derive_api_urls and the GHE issue).
-    if not _host_matches(parsed_org.host, "github.com"):
-        console.print(
-            "❌ Owner-scoped merge is currently only supported "
-            f"for github.com (got host: {parsed_org.host}).\n"
-            "   GitHub Enterprise support requires API base URL "
-            "configuration — use a direct PR URL instead."
-        )
-        raise typer.Exit(code=1)
+    # The host is guaranteed to be github.com here: ``parse_org_url`` is
+    # the single github.com-only choke point (it rejects every other
+    # host, including GHE, before a ``ParsedOrgUrl`` can reach this
+    # handler).  Enabling GHE (#343) means relaxing that one parser guard
+    # and threading ``derive_api_urls(host)`` through the service stack —
+    # deliberately not re-checked here so there is no second guard to
+    # drift out of sync.
 
     # --- Initialise GitHub client & token ---
     ctx.github_client = GitHubClient(ctx.token)
@@ -1422,8 +1420,12 @@ def _handle_org_merge(
         f"🔍 Owner mode: scanning {parsed_org.owner} for automation PRs..."
     )
 
-    # --- Token permission check (reuse existing helper) ---
-    _check_merge_permissions(ctx)
+    # NOTE: the token permission check is deferred until *after*
+    # enumeration (see below).  ``_check_merge_permissions`` probes a
+    # concrete repository, and ``check_token_permissions`` reports every
+    # operation as missing when no repo is supplied — running it here
+    # with an empty ``ctx.repo_name`` would abort every owner-wide run
+    # unconditionally.
 
     # --- Progress tracker (enumeration phase: repos fraction) ---
     if ctx.show_progress:
@@ -1474,6 +1476,16 @@ def _handle_org_merge(
         label = "automation " if only_automation else ""
         console.print(f"❌ No open {label}PRs found in {parsed_org.owner}")
         return
+
+    # --- Token permission check (reuse existing helper) ---
+    # Deferred from before enumeration: the helper needs a concrete repo
+    # to probe, so point it at the first in-scope PR's repository as a
+    # representative sample.  The common failure modes (expired/invalid
+    # token, no write access) fail identically on any repo; genuine
+    # per-repo permission variance with fine-grained tokens is caught at
+    # merge time by the scheduler's per-repository error isolation.
+    ctx.repo_name = owner_prs[0].repository_full_name.split("/", 1)[-1]
+    _check_merge_permissions(ctx)
 
     # --- Classify PRs as automation vs human ---
     # Substring matching is consistent with

--- a/src/dependamerge/cli.py
+++ b/src/dependamerge/cli.py
@@ -20,6 +20,7 @@ from rich.console import Console
 from rich.table import Table
 
 from ._version import __version__
+from .bot_identity import is_automation_author
 from .close_manager import AsyncCloseManager, CloseResult
 from .error_codes import (
     DependamergeError,
@@ -81,6 +82,12 @@ from .url_parser import (
 
 # Constants
 MAX_RETRIES = 2
+
+# Default owner-wide global wait ceiling (seconds) for `--max-wait`.
+# 15 minutes balances giving dependabot's rebase + CI time to land
+# against not blocking the shell indefinitely.  0 disables waiting
+# (fire-and-forget).
+DEFAULT_MAX_WAIT = 900.0
 
 
 def version_callback(value: bool):
@@ -338,6 +345,11 @@ class _MergeContext:
     github2gerrit_mode: str
     include_human_prs: bool = False
     rebase_local: bool = True
+    # Owner-wide global wait ceiling (seconds).  Default 900 (15 min);
+    # 0 = fire-and-forget (arm auto-merge, report pending, never block).
+    # Applies to owner/user-wide runs; ignored for single-PR and
+    # single-repository merges.
+    max_wait: float = DEFAULT_MAX_WAIT
 
     # Derived / mutable state
     github_client: GitHubClient | None = None
@@ -809,6 +821,10 @@ def _run_parallel_merge(
             netrc_file=ctx.netrc_file,
             rebase_local=ctx.rebase_local,
             repo_scoped=repo_scoped,
+            # The owner-wide global wait ceiling applies to striped
+            # (owner/user-wide) runs; single-PR and single-repository
+            # merges keep the uncapped per-PR ``merge_timeout`` behaviour.
+            max_wait=ctx.max_wait if stripe else None,
         ) as merge_manager:
             if not preview:
                 prefix = "\n" if leading_blank else ""
@@ -1138,17 +1154,15 @@ def _handle_repo_merge(
         return
 
     # --- Classify PRs as automation vs human ---
-    # Use AUTOMATION_TOOLS substring matching (consistent with
-    # GitHubService.fetch_repo_open_prs and _is_automation_author).
-    # GraphQL returns authors without the "[bot]" suffix (e.g.
-    # "dependabot" not "dependabot[bot]"), so the exact-match
-    # GitHubClient.is_automation_author() would misclassify them.
+    # Delegated to the shared bot-identity predicate so REST and GraphQL
+    # login forms (e.g. "dependabot[bot]" vs "dependabot") classify
+    # identically.
     def _is_auto(author: str | None) -> bool:
-        author_lower = (author or "").lower()
-        return any(tool in author_lower for tool in AUTOMATION_TOOLS)
+        return is_automation_author(author)
 
     automation_prs: list[PullRequestInfo] = []
     human_prs: list[PullRequestInfo] = []
+
     for pr in repo_prs:
         if _is_auto(pr.author):
             automation_prs.append(pr)
@@ -1363,6 +1377,38 @@ def _execute_repo_confirmed_merge(
     _print_failed_pr_details(real_results)
 
 
+def _owner_merge_order(
+    prs: list[PullRequestInfo],
+) -> list[PullRequestInfo]:
+    """Order owner-wide PRs for striped merging.
+
+    Sorts so that:
+
+    - Repositories with the most in-scope PRs come first.  These take the
+      longest to drain (each merge can make the next sibling ``behind`` /
+      ``dirty`` and trigger a rebase + CI wait), so starting them earliest
+      gives them the most wall-clock head start under the striped
+      scheduler's concurrent per-repository workers.
+    - Within a repository, PRs ascend by number, i.e. in the order the
+      automation raised them (oldest first).  Merging the oldest first
+      minimises the rebase churn imposed on the newer siblings.
+
+    Ties between equally-sized repositories break on repository name so
+    the order (and the grouped listing derived from it) is deterministic.
+    """
+    counts: dict[str, int] = {}
+    for pr in prs:
+        counts[pr.repository_full_name] = counts.get(pr.repository_full_name, 0) + 1
+    return sorted(
+        prs,
+        key=lambda p: (
+            -counts[p.repository_full_name],
+            p.repository_full_name,
+            p.number,
+        ),
+    )
+
+
 def _print_prs_grouped_by_repo(
     prs: list[PullRequestInfo],
 ) -> None:
@@ -1370,14 +1416,16 @@ def _print_prs_grouped_by_repo(
 
     Emits a header per repository followed by its PRs indented beneath,
     so a large owner-wide list stays scannable.  Repositories are listed
-    in sorted order; PRs within a repository are ordered by number.
+    in the order they first appear in ``prs`` (the caller passes them in
+    merge order via :func:`_owner_merge_order`, so the listing mirrors the
+    sequence in which they will be merged); PRs within a repository are
+    shown in the supplied order.
     """
     by_repo: dict[str, list[PullRequestInfo]] = {}
     for pr in prs:
         by_repo.setdefault(pr.repository_full_name, []).append(pr)
 
-    for repo in sorted(by_repo):
-        repo_prs = sorted(by_repo[repo], key=lambda p: p.number)
+    for repo, repo_prs in by_repo.items():
         console.print(f"\n📁 {repo} ({len(repo_prs)} PR(s))")
         for pr in repo_prs:
             console.print(f"  #{pr.number} {pr.title} (by {pr.author})")
@@ -1477,6 +1525,11 @@ def _handle_org_merge(
         console.print(f"❌ No open {label}PRs found in {parsed_org.owner}")
         return
 
+    # Order for striped merging: repositories with the most PRs first,
+    # ascending PR number within each repository (see _owner_merge_order).
+    # Both the grouped listing and the merge list derive from this order.
+    owner_prs = _owner_merge_order(owner_prs)
+
     # --- Token permission check (reuse existing helper) ---
     # Deferred from before enumeration: the helper needs a concrete repo
     # to probe, so point it at the first in-scope PR's repository as a
@@ -1488,11 +1541,9 @@ def _handle_org_merge(
     _check_merge_permissions(ctx)
 
     # --- Classify PRs as automation vs human ---
-    # Substring matching is consistent with
-    # GitHubService._is_automation_author / fetch_owner_open_prs.
+    # Delegated to the shared bot-identity predicate (see _handle_repo_merge).
     def _is_auto(author: str | None) -> bool:
-        author_lower = (author or "").lower()
-        return any(tool in author_lower for tool in AUTOMATION_TOOLS)
+        return is_automation_author(author)
 
     automation_prs: list[PullRequestInfo] = []
     human_prs: list[PullRequestInfo] = []
@@ -1985,6 +2036,18 @@ def merge(
             f"{DEFAULT_MERGE_TIMEOUT:.0f}"
         ),
     ),
+    max_wait: float = typer.Option(
+        DEFAULT_MAX_WAIT,
+        "--max-wait",
+        help=(
+            "Owner/user-wide runs only: global wall-clock ceiling in "
+            "seconds for the whole batch. The run returns once every PR "
+            "has merged or this elapses (anything still in flight keeps "
+            "auto-merge armed and is reported as pending). 0 = "
+            "fire-and-forget (arm auto-merge and return immediately, "
+            f"never block). Default: {DEFAULT_MAX_WAIT:.0f}"
+        ),
+    ),
     show_progress: bool = typer.Option(
         True, "--progress/--no-progress", help="Show real-time progress updates"
     ),
@@ -2203,6 +2266,7 @@ def merge(
     if parsed_org is not None:
         org_ctx = _MergeContext(
             pr_url=parsed_org.original_url,
+            max_wait=max_wait,
             no_confirm=no_confirm,
             similarity_threshold=similarity_threshold,
             merge_method=merge_method,
@@ -2270,6 +2334,7 @@ def merge(
     if parsed_repo is not None:
         repo_ctx = _MergeContext(
             pr_url=parsed_repo.original_url,
+            max_wait=max_wait,
             no_confirm=no_confirm,
             similarity_threshold=similarity_threshold,
             merge_method=merge_method,
@@ -2337,6 +2402,7 @@ def merge(
     assert parsed_url is not None
     ctx = _MergeContext(
         pr_url=parsed_url.original_url,
+        max_wait=max_wait,
         no_confirm=no_confirm,
         similarity_threshold=similarity_threshold,
         merge_method=merge_method,

--- a/src/dependamerge/copilot_handler.py
+++ b/src/dependamerge/copilot_handler.py
@@ -13,12 +13,10 @@ This module provides functionality to:
 import logging
 from typing import Any
 
+from .bot_identity import is_copilot
 from .models import PullRequestInfo, ReviewInfo
 
 logger = logging.getLogger(__name__)
-
-# Known Copilot author identifiers
-COPILOT_AUTHORS = {"Copilot", "github-copilot", "copilot[bot]", "github-copilot[bot]"}
 
 # Common Copilot comment patterns that are often safe to dismiss
 COMMON_COPILOT_PATTERNS = [
@@ -59,13 +57,9 @@ class CopilotCommentHandler:
         if not review.user:
             return False
 
-        # Check if author matches known Copilot identifiers
-        author_lower = review.user.lower()
-        for copilot_author in COPILOT_AUTHORS:
-            if copilot_author.lower() in author_lower:
-                return True
-
-        return False
+        # Route author matching through the shared identity predicate so
+        # every Copilot login form (REST and GraphQL) is recognised.
+        return is_copilot(review.user)
 
     def get_copilot_reviews(self, pr_info: PullRequestInfo) -> list[ReviewInfo]:
         """
@@ -321,11 +315,7 @@ class CopilotCommentHandler:
 
         for comment in comments:
             author = comment.get("author", {})
-            if author and author.get("login") in [
-                "github-copilot[bot]",
-                "copilot",
-                "copilot-pull-request-reviewer",
-            ]:
+            if author and is_copilot(author.get("login")):
                 return True
 
             # Also check comment body for Copilot patterns
@@ -670,12 +660,9 @@ class CopilotCommentHandler:
             copilot_comments = []
 
             for comment in all_comments:
-                author = comment.get("user", {}).get("login", "").lower()
+                author = comment.get("user", {}).get("login", "")
                 # Check if comment is from Copilot
-                if any(
-                    copilot_author.lower() in author
-                    for copilot_author in COPILOT_AUTHORS
-                ):
+                if is_copilot(author):
                     copilot_comments.append(comment)
                     if self.debug:
                         self.log.info(

--- a/src/dependamerge/github_async.py
+++ b/src/dependamerge/github_async.py
@@ -25,6 +25,8 @@ from tenacity import (
     wait_random_exponential,
 )
 
+from .bot_identity import is_copilot
+
 __all__ = [
     "GitHubAsync",
     "RateLimitError",
@@ -1876,7 +1878,7 @@ class GitHubAsync:
                     if state == "APPROVED":
                         approved = True
                     elif state == "CHANGES_REQUESTED":
-                        if author == "github-copilot[bot]":
+                        if is_copilot(author):
                             unresolved_copilot_reviews += 1
                         else:
                             human_changes_requested = True
@@ -1894,7 +1896,7 @@ class GitHubAsync:
                         continue
                     author = comment.get("user", {}).get("login", "")
                     # Count unresolved Copilot comments (those without replies dismissing them)
-                    if author == "github-copilot[bot]":
+                    if is_copilot(author):
                         # Simple heuristic: if comment doesn't have "DISMISSED" or similar resolution text
                         body = comment.get("body", "").lower()
                         if "dismissed" not in body and "resolved" not in body:

--- a/src/dependamerge/github_async.py
+++ b/src/dependamerge/github_async.py
@@ -879,6 +879,8 @@ class GitHubAsync:
             if isinstance(body, dict) and isinstance(body.get("message"), str):
                 return " ".join(body["message"].split())
         except Exception:
+            # Response body was not JSON (or .json() failed); fall through
+            # to the raw-text extraction below rather than failing here.
             pass
         try:
             raw = getattr(response, "text", "") or ""

--- a/src/dependamerge/github_client.py
+++ b/src/dependamerge/github_client.py
@@ -7,6 +7,7 @@ from datetime import datetime
 from typing import TYPE_CHECKING, Any, Optional
 from urllib.parse import urlparse
 
+from .bot_identity import is_automation_author
 from .models import (
     FileChange,
     OrganizationScanResult,
@@ -266,15 +267,12 @@ class GitHubClient:
             return False
 
     def is_automation_author(self, author: str) -> bool:
-        """Check if the author is a known automation tool."""
-        automation_authors = {
-            "dependabot[bot]",
-            "pre-commit-ci[bot]",
-            "renovate[bot]",
-            "github-actions[bot]",
-            "allcontributors[bot]",
-        }
-        return author in automation_authors
+        """Check if the author is a known automation tool.
+
+        Delegates to the shared :func:`bot_identity.is_automation_author`
+        so REST and GraphQL login forms are classified identically.
+        """
+        return is_automation_author(author)
 
     def get_pr_status_details(self, pr_info: PullRequestInfo) -> str:
         """Get detailed status information for a PR."""

--- a/src/dependamerge/github_graphql.py
+++ b/src/dependamerge/github_graphql.py
@@ -109,7 +109,7 @@ query($org: String!, $reposCursor: String) {
             body
             url
             isDraft
-            author { login }
+            author { __typename login }
             mergeable
             mergeStateStatus
             baseRefName
@@ -199,7 +199,7 @@ query($owner: String!, $name: String!, $prsCursor: String, $prsPageSize: Int!, $
         body
         url
         isDraft
-        author { login }
+        author { __typename login }
         mergeable
         mergeStateStatus
         baseRefName

--- a/src/dependamerge/github_graphql.py
+++ b/src/dependamerge/github_graphql.py
@@ -16,6 +16,7 @@ Notes:
 
 __all__ = [
     "ORG_REPOS_ONLY",
+    "USER_REPOS_ONLY",
     "ORG_REPOS_WITH_OPEN_PRS",
     "REPO_OPEN_PRS_PAGE",
     "ENABLE_AUTO_MERGE",
@@ -28,6 +29,10 @@ __all__ = [
 # totalCount is provided by the GitHub GraphQL API for free on connection
 # objects, so the first page immediately reveals the org-wide repo total
 # without requiring a separate counting pass.
+#
+# ``isFork`` is included so owner-wide bulk operations can exclude fork
+# repositories without a second round-trip; existing consumers that only
+# read ``nameWithOwner`` / ``isArchived`` simply ignore the extra field.
 ORG_REPOS_ONLY = """
 query($org: String!, $reposCursor: String) {
   organization(login: $org) {
@@ -40,6 +45,33 @@ query($org: String!, $reposCursor: String) {
       nodes {
         nameWithOwner
         isArchived
+        isFork
+      }
+    }
+  }
+}
+"""
+
+# User-account counterpart of ORG_REPOS_ONLY.  The ``repositories``
+# connection exists on both ``Organization`` and ``User``, so this query
+# is structurally identical apart from the ``user(login:)`` root.  It is
+# used as a runtime fallback when an owner login is not an organization
+# (the ``organization`` field returns null).  The ``$org`` variable name
+# is retained for call-site uniformity even though it carries a user
+# login here.
+USER_REPOS_ONLY = """
+query($org: String!, $reposCursor: String) {
+  user(login: $org) {
+    repositories(first: 100, after: $reposCursor, orderBy: { field: NAME, direction: ASC }) {
+      totalCount
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      nodes {
+        nameWithOwner
+        isArchived
+        isFork
       }
     }
   }

--- a/src/dependamerge/github_service.py
+++ b/src/dependamerge/github_service.py
@@ -455,8 +455,12 @@ class GitHubService:
         :meth:`_iter_org_repositories`).  Fork repositories are also
         skipped: owner-wide bulk merges target the owner's own
         automation PRs, not PRs on mirrored forks.  The progress total
-        is published from the first page's ``totalCount`` so the
-        percentage display is immediately accurate.
+        is published from the first page's ``totalCount``, which counts
+        *all* of the owner's repositories — including the archived and
+        fork repos this iterator filters out — so the denominator is
+        approximate and the percentage can finish below 100%.  It is
+        close enough for a progress bar, matching
+        :meth:`_iter_org_repositories`.
         """
         root_key, query = await self._resolve_owner_root(owner)
         cursor: str | None = None
@@ -1049,7 +1053,15 @@ class GitHubService:
                     raise
                 except Exception as e:
                     if self._progress:
+                        # Count the error *and* mark the repository as
+                        # processed.  Without the ``complete_repository``
+                        # call the per-repo counter would never advance
+                        # for a failed repo, leaving the progress fraction
+                        # stuck below 100% and the "Scanning <repo>"
+                        # label stale once the run finishes.  Passing 0
+                        # adds nothing to the unmergeable tally.
                         self._progress.add_error()
+                        self._progress.complete_repository(0)
                     return [], [f"Error scanning repository {repo_full_name}: {e}"]
 
         all_prs: list[PullRequestInfo] = []

--- a/src/dependamerge/github_service.py
+++ b/src/dependamerge/github_service.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 from collections.abc import AsyncIterator
 from datetime import datetime
@@ -11,6 +12,7 @@ from typing import Any
 
 from .github_async import (
     GitHubAsync,
+    GraphQLError,
     RateLimitError,
     SecondaryRateLimitError,
 )
@@ -379,13 +381,65 @@ class GitHubService:
             return cached
 
         variables = {"org": owner, "reposCursor": None}
-        data = await self._api.graphql(ORG_REPOS_ONLY, variables)
-        if (data or {}).get("organization") is not None:
+        # GitHub answers ``organization(login:)`` for a *user* login with
+        # ``data.organization = null`` AND a NOT_FOUND error in the
+        # ``errors`` array ("Could not resolve to an Organization ...").
+        # ``GitHubAsync.graphql`` raises ``GraphQLError`` on any non-transient
+        # ``errors`` payload, so the null-organization case never reaches the
+        # ``data`` check below — it surfaces as an exception instead.  Treat a
+        # NOT_FOUND-on-organization error as "not an org" and fall back to the
+        # user root; re-raise anything else (e.g. genuine transport or schema
+        # errors).
+        try:
+            data = await self._api.graphql(ORG_REPOS_ONLY, variables)
+            is_org = (data or {}).get("organization") is not None
+        except GraphQLError as exc:
+            if not self._is_not_an_organization_error(exc):
+                raise
+            is_org = False
+
+        if is_org:
             resolved = ("organization", ORG_REPOS_ONLY)
         else:
             resolved = ("user", USER_REPOS_ONLY)
         self._owner_root_cache[owner] = resolved
         return resolved
+
+    @staticmethod
+    def _is_not_an_organization_error(exc: GraphQLError) -> bool:
+        """Return True when a GraphQL error means "login is not an org".
+
+        ``GitHubAsync.graphql`` raises ``GraphQLError(json.dumps(errors))``,
+        so the exception text is the structured GraphQL ``errors`` array.
+        Parse it and match only a ``NOT_FOUND`` error reported against the
+        top-level ``organization`` field (``path == ["organization"]``),
+        so an unrelated ``NOT_FOUND`` on a nested field that merely mentions
+        "organization" cannot trigger the user-account fallback.
+
+        If the payload is not the expected JSON shape (e.g. the
+        retries-exhausted sentinel), fall back to the conservative
+        substring heuristic so a genuinely-missing org still falls back
+        rather than aborting.
+        """
+        try:
+            errors = json.loads(str(exc))
+        except (ValueError, TypeError):
+            errors = None
+
+        if isinstance(errors, list):
+            for error in errors:
+                if not isinstance(error, dict):
+                    continue
+                if str(error.get("type", "")).upper() != "NOT_FOUND":
+                    continue
+                path = error.get("path")
+                if path == ["organization"]:
+                    return True
+            return False
+
+        # Payload was not the structured errors array; degrade gracefully.
+        msg = str(exc).lower()
+        return "not_found" in msg and "organization" in msg
 
     async def _iter_owner_repositories(
         self, owner: str
@@ -934,7 +988,7 @@ class GitHubService:
         )
 
         if self._progress:
-            self._progress.complete_repository(0)
+            self._progress.complete_repository(len(results))
 
         return results
 
@@ -991,19 +1045,56 @@ class GitHubService:
                         self._progress.add_error()
                     return [], [f"Error scanning repository {repo_full_name}: {e}"]
 
-        tasks: list[asyncio.Task[Any]] = []
-        async for repo in self._iter_owner_repositories(owner):
-            tasks.append(asyncio.create_task(process_repo(repo)))
-
         all_prs: list[PullRequestInfo] = []
         errors: list[str] = []
-        if tasks:
-            # No return_exceptions: a propagated rate-limit error aborts
-            # the gather (the desired behaviour for global throttling).
-            results = await asyncio.gather(*tasks)
-            for repo_prs, repo_errors in results:
+
+        # Bounded producer/consumer pipeline.  A fixed pool of workers
+        # (sized to the repo-concurrency limit) drains repository nodes
+        # from a queue fed by the paginated iterator.  This caps in-flight
+        # work — both pending tasks and buffered nodes — instead of
+        # materialising one task per repository up front, which matters
+        # for owners with thousands of repositories.  A propagated
+        # rate-limit error from any worker tears the whole pipeline down
+        # (see the teardown below), preserving the global-throttle
+        # semantics of aborting the run rather than skipping repos.
+        worker_count = max(1, self._max_repo_tasks)
+        queue: asyncio.Queue[dict[str, Any] | None] = asyncio.Queue(
+            maxsize=worker_count * 2
+        )
+
+        async def producer() -> None:
+            async for repo in self._iter_owner_repositories(owner):
+                await queue.put(repo)
+            # One sentinel per worker so each terminates once the backlog
+            # drains.
+            for _ in range(worker_count):
+                await queue.put(None)
+
+        async def worker() -> None:
+            while True:
+                repo = await queue.get()
+                if repo is None:
+                    return
+                repo_prs, repo_errors = await process_repo(repo)
+                # Safe to mutate the shared lists without a lock: asyncio
+                # is single-threaded and ``extend`` does not await.
                 all_prs.extend(repo_prs)
                 errors.extend(repo_errors)
+
+        producer_task = asyncio.create_task(producer())
+        worker_tasks = [asyncio.create_task(worker()) for _ in range(worker_count)]
+        pipeline = [producer_task, *worker_tasks]
+        try:
+            # No return_exceptions: a propagated rate-limit error aborts
+            # the pipeline (the desired behaviour for global throttling).
+            await asyncio.gather(*pipeline)
+        except BaseException:
+            # Tear the pipeline down so no worker is left blocked on the
+            # queue, then re-raise the original (e.g. rate-limit) error.
+            for task in pipeline:
+                task.cancel()
+            await asyncio.gather(*pipeline, return_exceptions=True)
+            raise
 
         return all_prs, errors
 

--- a/src/dependamerge/github_service.py
+++ b/src/dependamerge/github_service.py
@@ -9,8 +9,17 @@ from collections.abc import AsyncIterator
 from datetime import datetime
 from typing import Any
 
-from .github_async import GitHubAsync
-from .github_graphql import GET_BRANCH_PROTECTION, ORG_REPOS_ONLY, REPO_OPEN_PRS_PAGE
+from .github_async import (
+    GitHubAsync,
+    RateLimitError,
+    SecondaryRateLimitError,
+)
+from .github_graphql import (
+    GET_BRANCH_PROTECTION,
+    ORG_REPOS_ONLY,
+    REPO_OPEN_PRS_PAGE,
+    USER_REPOS_ONLY,
+)
 from .models import (
     ComparisonResult,
     CopilotComment,
@@ -126,6 +135,10 @@ class GitHubService:
         self._debug_matching = debug_matching
         # Cache for branch protection settings to avoid repeated API calls
         self._branch_protection_cache: dict[str, dict[str, Any] | None] = {}
+        # Cache for resolved owner account type (organization vs user),
+        # keyed by owner login.  Value is a ``(root_key, query)`` tuple so
+        # repeated repository-pagination pages do not re-probe.
+        self._owner_root_cache: dict[str, tuple[str, str]] = {}
         self.log = logging.getLogger(__name__)
 
     async def close(self) -> None:
@@ -347,6 +360,76 @@ class GitHubService:
         """
         async for repo in self._iter_org_repositories(org):
             yield repo
+
+    async def _resolve_owner_root(self, owner: str) -> tuple[str, str]:
+        """Resolve whether ``owner`` is an organization or a user account.
+
+        Probes the ``organization(login:)`` repositories query first; if
+        that root resolves to null (the login is not an org), falls back
+        to the ``user(login:)`` query.  The verdict is cached so repeated
+        pagination pages do not re-probe.
+
+        Returns:
+            A ``(root_key, query)`` tuple where ``root_key`` is the
+            top-level GraphQL field (``"organization"`` or ``"user"``)
+            and ``query`` is the matching query document.
+        """
+        cached = self._owner_root_cache.get(owner)
+        if cached is not None:
+            return cached
+
+        variables = {"org": owner, "reposCursor": None}
+        data = await self._api.graphql(ORG_REPOS_ONLY, variables)
+        if (data or {}).get("organization") is not None:
+            resolved = ("organization", ORG_REPOS_ONLY)
+        else:
+            resolved = ("user", USER_REPOS_ONLY)
+        self._owner_root_cache[owner] = resolved
+        return resolved
+
+    async def _iter_owner_repositories(
+        self, owner: str
+    ) -> AsyncIterator[dict[str, Any]]:
+        """Iterate an owner's non-archived, non-fork repositories.
+
+        Works for both organizations and personal user accounts: the
+        correct GraphQL root is resolved once via
+        :meth:`_resolve_owner_root` and reused for every page.
+
+        Archived repositories are skipped (consistent with
+        :meth:`_iter_org_repositories`).  Fork repositories are also
+        skipped: owner-wide bulk merges target the owner's own
+        automation PRs, not PRs on mirrored forks.  The progress total
+        is published from the first page's ``totalCount`` so the
+        percentage display is immediately accurate.
+        """
+        root_key, query = await self._resolve_owner_root(owner)
+        cursor: str | None = None
+        total_set = False
+        while True:
+            variables = {"org": owner, "reposCursor": cursor}
+            data = await self._api.graphql(query, variables)
+            root = (data or {}).get(root_key) or {}
+            repos = root.get("repositories") or {}
+
+            if not total_set:
+                total_count = repos.get("totalCount")
+                if total_count is not None and self._progress:
+                    self._progress.update_total_repositories(total_count)
+                total_set = True
+
+            nodes: list[dict[str, Any]] = repos.get("nodes", []) or []
+            for repo in nodes:
+                if repo.get("isArchived"):
+                    continue
+                if repo.get("isFork"):
+                    continue
+                yield repo
+
+            page_info = repos.get("pageInfo") or {}
+            if not page_info.get("hasNextPage"):
+                break
+            cursor = page_info.get("endCursor")
 
     async def _iter_repo_open_prs_pages(
         self, owner: str, name: str, cursor: str | None
@@ -768,6 +851,53 @@ class GitHubService:
 
         return results
 
+    async def _collect_repo_open_prs(
+        self,
+        owner: str,
+        repo: str,
+        *,
+        only_automation: bool,
+    ) -> list[PullRequestInfo]:
+        """Fetch + convert + filter the open PRs of a single repository.
+
+        This is the shared body used by both :meth:`fetch_repo_open_prs`
+        (single-repository bulk merge) and :meth:`fetch_owner_open_prs`
+        (owner-wide bulk merge), so the GraphQL-node-to-PullRequestInfo
+        conversion and automation filtering live in exactly one place.
+
+        Unlike its callers it does not emit ``start_repository`` /
+        ``complete_repository`` progress events; the caller owns the
+        per-repository progress lifecycle.
+        """
+        repo_full_name = f"{owner}/{repo}"
+
+        first_nodes, page_info = await self._fetch_repo_prs_first_page(owner, repo)
+        pr_nodes = list(first_nodes)
+        has_next = bool(page_info.get("hasNextPage"))
+        end_cursor = page_info.get("endCursor") or None
+
+        # Fetch additional pages if present
+        if has_next:
+            async for pr_node in self._iter_repo_open_prs_pages(
+                owner, repo, end_cursor
+            ):
+                pr_nodes.append(pr_node)
+
+        results: list[PullRequestInfo] = []
+        for pr_node in pr_nodes:
+            pr_info = self.to_pull_request_info(repo_full_name, pr_node)
+
+            if self._progress:
+                self._progress.analyze_pr(pr_info.number, repo_full_name)
+
+            # Filter by automation author if requested
+            if only_automation and not self._is_automation_author(pr_info.author):
+                continue
+
+            results.append(pr_info)
+
+        return results
+
     async def fetch_repo_open_prs(
         self,
         owner: str,
@@ -799,42 +929,83 @@ class GitHubService:
                 f"Fetching open PRs from {repo_full_name}"
             )
 
-        first_nodes, page_info = await self._fetch_repo_prs_first_page(
-            owner, repo
+        results = await self._collect_repo_open_prs(
+            owner, repo, only_automation=only_automation
         )
-        pr_nodes = list(first_nodes)
-        has_next = bool(page_info.get("hasNextPage"))
-        end_cursor = page_info.get("endCursor") or None
-
-        # Fetch additional pages if present
-        if has_next:
-            async for pr_node in self._iter_repo_open_prs_pages(
-                owner, repo, end_cursor
-            ):
-                pr_nodes.append(pr_node)
-
-        results: list[PullRequestInfo] = []
-        for pr_node in pr_nodes:
-            pr_info = self.to_pull_request_info(repo_full_name, pr_node)
-
-            if self._progress:
-                self._progress.analyze_pr(pr_info.number, repo_full_name)
-
-            # Filter by automation author if requested
-            if only_automation:
-                is_auto = any(
-                    bot in (pr_info.author or "").lower()
-                    for bot in AUTOMATION_TOOLS
-                )
-                if not is_auto:
-                    continue
-
-            results.append(pr_info)
 
         if self._progress:
             self._progress.complete_repository(0)
 
         return results
+
+    async def fetch_owner_open_prs(
+        self,
+        owner: str,
+        *,
+        only_automation: bool = True,
+    ) -> tuple[list[PullRequestInfo], list[str]]:
+        """Fetch open PRs across every in-scope repository of an owner.
+
+        Enumerates the owner's non-archived, non-fork repositories
+        (organization or user account, resolved at runtime) and fetches
+        their open PRs with bounded per-repository concurrency, reusing
+        the same per-repo body as :meth:`fetch_repo_open_prs`.
+
+        Per-repository failures are isolated: a transient error scanning
+        one repository is recorded and enumeration continues, so a single
+        bad repository never aborts an owner-wide run.  Global
+        rate-limit / secondary-rate-limit errors are *not* swallowed —
+        they propagate so the API layer's backoff governs the whole run.
+
+        Args:
+            owner: The organization or user login.
+            only_automation: If True, only return PRs from automation tools.
+
+        Returns:
+            A ``(prs, errors)`` tuple: the collected PRs across all
+            repositories, and a list of human-readable per-repository
+            error strings (empty when everything succeeded).
+        """
+
+        async def process_repo(
+            repo_node: dict[str, Any],
+        ) -> tuple[list[PullRequestInfo], list[str]]:
+            async with self._repo_semaphore:
+                repo_full_name = repo_node.get("nameWithOwner", "unknown/unknown")
+                if self._progress:
+                    self._progress.start_repository(repo_full_name)
+                try:
+                    repo_owner, repo_name = self._split_owner_repo(repo_full_name)
+                    prs = await self._collect_repo_open_prs(
+                        repo_owner, repo_name, only_automation=only_automation
+                    )
+                    if self._progress:
+                        self._progress.complete_repository(len(prs))
+                    return prs, []
+                except (RateLimitError, SecondaryRateLimitError):
+                    # Global rate limiting must abort the whole run rather
+                    # than be recorded as a per-repo error and skipped.
+                    raise
+                except Exception as e:
+                    if self._progress:
+                        self._progress.add_error()
+                    return [], [f"Error scanning repository {repo_full_name}: {e}"]
+
+        tasks: list[asyncio.Task[Any]] = []
+        async for repo in self._iter_owner_repositories(owner):
+            tasks.append(asyncio.create_task(process_repo(repo)))
+
+        all_prs: list[PullRequestInfo] = []
+        errors: list[str] = []
+        if tasks:
+            # No return_exceptions: a propagated rate-limit error aborts
+            # the gather (the desired behaviour for global throttling).
+            results = await asyncio.gather(*tasks)
+            for repo_prs, repo_errors in results:
+                all_prs.extend(repo_prs)
+                errors.extend(repo_errors)
+
+        return all_prs, errors
 
     async def get_branch_protection_settings(
         self, owner: str, repo: str, branch: str = "main"

--- a/src/dependamerge/github_service.py
+++ b/src/dependamerge/github_service.py
@@ -10,6 +10,7 @@ from collections.abc import AsyncIterator
 from datetime import datetime
 from typing import Any
 
+from .bot_identity import canonical_bot_login, is_automation_author
 from .github_async import (
     GitHubAsync,
     GraphQLError,
@@ -653,7 +654,10 @@ class GitHubService:
             repository=repo_full_name,
             pr_number=int(pr.get("number", 0)),
             title=pr.get("title") or "",
-            author=((pr.get("author") or {}).get("login") or "unknown"),
+            author=canonical_bot_login(
+                (pr.get("author") or {}).get("login"),
+                (pr.get("author") or {}).get("__typename"),
+            ),
             url=pr.get("url") or "",
             reasons=reasons,
             copilot_comments_count=len(copilot_comments),
@@ -684,7 +688,10 @@ class GitHubService:
             node_id=pr.get("id"),  # GraphQL node ID for mutations
             title=pr.get("title") or "",
             body=(pr.get("body") or None),
-            author=((pr.get("author") or {}).get("login") or "unknown"),
+            author=canonical_bot_login(
+                (pr.get("author") or {}).get("login"),
+                (pr.get("author") or {}).get("__typename"),
+            ),
             head_sha=pr.get("headRefOid") or "",
             base_branch=pr.get("baseRefName") or "",
             head_branch=pr.get("headRefName") or "",
@@ -1647,9 +1654,12 @@ class GitHubService:
         return stats
 
     def _is_automation_author(self, author: str) -> bool:
-        """Check if author is an automation tool."""
-        author_lower = author.lower()
-        return any(tool in author_lower for tool in AUTOMATION_TOOLS)
+        """Check if author is an automation tool.
+
+        Delegates to the shared :func:`bot_identity.is_automation_author`
+        so REST and GraphQL login forms are classified identically.
+        """
+        return is_automation_author(author)
 
     def _affects_action_files(self, files: list[dict[str, Any]]) -> bool:
         """Check if files include action definition or implementation files."""

--- a/src/dependamerge/gitreview.py
+++ b/src/dependamerge/gitreview.py
@@ -49,6 +49,11 @@ DEFAULT_GERRIT_PORT: int = 29418
 #   • are case-insensitive on the key name (``(?i)``)
 #   • tolerate optional horizontal whitespace around ``=``
 #   • strip trailing whitespace / ``\r`` so Windows line endings are handled
+#
+# The trailing ``[ \t\r]*$`` component on every pattern is what absorbs
+# a Windows ``\r`` (and any trailing spaces/tabs) before the line
+# anchor, so values parsed from CRLF-terminated files do not retain a
+# stray carriage return.
 # ───────────────────────────────────────────────────────────────────────
 
 _HOST_RE = re.compile(r"(?mi)^host[ \t]*=[ \t]*(.+?)[ \t\r]*$")

--- a/src/dependamerge/merge_manager.py
+++ b/src/dependamerge/merge_manager.py
@@ -410,10 +410,12 @@ class AsyncMergeManager:
         # that every per-PR wait is clamped to (see
         # ``_wait_for_auto_merge``); ``0`` (``_no_wait``) skips waiting
         # entirely; ``None`` leaves each per-PR ``merge_timeout``
-        # uncapped (repository / similar-PR runs).  Reset first so a
-        # reused manager instance never carries a stale deadline from a
-        # previous run into this one.
+        # uncapped (repository / similar-PR runs).  Reset both first so a
+        # reused manager instance never carries a stale deadline — or a
+        # stale ``_no_wait`` flag — from a previous run into this one
+        # (``_max_wait`` may differ between runs on the same instance).
         self._run_deadline = None
+        self._no_wait = self._max_wait is not None and self._max_wait <= 0
         if self._max_wait is not None and self._max_wait > 0:
             self._run_deadline = asyncio.get_running_loop().time() + self._max_wait
 
@@ -575,7 +577,10 @@ class AsyncMergeManager:
             for repo, items in grouped.items()
         ]
 
-        # Workers never raise (each PR is wrapped defensively above).
+        # Workers swallow every per-PR exception (each PR is wrapped
+        # defensively above), so the only thing they can propagate is
+        # ``asyncio.CancelledError`` on shutdown — which ``gather``
+        # re-raises to tear the whole run down.
         await asyncio.gather(*tasks)
 
         return [result_by_index[i] for i in range(len(pr_list))]
@@ -4658,14 +4663,32 @@ class AsyncMergeManager:
                     pr_info.number,
                     exc,
                 )
-            await self._enable_auto_merge_for_pr(pr_info, owner, repo)
-            result.status = MergeStatus.AUTO_MERGE_PENDING
-            log_and_print(
-                self.log,
-                self._console,
-                f"⏳ Auto-merge armed (no-wait): {pr_info.html_url}",
-                level="info",
-            )
+            auto_ok = await self._enable_auto_merge_for_pr(pr_info, owner, repo)
+            if auto_ok:
+                result.status = MergeStatus.AUTO_MERGE_PENDING
+                log_and_print(
+                    self.log,
+                    self._console,
+                    f"⏳ Auto-merge armed (no-wait): {pr_info.html_url}",
+                    level="info",
+                )
+            else:
+                # Auto-merge could not be armed (e.g. the repository has
+                # the feature disabled), so nothing will merge this PR
+                # later.  Report BLOCKED rather than a misleading
+                # AUTO_MERGE_PENDING: the PR is left approved and rebased
+                # but will not merge on its own.
+                result.status = MergeStatus.BLOCKED
+                result.error = (
+                    "auto-merge unavailable (no-wait); PR approved and "
+                    "rebase requested but not merged"
+                )
+                log_and_print(
+                    self.log,
+                    self._console,
+                    f"🛑 Auto-merge unavailable (no-wait): {pr_info.html_url}",
+                    level="warning",
+                )
             return result
 
         # Dependabot: request a rebase (regenerates the lockfile +

--- a/src/dependamerge/merge_manager.py
+++ b/src/dependamerge/merge_manager.py
@@ -365,7 +365,10 @@ class AsyncMergeManager:
         Merge multiple PRs in parallel.
 
         Args:
-            pr_list: List of (PullRequestInfo, ComparisonResult) tuples
+            pr_list: List of ``(PullRequestInfo, ComparisonResult | None)``
+                tuples.  The comparison element is ``None`` for owner-wide
+                and repository-wide runs (no source PR to compare
+                against) and a ``ComparisonResult`` for similar-PR runs.
             stripe: When True, schedule the batch with the striped
                 scheduler (see :meth:`_run_striped`): PRs are grouped by
                 repository and at most one PR per repository is processed
@@ -469,32 +472,53 @@ class AsyncMergeManager:
           repository's PRs strictly sequentially, so **at most one PR per
           repository is ever in flight**.
         - Lets distinct repositories run concurrently, bounded by the
-          shared merge semaphore.  Because ``asyncio.Semaphore`` is FIFO,
-          a repository releasing its slot between PRs goes to the back of
-          the queue behind other repositories' waiting PRs, which
-          naturally round-robins ("stripes") work across repositories.
+          shared merge semaphore.  When a repository releases its slot
+          between PRs it re-acquires the semaphore for its next PR,
+          competing afresh with other repositories' waiting PRs.  In
+          practice CPython wakes semaphore waiters in roughly the order
+          they blocked, so this tends to round-robin ("stripe") work
+          across repositories — but that ordering is only a best-effort
+          optimisation, not a correctness property.  Fairness is **not**
+          part of the public ``asyncio.Semaphore`` contract and is not
+          relied upon: the single-flight-per-repository invariant above
+          comes solely from each repository's serial worker, regardless
+          of the order in which the semaphore admits waiters.
 
         Combined with ``repo_scoped`` mergeability refresh, when a
         repository's second PR finally starts it re-reads state the first
         PR's merge may have invalidated.
         """
         # Group by repository, preserving first-seen order so the stripe
-        # ordering is deterministic.
-        grouped: dict[str, list[tuple[PullRequestInfo, ComparisonResult | None]]] = {}
-        for item in pr_list:
-            grouped.setdefault(item[0].repository_full_name, []).append(item)
+        # ordering is deterministic.  Each item is carried with its index
+        # in ``pr_list`` so results reassemble in the caller's order.
+        grouped: dict[
+            str, list[tuple[int, tuple[PullRequestInfo, ComparisonResult | None]]]
+        ] = {}
+        for index, item in enumerate(pr_list):
+            grouped.setdefault(item[0].repository_full_name, []).append((index, item))
 
-        # Results are keyed by the identity of each work item so they can
-        # be reassembled in the caller's original order.
-        result_by_id: dict[int, MergeResult] = {}
+        # Results are keyed by each work item's position in ``pr_list``.
+        # Positional keys (rather than ``id(item)``) stay correct even if
+        # the caller passes duplicate tuple objects (e.g. ``[item] * n``),
+        # where ``id()`` would collide and later results would overwrite
+        # earlier ones.
+        result_by_index: dict[int, MergeResult] = {}
 
         async def _repo_worker(
-            items: list[tuple[PullRequestInfo, ComparisonResult | None]],
+            items: list[tuple[int, tuple[PullRequestInfo, ComparisonResult | None]]],
         ) -> None:
-            for item in items:
+            for index, item in items:
                 pr_info = item[0]
                 try:
                     res = await self._merge_single_pr_with_semaphore(pr_info)
+                except asyncio.CancelledError:
+                    # Cancellation must propagate so the gather below can
+                    # tear the run down.  On Python >= 3.10 CancelledError
+                    # already derives from BaseException (not Exception),
+                    # so the handler below would not catch it; this
+                    # explicit re-raise documents that intent and guards
+                    # against the broad handler ever being widened.
+                    raise
                 except Exception as e:
                     # Defensive: a crash on one PR must not lose results
                     # for the remaining PRs in the same repository.
@@ -509,7 +533,7 @@ class AsyncMergeManager:
                         pr_info.number,
                         e,
                     )
-                result_by_id[id(item)] = res
+                result_by_index[index] = res
 
         tasks = [
             asyncio.create_task(
@@ -522,7 +546,7 @@ class AsyncMergeManager:
         # Workers never raise (each PR is wrapped defensively above).
         await asyncio.gather(*tasks)
 
-        return [result_by_id[id(item)] for item in pr_list]
+        return [result_by_index[i] for i in range(len(pr_list))]
 
     def _collect_results(
         self,

--- a/src/dependamerge/merge_manager.py
+++ b/src/dependamerge/merge_manager.py
@@ -358,12 +358,23 @@ class AsyncMergeManager:
     async def merge_prs_parallel(
         self,
         pr_list: list[tuple[PullRequestInfo, ComparisonResult | None]],
+        *,
+        stripe: bool = False,
     ) -> list[MergeResult]:
         """
         Merge multiple PRs in parallel.
 
         Args:
             pr_list: List of (PullRequestInfo, ComparisonResult) tuples
+            stripe: When True, schedule the batch with the striped
+                scheduler (see :meth:`_run_striped`): PRs are grouped by
+                repository and at most one PR per repository is processed
+                at a time, while distinct repositories run concurrently.
+                Used for owner-wide runs where the flat list mixes many
+                repositories and back-to-back same-repo merges would race
+                GitHub's mergeability propagation.  When False (default)
+                the flat scheduler is used (one task per PR), suitable for
+                single-PR and single-repository batches.
 
         Returns:
             List of MergeResult objects with operation results
@@ -383,15 +394,6 @@ class AsyncMergeManager:
             owner = pr_list[0][0].repository_full_name.split("/", 1)[0]
             await self._org_approval_rulesets(owner)
 
-        # Create tasks for all PRs
-        tasks = []
-        for pr_info, _comparison in pr_list:
-            task = asyncio.create_task(
-                self._merge_single_pr_with_semaphore(pr_info),
-                name=f"merge-{pr_info.repository_full_name}#{pr_info.number}",
-            )
-            tasks.append(task)
-
         # Background ticker that surfaces a single-line countdown
         # whenever one or more workers are waiting for required
         # checks to complete (auto-merge wait loop). The countdown
@@ -403,8 +405,10 @@ class AsyncMergeManager:
         )
 
         try:
-            # Wait for all tasks to complete
-            results = await asyncio.gather(*tasks, return_exceptions=True)
+            if stripe:
+                final_results = await self._run_striped(pr_list)
+            else:
+                final_results = await self._run_flat(pr_list)
         finally:
             ticker_task.cancel()
             try:
@@ -423,7 +427,114 @@ class AsyncMergeManager:
                     exc_info=True,
                 )
 
-        # Process results and handle exceptions
+        self._results = final_results
+        return final_results
+
+    async def _run_flat(
+        self,
+        pr_list: list[tuple[PullRequestInfo, ComparisonResult | None]],
+    ) -> list[MergeResult]:
+        """Flat scheduler: one task per PR, bounded by the merge semaphore.
+
+        Suitable for single-PR and single-repository batches where there
+        is no need to avoid stacking same-repo merges (the per-repo merge
+        dispatch lock already serialises the final API call).
+        """
+        tasks = []
+        for pr_info, _comparison in pr_list:
+            task = asyncio.create_task(
+                self._merge_single_pr_with_semaphore(pr_info),
+                name=f"merge-{pr_info.repository_full_name}#{pr_info.number}",
+            )
+            tasks.append(task)
+
+        results = await asyncio.gather(*tasks, return_exceptions=True)
+        return self._collect_results(pr_list, results)
+
+    async def _run_striped(
+        self,
+        pr_list: list[tuple[PullRequestInfo, ComparisonResult | None]],
+    ) -> list[MergeResult]:
+        """Striped scheduler: one serial worker per repository.
+
+        Owner-wide batches frequently contain several PRs targeting the
+        same repository (e.g. dependabot and pre-commit-ci both opening
+        PRs in one repo).  Merging two PRs in the same repository
+        back-to-back races GitHub's branch-protection / mergeability
+        propagation.  To avoid that structurally (no injected delays, no
+        random retries) this scheduler:
+
+        - Groups PRs by repository, preserving first-seen order.
+        - Runs one worker coroutine per repository that processes that
+          repository's PRs strictly sequentially, so **at most one PR per
+          repository is ever in flight**.
+        - Lets distinct repositories run concurrently, bounded by the
+          shared merge semaphore.  Because ``asyncio.Semaphore`` is FIFO,
+          a repository releasing its slot between PRs goes to the back of
+          the queue behind other repositories' waiting PRs, which
+          naturally round-robins ("stripes") work across repositories.
+
+        Combined with ``repo_scoped`` mergeability refresh, when a
+        repository's second PR finally starts it re-reads state the first
+        PR's merge may have invalidated.
+        """
+        # Group by repository, preserving first-seen order so the stripe
+        # ordering is deterministic.
+        grouped: dict[str, list[tuple[PullRequestInfo, ComparisonResult | None]]] = {}
+        for item in pr_list:
+            grouped.setdefault(item[0].repository_full_name, []).append(item)
+
+        # Results are keyed by the identity of each work item so they can
+        # be reassembled in the caller's original order.
+        result_by_id: dict[int, MergeResult] = {}
+
+        async def _repo_worker(
+            items: list[tuple[PullRequestInfo, ComparisonResult | None]],
+        ) -> None:
+            for item in items:
+                pr_info = item[0]
+                try:
+                    res = await self._merge_single_pr_with_semaphore(pr_info)
+                except Exception as e:
+                    # Defensive: a crash on one PR must not lose results
+                    # for the remaining PRs in the same repository.
+                    res = MergeResult(
+                        pr_info=pr_info,
+                        status=MergeStatus.FAILED,
+                        error=str(e),
+                    )
+                    self.log.error(
+                        "Unexpected error merging PR %s#%s: %s",
+                        pr_info.repository_full_name,
+                        pr_info.number,
+                        e,
+                    )
+                result_by_id[id(item)] = res
+
+        tasks = [
+            asyncio.create_task(
+                _repo_worker(items),
+                name=f"merge-repo-{repo}",
+            )
+            for repo, items in grouped.items()
+        ]
+
+        # Workers never raise (each PR is wrapped defensively above).
+        await asyncio.gather(*tasks)
+
+        return [result_by_id[id(item)] for item in pr_list]
+
+    def _collect_results(
+        self,
+        pr_list: list[tuple[PullRequestInfo, ComparisonResult | None]],
+        results: list[Any],
+    ) -> list[MergeResult]:
+        """Map gathered task outcomes back to ``MergeResult`` objects.
+
+        Converts any propagated exception (from a per-PR task run with
+        ``return_exceptions=True``) into a FAILED result for the matching
+        PR, preserving the input ordering.
+        """
         final_results: list[MergeResult] = []
         for i, result in enumerate(results):
             if isinstance(result, Exception):
@@ -438,8 +549,6 @@ class AsyncMergeManager:
             else:
                 # result is guaranteed to be MergeResult here since it's not an Exception
                 final_results.append(cast(MergeResult, result))
-
-        self._results = final_results
         return final_results
 
     async def _merge_single_pr_with_semaphore(
@@ -1065,80 +1174,7 @@ class AsyncMergeManager:
                 )
 
             if not self._is_pr_mergeable(pr_info):
-                # Get detailed status for a more informative skip message
-                # Use async method to avoid event loop conflicts
-                repo_owner, repo_name = pr_info.repository_full_name.split("/")
-
-                # Check if blocked to get more detailed status
-                if pr_info.mergeable_state == "blocked" and self._github_client:
-                    try:
-                        detailed_status = (
-                            await self._github_client.analyze_block_reason(
-                                repo_owner, repo_name, pr_info.number, pr_info.head_sha
-                            )
-                        )
-                    except Exception:
-                        detailed_status = f"Blocked (state: {pr_info.mergeable_state})"
-                else:
-                    # For non-blocked states, provide basic status
-                    if pr_info.mergeable_state == "dirty":
-                        detailed_status = "Merge conflicts"
-                    elif pr_info.mergeable_state == "behind":
-                        detailed_status = "Rebase required (out of date)"
-                    elif pr_info.mergeable_state == "draft":
-                        detailed_status = "Draft PR"
-                    else:
-                        detailed_status = (
-                            f"Not mergeable (state: {pr_info.mergeable_state})"
-                        )
-
-                # Use the detailed status as the skip reason, with fallback
-                if detailed_status and detailed_status != "Status unclear":
-                    skip_reason = detailed_status.lower()
-                else:
-                    # Fallback to basic mapping if detailed status is unclear
-                    if pr_info.mergeable_state == "dirty":
-                        skip_reason = "merge conflicts"
-                    elif pr_info.mergeable_state == "behind":
-                        skip_reason = "behind"
-                    elif pr_info.mergeable_state == "blocked":
-                        if pr_info.mergeable is True:
-                            skip_reason = "blocked, requires review"
-                        else:
-                            skip_reason = "blocked by failing checks"
-                    elif pr_info.mergeable_state == "unstable":
-                        skip_reason = "unstable"
-                    elif pr_info.mergeable is False:
-                        skip_reason = "not mergeable"
-                    else:
-                        skip_reason = "unknown"
-
-                # Determine if this is truly blocked (unmergeable) or just skipped
-                if pr_info.mergeable_state == "dirty" or (
-                    pr_info.mergeable_state == "behind" and pr_info.mergeable is False
-                ):
-                    result.status = MergeStatus.BLOCKED
-                    icon = "🛑"
-                    status = "Blocked"
-                else:
-                    result.status = MergeStatus.SKIPPED
-                    icon = "⏭️"
-                    status = "Skipped"
-
-                log_and_print(
-                    self.log,
-                    self._console,
-                    f"{icon} {status}: {pr_info.html_url} [{skip_reason}]",
-                    level="info",
-                )
-
-                result.error = f"PR is not mergeable (state: {pr_info.mergeable_state}, mergeable: {pr_info.mergeable})"
-
-                # For the result error (used in CLI output), use the detailed status if it's more informative
-                if detailed_status and detailed_status != "Status unclear":
-                    result.error = detailed_status
-
-                return result
+                return await self._handle_not_mergeable_pr(pr_info, result)
 
             # Check for blocking reviews (changes requested)
             if self._has_blocking_reviews(pr_info):
@@ -1346,6 +1382,7 @@ class AsyncMergeManager:
                 and pr_info.mergeable_state == "blocked"
                 and self._github_client is not None
             ):
+                pre_block_reason: str | None = None
                 try:
                     pre_block_reason = await self._github_client.analyze_block_reason(
                         repo_owner,
@@ -1442,57 +1479,7 @@ class AsyncMergeManager:
             # Step 6: Attempt merge
             result.status = MergeStatus.MERGING
             if self.preview_mode:
-                # IMPORTANT: Preview output must be SINGLE LINE per PR for clean evaluation display
-                # Each PR should have exactly one line of output under "🔍 Dependamerge Evaluation"
-
-                # In preview mode, simulate what would happen based on current PR state
-                if pr_info.mergeable_state == "behind" and not self.fix_out_of_date:
-                    result.status = MergeStatus.SKIPPED
-                    result.error = "PR is behind base branch and --no-fix option is set"
-                    self._console.print(
-                        f"⏭️ Skipped: {pr_info.html_url} [behind, rebase disabled]",
-                        markup=False,
-                    )
-                elif pr_info.mergeable_state == "behind" and self.fix_out_of_date:
-                    # For behind PRs with fix enabled, show warning with rebase info
-                    result.status = MergeStatus.MERGED  # Would succeed after rebase
-                    # Use ``warning`` (not ``error``) so the MERGED result
-                    # does not carry a contradictory error message.
-                    result.warning = "behind base branch"
-                    if self.progress_tracker:
-                        self.progress_tracker.merge_success()
-                    self._console.print(
-                        f"⚠️ Rebase/merge: {pr_info.html_url} [behind base branch]",
-                        markup=False,
-                    )
-                elif pr_info.mergeable_state == "dirty":
-                    result.status = MergeStatus.BLOCKED
-                    result.error = "PR has merge conflicts"
-                    self._console.print(
-                        f"🛑 Blocked: {pr_info.html_url} [merge conflicts]",
-                        markup=False,
-                    )
-                elif (
-                    pr_info.mergeable is False and pr_info.mergeable_state == "blocked"
-                ):
-                    result.status = MergeStatus.BLOCKED
-                    result.error = "PR blocked by failing checks"
-                    self._console.print(
-                        f"🛑 Blocked: {pr_info.html_url} [blocked by failing checks]",
-                        markup=False,
-                    )
-                else:
-                    # Simulate successful merge in preview mode
-                    result.status = MergeStatus.MERGED
-                    if self.progress_tracker:
-                        self.progress_tracker.merge_success()
-                    # Single line summary for successful preview
-                    log_and_print(
-                        self.log,
-                        self._console,
-                        f"☑️ Approve/merge: {pr_info.html_url}",
-                        level="debug",
-                    )
+                self._simulate_preview_merge(pr_info, result)
             else:
                 if self.progress_tracker:
                     self.progress_tracker.update_operation(
@@ -1959,6 +1946,141 @@ class AsyncMergeManager:
             self._recently_approved.discard(pr_key)
 
         return result
+
+    async def _handle_not_mergeable_pr(
+        self, pr_info: PullRequestInfo, result: MergeResult
+    ) -> MergeResult:
+        """Classify and report a PR that failed the mergeability gate.
+
+        Extracted from ``_merge_single_pr`` to keep that method's
+        branch count manageable. Produces a detailed skip/block
+        reason, sets ``result`` accordingly, and returns it.
+        """
+        # Get detailed status for a more informative skip message
+        # Use async method to avoid event loop conflicts
+        repo_owner, repo_name = pr_info.repository_full_name.split("/")
+
+        # Check if blocked to get more detailed status
+        if pr_info.mergeable_state == "blocked" and self._github_client:
+            try:
+                detailed_status = await self._github_client.analyze_block_reason(
+                    repo_owner, repo_name, pr_info.number, pr_info.head_sha
+                )
+            except Exception:
+                detailed_status = f"Blocked (state: {pr_info.mergeable_state})"
+        else:
+            # For non-blocked states, provide basic status
+            if pr_info.mergeable_state == "dirty":
+                detailed_status = "Merge conflicts"
+            elif pr_info.mergeable_state == "behind":
+                detailed_status = "Rebase required (out of date)"
+            elif pr_info.mergeable_state == "draft":
+                detailed_status = "Draft PR"
+            else:
+                detailed_status = f"Not mergeable (state: {pr_info.mergeable_state})"
+
+        # Use the detailed status as the skip reason, with fallback
+        if detailed_status and detailed_status != "Status unclear":
+            skip_reason = detailed_status.lower()
+        else:
+            # Fallback to basic mapping if detailed status is unclear
+            if pr_info.mergeable_state == "dirty":
+                skip_reason = "merge conflicts"
+            elif pr_info.mergeable_state == "behind":
+                skip_reason = "behind"
+            elif pr_info.mergeable_state == "blocked":
+                if pr_info.mergeable is True:
+                    skip_reason = "blocked, requires review"
+                else:
+                    skip_reason = "blocked by failing checks"
+            elif pr_info.mergeable_state == "unstable":
+                skip_reason = "unstable"
+            elif pr_info.mergeable is False:
+                skip_reason = "not mergeable"
+            else:
+                skip_reason = "unknown"
+
+        # Determine if this is truly blocked (unmergeable) or just skipped
+        if pr_info.mergeable_state == "dirty" or (
+            pr_info.mergeable_state == "behind" and pr_info.mergeable is False
+        ):
+            result.status = MergeStatus.BLOCKED
+            icon = "🛑"
+            status = "Blocked"
+        else:
+            result.status = MergeStatus.SKIPPED
+            icon = "⏭️"
+            status = "Skipped"
+
+        log_and_print(
+            self.log,
+            self._console,
+            f"{icon} {status}: {pr_info.html_url} [{skip_reason}]",
+            level="info",
+        )
+
+        result.error = f"PR is not mergeable (state: {pr_info.mergeable_state}, mergeable: {pr_info.mergeable})"
+
+        # For the result error (used in CLI output), use the detailed status if it's more informative
+        if detailed_status and detailed_status != "Status unclear":
+            result.error = detailed_status
+
+        return result
+
+    def _simulate_preview_merge(
+        self, pr_info: PullRequestInfo, result: MergeResult
+    ) -> None:
+        """Simulate the Step 6 merge outcome for preview mode.
+
+        Preview output must be SINGLE LINE per PR for clean evaluation
+        display: each PR should produce exactly one line under the
+        "🔍 Dependamerge Evaluation" heading. Mutates ``result`` in place.
+        """
+        if pr_info.mergeable_state == "behind" and not self.fix_out_of_date:
+            result.status = MergeStatus.SKIPPED
+            result.error = "PR is behind base branch and --no-fix option is set"
+            self._console.print(
+                f"⏭️ Skipped: {pr_info.html_url} [behind, rebase disabled]",
+                markup=False,
+            )
+        elif pr_info.mergeable_state == "behind" and self.fix_out_of_date:
+            # For behind PRs with fix enabled, show warning with rebase info
+            result.status = MergeStatus.MERGED  # Would succeed after rebase
+            # Use ``warning`` (not ``error``) so the MERGED result
+            # does not carry a contradictory error message.
+            result.warning = "behind base branch"
+            if self.progress_tracker:
+                self.progress_tracker.merge_success()
+            self._console.print(
+                f"⚠️ Rebase/merge: {pr_info.html_url} [behind base branch]",
+                markup=False,
+            )
+        elif pr_info.mergeable_state == "dirty":
+            result.status = MergeStatus.BLOCKED
+            result.error = "PR has merge conflicts"
+            self._console.print(
+                f"🛑 Blocked: {pr_info.html_url} [merge conflicts]",
+                markup=False,
+            )
+        elif pr_info.mergeable is False and pr_info.mergeable_state == "blocked":
+            result.status = MergeStatus.BLOCKED
+            result.error = "PR blocked by failing checks"
+            self._console.print(
+                f"🛑 Blocked: {pr_info.html_url} [blocked by failing checks]",
+                markup=False,
+            )
+        else:
+            # Simulate successful merge in preview mode
+            result.status = MergeStatus.MERGED
+            if self.progress_tracker:
+                self.progress_tracker.merge_success()
+            # Single line summary for successful preview
+            log_and_print(
+                self.log,
+                self._console,
+                f"☑️ Approve/merge: {pr_info.html_url}",
+                level="debug",
+            )
 
     @staticmethod
     def _block_reason_indicates_pending_checks(

--- a/src/dependamerge/merge_manager.py
+++ b/src/dependamerge/merge_manager.py
@@ -19,6 +19,7 @@ from urllib.parse import quote
 from rich.console import Console
 
 from . import rebase
+from .bot_identity import is_dependabot
 from .copilot_handler import CopilotCommentHandler
 from .gerrit import (
     GerritAuthError,
@@ -139,6 +140,7 @@ class AsyncMergeManager:
         netrc_file: Path | None = None,
         rebase_local: bool = True,
         repo_scoped: bool = False,
+        max_wait: float | None = None,
     ):
         self.token = token
         self.default_merge_method = merge_method
@@ -162,15 +164,33 @@ class AsyncMergeManager:
         # the legacy REST-only path (simpler but loses signature
         # verification on signed branches).
         self.rebase_local = rebase_local
-        # When True, the batch targets a single repository, so a merge
-        # by one worker can make a sibling PR ``dirty`` / ``behind``
-        # between the up-front fetch and this worker's dispatch.  In
-        # that mode we refresh each PR's live merge state immediately
-        # before dispatching the merge (see
-        # ``_refresh_pr_mergeability``).  Left False for org-wide runs,
-        # where PRs target different repositories and the snapshot is
-        # not invalidated by our own merges.
+        # When True, a worker refreshes its PR's live merge state just
+        # before dispatching, because a sibling merge can make a PR
+        # ``dirty`` / ``behind`` between the up-front fetch and this
+        # worker's dispatch (see ``_refresh_pr_mergeability``).  Enabled
+        # both for single-repository batches and for owner-wide striped
+        # runs, where each repository's PRs are serialised so an earlier
+        # merge can invalidate a later sibling.  Left False only for
+        # similar-PR runs spread across unrelated repositories, where our
+        # own merges do not invalidate the snapshot.
         self._repo_scoped = repo_scoped
+        # Owner-wide global wait ceiling (seconds), or ``None`` for
+        # repository / similar-PR runs which keep the legacy per-PR
+        # ``merge_timeout`` behaviour with no overall cap.  Semantics:
+        #   * ``None``  — no global ceiling (per-PR ``merge_timeout``
+        #                 governs each wait independently).
+        #   * ``> 0``   — a wall-clock ceiling for the whole run; every
+        #                 per-PR wait deadline is clamped to it, so the
+        #                 run cannot block past this bound.  Anything
+        #                 still in flight when it elapses keeps auto-merge
+        #                 armed and is reported AUTO_MERGE_PENDING.
+        #   * ``0``     — fire-and-forget: never block.  Approve, arm
+        #                 auto-merge, report AUTO_MERGE_PENDING, move on.
+        # ``_run_deadline`` (the resolved monotonic ceiling) and
+        # ``_no_wait`` (the ``0`` case) are set when a run starts.
+        self._max_wait = max_wait
+        self._run_deadline: float | None = None
+        self._no_wait: bool = max_wait is not None and max_wait <= 0
         self.log = logging.getLogger(__name__)
 
         # Centralised merge-operation timing
@@ -384,6 +404,18 @@ class AsyncMergeManager:
         """
         if not pr_list:
             return []
+
+        # Resolve the owner-wide global wait ceiling for this run.  A
+        # positive ``max_wait`` becomes a monotonic wall-clock deadline
+        # that every per-PR wait is clamped to (see
+        # ``_wait_for_auto_merge``); ``0`` (``_no_wait``) skips waiting
+        # entirely; ``None`` leaves each per-PR ``merge_timeout``
+        # uncapped (repository / similar-PR runs).  Reset first so a
+        # reused manager instance never carries a stale deadline from a
+        # previous run into this one.
+        self._run_deadline = None
+        if self._max_wait is not None and self._max_wait > 0:
+            self._run_deadline = asyncio.get_running_loop().time() + self._max_wait
 
         if self.preview_mode:
             self.log.info(f"🔍 PREVIEW: Would merge {len(pr_list)} PRs")
@@ -1764,7 +1796,7 @@ class AsyncMergeManager:
                     #      recovery via ``_trigger_stale_precommit_ci``
                     #      (which posts ``pre-commit.ci run``).
                     recreated_pr = None
-                    if pr_info.author == "dependabot[bot]" and not self.preview_mode:
+                    if is_dependabot(pr_info.author) and not self.preview_mode:
                         reason_lower = failure_reason.lower()
                         # Branch protection *and* repository rulesets can
                         # both block a dependabot PR for reasons recreation
@@ -3340,7 +3372,7 @@ class AsyncMergeManager:
         repo_owner, repo_name = pr_info.repository_full_name.split("/", 1)
 
         # 1. Only applies to dependabot PRs
-        if pr_info.author != "dependabot[bot]":
+        if not is_dependabot(pr_info.author):
             return None
 
         # 2. Check whether the branch requires signed commits
@@ -3487,7 +3519,7 @@ class AsyncMergeManager:
                             if not isinstance(pr_data, dict):
                                 continue
                             pr_author = pr_data.get("user", {}).get("login", "")
-                            if pr_author != "dependabot[bot]":
+                            if not is_dependabot(pr_author):
                                 continue
 
                             new_number = pr_data.get("number")
@@ -4344,12 +4376,24 @@ class AsyncMergeManager:
         if self._github_client is None:
             return False, False
 
+        # Fire-and-forget (``max_wait == 0``): never block.  Returning
+        # "not closed" lets callers fall through to the auto-merge-pending
+        # path (Step 6 / the conflict handler arms auto-merge and reports
+        # AUTO_MERGE_PENDING).  Auto-merge is armed by the caller before
+        # this point, so GitHub still completes the merge later.
+        if self._no_wait:
+            return False, False
+
         pr_key = f"{owner}/{repo}#{pr_info.number}"
         loop = asyncio.get_running_loop()
         # Drive the wait off a monotonic deadline so the total is
         # bounded even if a single iteration over-sleeps slightly.
         if deadline is None:
             deadline = loop.time() + self._merge_timeout
+        # Clamp to the owner-wide global ceiling (when set) so no single
+        # PR's wait can push the whole run past ``max_wait``.
+        if self._run_deadline is not None:
+            deadline = min(deadline, self._run_deadline)
         # Local alias so the type checker can narrow
         # ``self._github_client`` across the await boundary.
         wait_client = self._github_client
@@ -4535,6 +4579,19 @@ class AsyncMergeManager:
             self._console.print(f"🛑 Closed without merging: {pr_info.html_url}")
         return result
 
+    def _dependabot_is_rebasing(self, body: str | None) -> bool:
+        """Return True when a PR body shows dependabot mid-self-rebase.
+
+        Dependabot writes a notice into the PR body while it rebases the
+        branch on its own (after the base moved).  Detecting it lets the
+        conflict handler wait for the in-progress rebase instead of
+        sending a redundant ``@dependabot rebase`` macro.
+        """
+        if not body:
+            return False
+        lowered = body.lower()
+        return "dependabot is rebasing" in lowered or "is rebasing this pr" in lowered
+
     async def _handle_merge_conflict(
         self,
         pr_info: PullRequestInfo,
@@ -4561,7 +4618,7 @@ class AsyncMergeManager:
         # conflicted lockfile, and a blind force-push would only break
         # the approval chain (this org forbids self-merge of pushed
         # commits).  Report the conflict and fail fast.
-        if pr_info.author != "dependabot[bot]":
+        if not is_dependabot(pr_info.author):
             log_and_print(
                 self.log,
                 self._console,
@@ -4574,26 +4631,71 @@ class AsyncMergeManager:
                 self.progress_tracker.merge_failure()
             return result
 
-        # Dependabot: request a rebase (regenerates the lockfile +
-        # signs the commit).
-        log_and_print(
-            self.log,
-            self._console,
-            f"🔄 Requesting dependabot rebase: {pr_info.html_url}",
-            level="info",
-        )
-        if not await self._request_dependabot_rebase(pr_info, owner, repo):
+        # Detect whether dependabot is already self-rebasing this PR.
+        # When its base branch moves (e.g. a sibling PR merged), it
+        # rebases the branch on its own and writes a marker into the PR
+        # body while it does.  In that window we must not send a
+        # duplicate ``@dependabot rebase`` macro: the in-progress rebase
+        # will clear the conflict, so we wait for it rather than poke it.
+        already_rebasing = self._dependabot_is_rebasing(pr_info.body)
+
+        # Fire-and-forget (``max_wait == 0``): ask dependabot to rebase
+        # (unless it already is), arm auto-merge, and report pending
+        # without blocking this repository's serial worker.  Approval is
+        # best-effort here — a subsequent dependabot force-push dismisses
+        # it when the branch enables "dismiss stale reviews", which is the
+        # documented trade-off of not waiting to approve the rebased head.
+        if self._no_wait:
+            if not already_rebasing:
+                await self._request_dependabot_rebase(pr_info, owner, repo)
+            try:
+                await self._approve_pr(owner, repo, pr_info.number)
+            except Exception as exc:
+                self.log.debug(
+                    "no-wait approve failed for %s/%s#%s: %s",
+                    owner,
+                    repo,
+                    pr_info.number,
+                    exc,
+                )
+            await self._enable_auto_merge_for_pr(pr_info, owner, repo)
+            result.status = MergeStatus.AUTO_MERGE_PENDING
             log_and_print(
                 self.log,
                 self._console,
-                f"🔀 Merge conflict: {pr_info.html_url}",
+                f"⏳ Auto-merge armed (no-wait): {pr_info.html_url}",
                 level="info",
             )
-            result.status = MergeStatus.FAILED
-            result.error = "merge conflicts"
-            if self.progress_tracker:
-                self.progress_tracker.merge_failure()
             return result
+
+        # Dependabot: request a rebase (regenerates the lockfile +
+        # signs the commit) unless it is already rebasing on its own.
+        if already_rebasing:
+            log_and_print(
+                self.log,
+                self._console,
+                f"🔄 Dependabot already rebasing: {pr_info.html_url}",
+                level="info",
+            )
+        else:
+            log_and_print(
+                self.log,
+                self._console,
+                f"🔄 Requesting dependabot rebase: {pr_info.html_url}",
+                level="info",
+            )
+            if not await self._request_dependabot_rebase(pr_info, owner, repo):
+                log_and_print(
+                    self.log,
+                    self._console,
+                    f"🔀 Merge conflict: {pr_info.html_url}",
+                    level="info",
+                )
+                result.status = MergeStatus.FAILED
+                result.error = "merge conflicts"
+                if self.progress_tracker:
+                    self.progress_tracker.merge_failure()
+                return result
 
         # Share a single ``merge_timeout`` budget across both wait
         # phases (waiting for the rebase, then for checks).
@@ -4751,7 +4853,7 @@ class AsyncMergeManager:
         Sets ``result`` to ``FAILED`` and returns it.
         """
         stuck_reported = False
-        if pr_info.author != "dependabot[bot]" and not self.preview_mode:
+        if not is_dependabot(pr_info.author) and not self.preview_mode:
             try:
                 detection = await self._detect_stuck_required_check(pr_info)
             except Exception as exc:

--- a/src/dependamerge/pr_comparator.py
+++ b/src/dependamerge/pr_comparator.py
@@ -4,6 +4,7 @@
 import re
 from difflib import SequenceMatcher
 
+from .bot_identity import normalize_bot_login
 from .models import ComparisonResult, FileChange, PullRequestInfo
 
 
@@ -304,18 +305,12 @@ class PRComparator:
     def _normalize_author(self, author: str | None) -> str:
         """Normalize author name to handle differences between REST and GraphQL APIs.
 
-        GitHub's REST API returns 'dependabot[bot]' while GraphQL returns 'dependabot'.
-        This method normalizes both to the same format for comparison.
+        GitHub's REST API returns 'dependabot[bot]' while GraphQL returns
+        'dependabot'.  Delegates to the shared
+        :func:`bot_identity.normalize_bot_login` so author comparison uses
+        the same canonical form as the rest of the codebase.
         """
-        if not author:
-            return ""
-
-        # Remove [bot] suffix if present to normalize bot names
-        normalized = author.lower()
-        if normalized.endswith("[bot]"):
-            normalized = normalized[:-5]  # Remove "[bot]"
-
-        return normalized
+        return normalize_bot_login(author)
 
     def _is_precommit_body(self, body: str | None) -> bool:
         """Check if body contains pre-commit specific patterns."""

--- a/src/dependamerge/resolve_conflicts.py
+++ b/src/dependamerge/resolve_conflicts.py
@@ -314,10 +314,15 @@ class FixOrchestrator:
                     # Attempt to abort any in-progress rebase and record failure
                     try:
                         rebase_abort(cwd=workspace)
-                    except Exception:
+                    except Exception as abort_err:
                         # Cleanup abort is best-effort; the failure is
-                        # already recorded below regardless.
-                        pass
+                        # already recorded below regardless.  Surface it
+                        # through the orchestrator logger so an unexpected
+                        # cleanup failure remains discoverable.
+                        self._log(
+                            f"{ctx.base_repo_full_name}#{ctx.pr_number}: "
+                            f"rebase --abort cleanup failed: {abort_err}"
+                        )
                     results.append(
                         FixResult(
                             selection=sel,
@@ -619,10 +624,22 @@ class InteractiveResolver:
             )
             return
 
-        # If the editor is VS Code ('code'), ensure we wait for window close (-w)
-        # Heuristic: if command contains 'code', add '-w' if not present
+        # If the editor is VS Code, ensure we wait for the window to close
+        # (-w) so the rebase does not continue before the user has saved
+        # their conflict resolutions.
+        #
+        # Match on the launcher's program name (basename without a Windows
+        # extension) against the known VS Code commands rather than a naive
+        # substring test: a plain ``"code" in cmd_parts[0]`` would also fire
+        # on unrelated binaries such as ``encode``, ``xcode`` or ``mycode``,
+        # while still missing path-qualified launchers like ``/usr/bin/code``.
         cmd_parts = shlex.split(editor_cmd)
-        if cmd_parts and "code" in cmd_parts[0] and "-w" not in cmd_parts:
+        prog = (
+            Path(cmd_parts[0]).name.lower().removesuffix(".cmd").removesuffix(".exe")
+            if cmd_parts
+            else ""
+        )
+        if prog in ("code", "code-insiders") and "-w" not in cmd_parts:
             cmd_parts.append("-w")
 
         if paths:

--- a/src/dependamerge/url_parser.py
+++ b/src/dependamerge/url_parser.py
@@ -581,8 +581,15 @@ def derive_api_urls(host: str) -> tuple[str, str]:
 
     Returns:
         A ``(api_url, graphql_url)`` tuple.
+
+    Raises:
+        ValueError: If ``host`` is empty or whitespace-only, which would
+            otherwise yield a subtly broken base URL such as
+            ``https:///api/v3``.
     """
-    host = (host or "").lower()
+    host = (host or "").strip().lower()
+    if not host:
+        raise ValueError("derive_api_urls requires a non-empty host")
     if _host_matches(host, "github.com"):
         return ("https://api.github.com", "https://api.github.com/graphql")
     # GitHub Enterprise Server base URLs.

--- a/src/dependamerge/url_parser.py
+++ b/src/dependamerge/url_parser.py
@@ -72,6 +72,34 @@ class ParsedUrl:
 
 
 @dataclass(frozen=True)
+class ParsedOrgUrl:
+    """
+    Parsed organization/owner URL (not a specific repo or PR).
+
+    Represents an owner-wide scope, e.g. ``https://github.com/owner``.
+    The owner may be either a GitHub organization or a personal user
+    account; the two are indistinguishable from the URL alone and are
+    disambiguated at runtime when enumerating repositories.
+
+    Attributes:
+        source: The code review platform (GitHub only for now).
+        host: The hostname of the server.
+        owner: The organization or user login.
+        original_url: The original URL that was parsed.
+    """
+
+    source: ChangeSource
+    host: str
+    owner: str
+    original_url: str
+
+    @property
+    def is_github(self) -> bool:
+        """Check if this URL is from GitHub."""
+        return self.source == ChangeSource.GITHUB
+
+
+@dataclass(frozen=True)
 class ParsedRepoUrl:
     """
     Parsed repository URL (not a specific PR/change).
@@ -438,13 +466,139 @@ def parse_repo_url(url: str) -> ParsedRepoUrl:
     )
 
 
+def parse_org_url(url: str) -> ParsedOrgUrl:
+    """
+    Parse a GitHub organization/owner URL (not a specific repo or PR).
+
+    Supports the following owner-wide forms (trailing slashes are
+    cosmetic and ignored):
+        https://github.com/owner
+        https://github.com/owner/
+        https://github.com/orgs/owner
+        https://github.com/orgs/owner/repositories
+
+    The owner may be an organization or a personal user account; the two
+    are indistinguishable here and are disambiguated at runtime when the
+    repositories are enumerated.
+
+    Args:
+        url: The URL to parse.
+
+    Returns:
+        A ParsedOrgUrl instance with the extracted owner.
+
+    Raises:
+        UrlParseError: If the URL is not recognised as an owner-wide URL.
+    """
+    url = url.strip()
+    if not url:
+        raise UrlParseError("URL cannot be empty")
+
+    # Ensure URL has a scheme
+    if not url.startswith(("http://", "https://")):
+        url = "https://" + url
+
+    try:
+        parsed = urlparse(url)
+    except Exception as exc:
+        raise UrlParseError(f"Invalid URL format: {exc}") from exc
+
+    if not parsed.hostname:
+        raise UrlParseError("URL must include a hostname")
+
+    host = parsed.hostname.lower()
+    path = parsed.path.rstrip("/")
+
+    # SECURITY: Only github.com and actual subdomains of github.com are
+    # accepted.  GitHub Enterprise Server (GHE) uses arbitrary hostnames
+    # that cannot be reliably distinguished from non-GitHub hosts without
+    # explicit configuration.  This github.com-only guard is the single
+    # choke point to relax when GHE owner-wide support is enabled (see
+    # derive_api_urls() and the GHE tracking issue) — do NOT scatter
+    # additional host checks elsewhere.
+    if not _host_matches(host, "github.com"):
+        raise UrlParseError(
+            f"Owner-wide URL parsing is only supported for github.com "
+            f"hosts (got host: {host}). GitHub Enterprise support is not "
+            f"yet enabled — use a direct PR URL for non-github.com hosts."
+        )
+
+    parts = [p for p in path.split("/") if p]
+
+    # Normalise the canonical GitHub org forms:
+    #   /orgs/owner               -> owner
+    #   /orgs/owner/repositories  -> owner
+    if parts and parts[0] == "orgs":
+        rest = parts[1:]
+        if rest and rest[-1] == "repositories":
+            rest = rest[:-1]
+        if len(rest) != 1:
+            raise UrlParseError(
+                f"Invalid GitHub organization URL format. Expected: "
+                f"https://{host}/orgs/owner"
+            )
+        owner = rest[0]
+        return ParsedOrgUrl(
+            source=ChangeSource.GITHUB,
+            host=host,
+            owner=owner,
+            original_url=url,
+        )
+
+    # Bare owner form: exactly one path segment.
+    if len(parts) != 1:
+        raise UrlParseError(
+            f"Invalid GitHub owner URL format. Expected: "
+            f"https://{host}/owner (an organization or user login)"
+        )
+
+    owner = parts[0]
+    return ParsedOrgUrl(
+        source=ChangeSource.GITHUB,
+        host=host,
+        owner=owner,
+        original_url=url,
+    )
+
+
+def derive_api_urls(host: str) -> tuple[str, str]:
+    """Derive the (REST, GraphQL) API base URLs for a GitHub host.
+
+    This is the single place that encodes the dotcom-vs-GHE base-URL
+    rule.  github.com (and its subdomains) use the dedicated
+    ``api.github.com`` host, while GitHub Enterprise Server installs
+    serve the API from ``https://HOST/api/v3`` (REST) and
+    ``https://HOST/api/graphql`` (GraphQL).
+
+    GHE is not yet wired through the service/client constructors (the
+    URL parsers still reject non-github.com hosts), but centralising
+    the derivation here means enabling GHE later is a matter of relaxing
+    that single guard and threading the returned URLs through — see the
+    GHE tracking issue.
+
+    Args:
+        host: The hostname (e.g. ``github.com`` or ``ghe.example.com``).
+
+    Returns:
+        A ``(api_url, graphql_url)`` tuple.
+    """
+    host = (host or "").lower()
+    if _host_matches(host, "github.com"):
+        return ("https://api.github.com", "https://api.github.com/graphql")
+    # GitHub Enterprise Server base URLs.
+    return (f"https://{host}/api/v3", f"https://{host}/api/graphql")
+
+
 __all__ = [
     "ChangeSource",
+    "ParsedOrgUrl",
     "ParsedRepoUrl",
     "ParsedUrl",
     "UrlParseError",
     "_host_matches",
+    "derive_api_urls",
     "detect_source",
     "parse_change_url",
+    "parse_org_url",
     "parse_repo_url",
 ]

--- a/tests/test_base_branch_resolution.py
+++ b/tests/test_base_branch_resolution.py
@@ -59,18 +59,21 @@ class TestResolveDefaultBranch:
         async with GitHubAsync(token="t") as api:
             api.get = AsyncMock(return_value={"default_branch": "master"})  # type: ignore[method-assign]
             assert await api._resolve_default_branch("owner", "repo") == "master"
+            api.get.assert_awaited_once_with("/repos/owner/repo")
 
     @pytest.mark.asyncio
     async def test_returns_none_when_field_absent(self) -> None:
         async with GitHubAsync(token="t") as api:
             api.get = AsyncMock(return_value={})  # type: ignore[method-assign]
             assert await api._resolve_default_branch("owner", "repo") is None
+            api.get.assert_awaited_once_with("/repos/owner/repo")
 
     @pytest.mark.asyncio
     async def test_returns_none_on_error(self) -> None:
         async with GitHubAsync(token="t") as api:
             api.get = AsyncMock(side_effect=RuntimeError("403 Forbidden"))  # type: ignore[method-assign]
             assert await api._resolve_default_branch("owner", "repo") is None
+            api.get.assert_awaited_once_with("/repos/owner/repo")
 
 
 class TestAnalyzeBlockReasonBaseBranch:
@@ -78,7 +81,12 @@ class TestAnalyzeBlockReasonBaseBranch:
     async def test_uses_pr_base_ref_not_assumed_main(self) -> None:
         """The PR's own base ref (e.g. master) drives guard detection."""
         async with GitHubAsync(token="t") as api:
-            api.get = _block_reason_router(pr_data={"base": {"ref": "master"}})  # type: ignore[method-assign]
+            # Wrap the router in an AsyncMock so the call list can be
+            # inspected: a readable PR base ref must satisfy resolution
+            # without falling back to a repository-metadata lookup.
+            api.get = AsyncMock(  # type: ignore[method-assign]
+                side_effect=_block_reason_router(pr_data={"base": {"ref": "master"}})
+            )
             api.get_required_status_checks = AsyncMock(return_value=[])  # type: ignore[method-assign]
 
             with patch.object(
@@ -94,6 +102,14 @@ class TestAnalyzeBlockReasonBaseBranch:
             api.get_required_status_checks.assert_awaited_once_with(
                 "owner", "repo", "master"
             )
+            # The base ref came straight from the PR, so the repository
+            # default-branch fallback must not have been triggered.
+            repo_meta_calls = [
+                call
+                for call in api.get.await_args_list
+                if call.args == ("/repos/owner/repo",)
+            ]
+            assert not repo_meta_calls
 
     @pytest.mark.asyncio
     async def test_falls_back_to_repo_default_branch(self) -> None:

--- a/tests/test_bot_identity.py
+++ b/tests/test_bot_identity.py
@@ -1,0 +1,127 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 The Linux Foundation
+"""Tests for the shared bot-identity helpers."""
+
+from __future__ import annotations
+
+import pytest
+
+from dependamerge.bot_identity import (
+    canonical_bot_login,
+    is_automation_author,
+    is_copilot,
+    is_dependabot,
+    normalize_bot_login,
+)
+
+
+class TestCanonicalBotLogin:
+    """``canonical_bot_login`` normalises GraphQL ``Bot`` logins to REST form."""
+
+    def test_bot_typename_appends_suffix(self) -> None:
+        assert canonical_bot_login("dependabot", "Bot") == "dependabot[bot]"
+
+    def test_bot_typename_applies_to_any_app_actor(self) -> None:
+        # Driven by __typename, not a dependabot-specific match: every bot
+        # is canonicalised uniformly.
+        assert canonical_bot_login("renovate", "Bot") == "renovate[bot]"
+        assert canonical_bot_login("pre-commit-ci", "Bot") == "pre-commit-ci[bot]"
+        assert canonical_bot_login("github-actions", "Bot") == "github-actions[bot]"
+
+    def test_already_suffixed_is_idempotent(self) -> None:
+        assert canonical_bot_login("dependabot[bot]", "Bot") == "dependabot[bot]"
+
+    def test_user_typename_unchanged(self) -> None:
+        # A human login that happens to resemble a bot is left untouched.
+        assert canonical_bot_login("octocat", "User") == "octocat"
+
+    def test_missing_typename_leaves_login_unchanged(self) -> None:
+        # Without __typename (e.g. an older query) the bare login is
+        # preserved; predicates below still match it.
+        assert canonical_bot_login("dependabot", None) == "dependabot"
+
+    def test_empty_login_returns_unknown(self) -> None:
+        assert canonical_bot_login(None, "Bot") == "unknown"
+        assert canonical_bot_login("", "Bot") == "unknown"
+
+
+class TestNormalizeBotLogin:
+    @pytest.mark.parametrize(
+        ("value", "expected"),
+        [
+            ("dependabot[bot]", "dependabot"),
+            ("dependabot", "dependabot"),
+            ("Dependabot[bot]", "dependabot"),
+            ("RENOVATE[BOT]", "renovate"),
+            (None, ""),
+            ("", ""),
+        ],
+    )
+    def test_normalize(self, value: str | None, expected: str) -> None:
+        assert normalize_bot_login(value) == expected
+
+
+class TestIsDependabot:
+    def test_matches_both_forms(self) -> None:
+        assert is_dependabot("dependabot[bot]")
+        assert is_dependabot("dependabot")
+        assert is_dependabot("Dependabot[bot]")
+
+    def test_rejects_other_actors(self) -> None:
+        assert not is_dependabot("renovate[bot]")
+        assert not is_dependabot("octocat")
+        assert not is_dependabot(None)
+        assert not is_dependabot("")
+
+
+class TestIsCopilot:
+    @pytest.mark.parametrize(
+        "login",
+        [
+            "Copilot",
+            "copilot",
+            "copilot[bot]",
+            "github-copilot",
+            "github-copilot[bot]",
+            "copilot-pull-request-reviewer",
+        ],
+    )
+    def test_matches_every_copilot_identity(self, login: str) -> None:
+        assert is_copilot(login)
+
+    def test_rejects_other_actors(self) -> None:
+        assert not is_copilot("dependabot[bot]")
+        assert not is_copilot("octocat")
+        assert not is_copilot(None)
+        assert not is_copilot("")
+
+
+class TestIsAutomationAuthor:
+    @pytest.mark.parametrize(
+        "author",
+        [
+            # Known tools, REST (suffixed) form.
+            "dependabot[bot]",
+            "renovate[bot]",
+            "pre-commit-ci[bot]",
+            "github-actions[bot]",
+            "allcontributors[bot]",
+            # Known tools, GraphQL (bare) form.
+            "dependabot",
+            "renovate",
+            "github-actions",
+            # Copilot is automation too.
+            "github-copilot[bot]",
+            # Unknown bot caught by the [bot] fallthrough.
+            "some-future-bot[bot]",
+        ],
+    )
+    def test_classifies_automation(self, author: str) -> None:
+        assert is_automation_author(author)
+
+    @pytest.mark.parametrize(
+        "author",
+        ["john-doe", "jane-smith", "some-user", None, ""],
+    )
+    def test_rejects_humans(self, author: str | None) -> None:
+        assert not is_automation_author(author)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -168,6 +168,30 @@ class TestCLI:
         assert result.exit_code == 1
         assert "❌ Invalid URL:" in result.stdout
 
+    def test_merge_command_rejects_negative_max_wait(self):
+        """Negative --max-wait must fail fast before any URL routing.
+
+        Regression for the Copilot finding: ``--max-wait`` documents
+        ``0`` (fire-and-forget) and ``> 0`` (wall-clock ceiling), but a
+        negative value was silently accepted and coerced into a
+        surprising instant no-wait run (``max_wait <= 0``).  The command
+        now rejects negatives with exit code 1.
+        """
+        result = self.runner.invoke(
+            app,
+            [
+                "merge",
+                "https://github.com/owner/repo/pull/22",
+                "--token",
+                "test_token",
+                "--max-wait",
+                "-1",
+            ],
+        )
+
+        assert result.exit_code == 1
+        assert "Invalid --max-wait" in result.stdout
+
     @patch("dependamerge.cli.GitHubClient")
     def test_merge_command_non_automation_pr(self, mock_client_class):
         mock_client = Mock()

--- a/tests/test_merge_conflict_handling.py
+++ b/tests/test_merge_conflict_handling.py
@@ -449,6 +449,79 @@ class TestHandleMergeConflict:
         # The failure is handled before auto-merge is even attempted.
         mock_enable.assert_not_called()
 
+    @pytest.mark.asyncio
+    async def test_no_wait_auto_merge_armed_reports_pending(self) -> None:
+        """Fire-and-forget with auto-merge available -> AUTO_MERGE_PENDING."""
+        mgr, _client = make_merge_manager(max_wait=0)
+        assert mgr._no_wait is True
+        pr = _make_pr()
+
+        with (
+            patch.object(
+                mgr,
+                "_request_dependabot_rebase",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
+            patch.object(mgr, "_approve_pr", new_callable=AsyncMock, return_value=True),
+            patch.object(
+                mgr,
+                "_enable_auto_merge_for_pr",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
+            patch.object(
+                mgr, "_wait_for_auto_merge", new_callable=AsyncMock
+            ) as mock_wait,
+        ):
+            result = await mgr._handle_merge_conflict(
+                pr, "lfreleng-actions", "lftools-uv", _result(pr)
+            )
+
+        assert result.status == MergeStatus.AUTO_MERGE_PENDING
+        # Fire-and-forget never blocks on the wait loop.
+        mock_wait.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_no_wait_auto_merge_unavailable_reports_blocked(self) -> None:
+        """Fire-and-forget with auto-merge unavailable -> BLOCKED.
+
+        Regression for the Copilot finding: in the ``max_wait == 0``
+        path the return of ``_enable_auto_merge_for_pr`` was ignored, so
+        a PR that could not arm auto-merge was still reported as
+        AUTO_MERGE_PENDING even though GitHub would never merge it.
+        """
+        mgr, _client = make_merge_manager(max_wait=0)
+        assert mgr._no_wait is True
+        pr = _make_pr()
+
+        with (
+            patch.object(
+                mgr,
+                "_request_dependabot_rebase",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
+            patch.object(mgr, "_approve_pr", new_callable=AsyncMock, return_value=True),
+            patch.object(
+                mgr,
+                "_enable_auto_merge_for_pr",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+            patch.object(
+                mgr, "_wait_for_auto_merge", new_callable=AsyncMock
+            ) as mock_wait,
+        ):
+            result = await mgr._handle_merge_conflict(
+                pr, "lfreleng-actions", "lftools-uv", _result(pr)
+            )
+
+        # Must NOT be AUTO_MERGE_PENDING (auto-merge was never armed).
+        assert result.status == MergeStatus.BLOCKED
+        assert "auto-merge unavailable" in (result.error or "")
+        mock_wait.assert_not_called()
+
 
 class TestConflictRoutingFromMergeSinglePr:
     """``_merge_single_pr`` routes ``dirty`` PRs to the conflict handler."""

--- a/tests/test_org_merge.py
+++ b/tests/test_org_merge.py
@@ -196,6 +196,15 @@ class TestDeriveApiUrls:
         api, _ = derive_api_urls("GitHub.com")
         assert api == "https://api.github.com"
 
+    def test_empty_host_raises(self):
+        with pytest.raises(ValueError):
+            derive_api_urls("")
+
+    def test_whitespace_host_raises(self):
+        # A whitespace-only host would otherwise produce "https:///api/v3".
+        with pytest.raises(ValueError):
+            derive_api_urls("   ")
+
 
 # ---------------------------------------------------------------------------
 # CLI routing: owner URL -> _handle_org_merge
@@ -225,8 +234,8 @@ class TestMergeOrgUrl:
 
         mock_asyncio_run.side_effect = _mock_asyncio_run(
             [
-                _PERMS_OK,  # permissions check
                 ([auto_pr], []),  # fetch_owner_open_prs -> (prs, errors)
+                _PERMS_OK,  # permissions check (deferred until after scan)
                 [],  # parallel merge preview
             ]
         )
@@ -250,8 +259,7 @@ class TestMergeOrgUrl:
 
         mock_asyncio_run.side_effect = _mock_asyncio_run(
             [
-                _PERMS_OK,
-                ([], []),  # no PRs, no errors
+                ([], []),  # no PRs, no errors (perms check is skipped)
             ]
         )
 
@@ -278,7 +286,7 @@ class TestMergeOrgUrl:
         mock_client.token = "test_token"
         mock_client_class.return_value = mock_client
 
-        mock_asyncio_run.side_effect = _mock_asyncio_run([_PERMS_OK, (prs, []), []])
+        mock_asyncio_run.side_effect = _mock_asyncio_run([(prs, []), _PERMS_OK, []])
 
         result = self.runner.invoke(
             app,
@@ -303,8 +311,8 @@ class TestMergeOrgUrl:
 
         mock_asyncio_run.side_effect = _mock_asyncio_run(
             [
-                _PERMS_OK,
                 ([auto_pr], ["Error scanning repository acme/broken: boom"]),
+                _PERMS_OK,
                 [],
             ]
         )
@@ -329,7 +337,7 @@ class TestMergeOrgUrl:
         mock_client.token = "test_token"
         mock_client_class.return_value = mock_client
 
-        mock_asyncio_run.side_effect = _mock_asyncio_run([_PERMS_OK, ([], [])])
+        mock_asyncio_run.side_effect = _mock_asyncio_run([([], [])])
 
         result = self.runner.invoke(
             app,
@@ -347,6 +355,64 @@ class TestMergeOrgUrl:
         assert result.exit_code == 0
         out = _strip_ansi(result.stdout)
         assert "owner" in out.lower()
+
+    @patch("dependamerge.cli._check_merge_permissions")
+    @patch("dependamerge.cli.GitHubClient")
+    @patch("dependamerge.cli.asyncio.run")
+    def test_permission_check_uses_concrete_repo(
+        self, mock_asyncio_run, mock_client_class, mock_check_perms
+    ):
+        # Regression: the owner-wide permission check must probe a real
+        # repository.  check_token_permissions reports every operation as
+        # missing when handed an empty repo, which would abort every
+        # owner-wide run.  Capture ctx.repo_name at call time and assert
+        # it names the representative repo, not "".
+        auto_pr = _make_pr(1, repo="acme/widget")
+
+        mock_client = Mock()
+        mock_client.token = "test_token"
+        mock_client_class.return_value = mock_client
+
+        # Enumeration runs first; the deferred permission check follows.
+        mock_asyncio_run.side_effect = _mock_asyncio_run([([auto_pr], []), []])
+
+        captured: dict[str, str] = {}
+
+        def _capture(ctx):
+            captured["repo_name"] = ctx.repo_name
+
+        mock_check_perms.side_effect = _capture
+
+        result = self.runner.invoke(
+            app,
+            ["merge", "https://github.com/acme", "--token", "test_token"],
+        )
+
+        assert result.exit_code == 0, f"CLI failed: {result.stdout}"
+        mock_check_perms.assert_called_once()
+        assert captured["repo_name"] == "widget"
+
+    @patch("dependamerge.cli._check_merge_permissions")
+    @patch("dependamerge.cli.GitHubClient")
+    @patch("dependamerge.cli.asyncio.run")
+    def test_permission_check_skipped_when_no_prs(
+        self, mock_asyncio_run, mock_client_class, mock_check_perms
+    ):
+        # With nothing to merge there is no representative repo, so the
+        # permission check must not run at all.
+        mock_client = Mock()
+        mock_client.token = "test_token"
+        mock_client_class.return_value = mock_client
+
+        mock_asyncio_run.side_effect = _mock_asyncio_run([([], [])])
+
+        result = self.runner.invoke(
+            app,
+            ["merge", "https://github.com/acme", "--token", "test_token"],
+        )
+
+        assert result.exit_code == 0, f"CLI failed: {result.stdout}"
+        mock_check_perms.assert_not_called()
 
 
 class TestOrgConfirmationHash:
@@ -468,6 +534,71 @@ class TestFetchOwnerOpenPrs:
         assert root_key == "user"
 
     @pytest.mark.asyncio
+    async def test_resolve_owner_root_user_fallback_on_not_found_error(self):
+        # Against real GitHub, organization(login: <user>) returns a
+        # NOT_FOUND GraphQL error (data.organization = null), which
+        # GitHubAsync.graphql surfaces as GraphQLError.  That must be
+        # treated as "not an org" and fall back to the user root.
+        from dependamerge.github_async import GraphQLError
+
+        svc = GitHubService(token="test_token")
+
+        async def fake_graphql(query, variables):
+            raise GraphQLError(
+                '[{"type": "NOT_FOUND", "path": ["organization"], '
+                '"message": "Could not resolve to an Organization with '
+                "the login of 'someuser'.\"}]"
+            )
+
+        svc._api.graphql = fake_graphql  # type: ignore[assignment]
+
+        root_key, _query = await svc._resolve_owner_root("someuser")
+        await svc.close()
+        assert root_key == "user"
+
+    @pytest.mark.asyncio
+    async def test_resolve_owner_root_propagates_unrelated_graphql_error(self):
+        # A GraphQL error that is *not* the not-an-organization NOT_FOUND
+        # must propagate rather than be silently downgraded to a user
+        # fallback.
+        from dependamerge.github_async import GraphQLError
+
+        svc = GitHubService(token="test_token")
+
+        async def fake_graphql(query, variables):
+            raise GraphQLError(
+                '[{"type": "FORBIDDEN", "message": "Resource not accessible"}]'
+            )
+
+        svc._api.graphql = fake_graphql  # type: ignore[assignment]
+
+        with pytest.raises(GraphQLError):
+            await svc._resolve_owner_root("someuser")
+        await svc.close()
+
+    @pytest.mark.asyncio
+    async def test_resolve_owner_root_propagates_nested_not_found(self):
+        # A NOT_FOUND on a *nested* field under the organization root
+        # (path longer than ["organization"]) means the org resolved but a
+        # sub-field failed; it must NOT be downgraded to a user fallback.
+        # Only an exact top-level ["organization"] NOT_FOUND counts.
+        from dependamerge.github_async import GraphQLError
+
+        svc = GitHubService(token="test_token")
+
+        async def fake_graphql(query, variables):
+            raise GraphQLError(
+                '[{"type": "NOT_FOUND", "path": ["organization", "repositories"], '
+                '"message": "Could not resolve organization repositories."}]'
+            )
+
+        svc._api.graphql = fake_graphql  # type: ignore[assignment]
+
+        with pytest.raises(GraphQLError):
+            await svc._resolve_owner_root("someuser")
+        await svc.close()
+
+    @pytest.mark.asyncio
     async def test_resolve_owner_root_cached(self):
         svc = GitHubService(token="test_token")
         calls = 0
@@ -484,6 +615,40 @@ class TestFetchOwnerOpenPrs:
         await svc.close()
         # Second call served from cache; only one probe.
         assert calls == 1
+
+    @pytest.mark.asyncio
+    async def test_fetch_repo_open_prs_reports_result_count_to_progress(self):
+        # complete_repository must receive the in-scope PR count (len of
+        # results), consistent with find_similar_prs / fetch_owner_open_prs,
+        # not a hard-coded 0.
+        completed: list[int] = []
+
+        class _Progress:
+            def start_repository(self, name):  # noqa: D401
+                pass
+
+            def update_operation(self, msg):
+                pass
+
+            def complete_repository(self, count):
+                completed.append(count)
+
+        svc = GitHubService(token="test_token")
+        svc._progress = _Progress()  # type: ignore[assignment]
+
+        async def fake_collect(owner, repo, *, only_automation=True):
+            return [
+                _make_pr(1, repo="acme/repo"),
+                _make_pr(2, repo="acme/repo"),
+            ]
+
+        svc._collect_repo_open_prs = fake_collect  # type: ignore[assignment]
+
+        results = await svc.fetch_repo_open_prs("acme", "repo")
+        await svc.close()
+
+        assert len(results) == 2
+        assert completed == [2]
 
     @pytest.mark.asyncio
     async def test_iter_owner_repositories_excludes_archived_and_forks(self):

--- a/tests/test_org_merge.py
+++ b/tests/test_org_merge.py
@@ -414,6 +414,41 @@ class TestMergeOrgUrl:
         assert result.exit_code == 0, f"CLI failed: {result.stdout}"
         mock_check_perms.assert_not_called()
 
+    def test_ghe_owner_url_surfaces_owner_wide_message(self):
+        # Regression: an owner-shaped URL on a non-github host (e.g. GHE)
+        # must surface parse_org_url's actionable "only supported for
+        # github.com … use a direct PR URL" rejection, not the generic
+        # parse_change_url "cannot determine platform" message.
+        result = self.runner.invoke(
+            app,
+            ["merge", "https://ghe.example.com/acme", "--token", "test_token"],
+        )
+
+        assert result.exit_code == 1
+        out = _strip_ansi(result.stdout)
+        assert "❌ Invalid URL:" in out
+        assert "Owner-wide" in out
+        assert "cannot determine platform" not in out.lower()
+
+    def test_ghe_non_owner_url_keeps_platform_guidance(self):
+        # A non-owner-shaped URL on a non-github host keeps the
+        # platform-agnostic parse_change_url guidance (which also covers
+        # Gerrit), rather than the owner-wide github.com-only message.
+        result = self.runner.invoke(
+            app,
+            [
+                "merge",
+                "https://gerrit.example.org/c/project/sub/extra",
+                "--token",
+                "test_token",
+            ],
+        )
+
+        assert result.exit_code == 1
+        out = _strip_ansi(result.stdout)
+        assert "❌ Invalid URL:" in out
+        assert "Owner-wide" not in out
+
 
 class TestOrgConfirmationHash:
     """The owner confirmation token is deterministic and scoped."""
@@ -486,6 +521,57 @@ class TestFetchOwnerOpenPrs:
         assert len(errors) == 1
         assert "acme/bad" in errors[0]
         assert "kaboom" in errors[0]
+
+    @pytest.mark.asyncio
+    async def test_per_repo_error_marks_repository_complete(self):
+        # Regression for the Copilot finding: on a per-repo error the
+        # error path called start_repository + add_error but never
+        # complete_repository, so the completed-repositories counter
+        # stalled (progress fraction stuck < 100%) and the current
+        # repo/operation stayed stale.  Both the good and the bad repo
+        # must now be marked complete.
+        completed: list[int] = []
+        errors_added = 0
+
+        class _Progress:
+            def start_repository(self, name):  # noqa: D401
+                pass
+
+            def update_operation(self, msg):
+                pass
+
+            def complete_repository(self, count):
+                completed.append(count)
+
+            def add_error(self):
+                nonlocal errors_added
+                errors_added += 1
+
+        svc = GitHubService(token="test_token")
+        svc._progress = _Progress()  # type: ignore[assignment]
+
+        async def fake_iter(owner):
+            for name in ("acme/good", "acme/bad"):
+                yield {"nameWithOwner": name}
+
+        async def fake_collect(owner, repo, *, only_automation):
+            if repo == "bad":
+                raise RuntimeError("kaboom")
+            return [_make_pr(1, repo=f"{owner}/{repo}")]
+
+        svc._iter_owner_repositories = fake_iter  # type: ignore[assignment]
+        svc._collect_repo_open_prs = fake_collect  # type: ignore[assignment]
+
+        prs, errors = await svc.fetch_owner_open_prs("acme")
+        await svc.close()
+
+        assert [pr.repository_full_name for pr in prs] == ["acme/good"]
+        assert len(errors) == 1
+        assert errors_added == 1
+        # Both repositories (success and failure) are marked complete, so
+        # the counter reaches the repository total; the failed repo adds
+        # 0 to the unmergeable tally.
+        assert sorted(completed) == [0, 1]
 
     @pytest.mark.asyncio
     async def test_rate_limit_propagates(self):

--- a/tests/test_org_merge.py
+++ b/tests/test_org_merge.py
@@ -1,0 +1,533 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 The Linux Foundation
+
+"""Tests for the owner-wide (org/user) bulk merge feature."""
+
+import hashlib
+import re
+from unittest.mock import Mock, patch
+
+import pytest
+from typer.testing import CliRunner
+
+from dependamerge.cli import app
+from dependamerge.github_service import GitHubService
+from dependamerge.models import FileChange, PullRequestInfo
+from dependamerge.url_parser import (
+    ChangeSource,
+    UrlParseError,
+    derive_api_urls,
+    parse_org_url,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _strip_ansi(text: str) -> str:
+    return re.sub(r"\x1b\[[0-9;]*m", "", text)
+
+
+def _mock_asyncio_run(side_effects: list[object]):
+    """Mock asyncio.run that closes coroutines to avoid RuntimeWarning."""
+    call_index = 0
+
+    def _side_effect(coro):
+        nonlocal call_index
+        coro.close()
+        if call_index < len(side_effects):
+            result = side_effects[call_index]
+            call_index += 1
+            return result
+        raise AssertionError(
+            f"Unexpected asyncio.run call #{call_index + 1} "
+            f"(only {len(side_effects)} side-effects provided)"
+        )
+
+    return _side_effect
+
+
+def _make_pr(
+    number: int,
+    author: str = "dependabot[bot]",
+    title: str = "Bump foo from 1.0 to 2.0",
+    repo: str = "owner/repo",
+) -> PullRequestInfo:
+    return PullRequestInfo(
+        number=number,
+        title=title,
+        body="Automated dependency update",
+        author=author,
+        head_sha="abc123",
+        base_branch="main",
+        head_branch="dependabot/npm_and_yarn/foo-2.0",
+        state="open",
+        mergeable=True,
+        mergeable_state="clean",
+        behind_by=0,
+        files_changed=[
+            FileChange(
+                filename="package.json",
+                additions=1,
+                deletions=1,
+                changes=2,
+                status="modified",
+            )
+        ],
+        repository_full_name=repo,
+        html_url=f"https://github.com/{repo}/pull/{number}",
+    )
+
+
+# ---------------------------------------------------------------------------
+# URL parser: parse_org_url
+# ---------------------------------------------------------------------------
+
+
+class TestParseOrgUrl:
+    def test_bare_owner(self):
+        parsed = parse_org_url("https://github.com/lfreleng-actions")
+        assert parsed.owner == "lfreleng-actions"
+        assert parsed.host == "github.com"
+        assert parsed.source is ChangeSource.GITHUB
+        assert parsed.is_github
+
+    def test_trailing_slash_identical(self):
+        without = parse_org_url("https://github.com/acme")
+        with_slash = parse_org_url("https://github.com/acme/")
+        assert without.owner == with_slash.owner == "acme"
+
+    def test_without_scheme(self):
+        parsed = parse_org_url("github.com/acme")
+        assert parsed.owner == "acme"
+
+    def test_http_scheme(self):
+        parsed = parse_org_url("http://github.com/acme")
+        assert parsed.owner == "acme"
+
+    def test_orgs_canonical_form(self):
+        parsed = parse_org_url("https://github.com/orgs/acme")
+        assert parsed.owner == "acme"
+
+    def test_orgs_repositories_form(self):
+        parsed = parse_org_url("https://github.com/orgs/acme/repositories")
+        assert parsed.owner == "acme"
+
+    def test_orgs_repositories_trailing_slash(self):
+        parsed = parse_org_url("https://github.com/orgs/acme/repositories/")
+        assert parsed.owner == "acme"
+
+    def test_preserves_original_url(self):
+        url = "https://github.com/acme/"
+        parsed = parse_org_url(url)
+        assert parsed.original_url == url
+
+    def test_owner_with_dashes(self):
+        parsed = parse_org_url("https://github.com/lf-releng-actions")
+        assert parsed.owner == "lf-releng-actions"
+
+    def test_repo_url_rejected(self):
+        # owner/repo is a repository scope, not owner-wide.
+        with pytest.raises(UrlParseError):
+            parse_org_url("https://github.com/acme/widget")
+
+    def test_pr_url_rejected(self):
+        with pytest.raises(UrlParseError):
+            parse_org_url("https://github.com/acme/widget/pull/5")
+
+    def test_orgs_only_rejected(self):
+        # /orgs with no owner is not a valid owner URL.
+        with pytest.raises(UrlParseError):
+            parse_org_url("https://github.com/orgs")
+
+    def test_empty_raises(self):
+        with pytest.raises(UrlParseError):
+            parse_org_url("")
+
+    def test_whitespace_only_raises(self):
+        with pytest.raises(UrlParseError):
+            parse_org_url("   ")
+
+    def test_ghe_host_rejected(self):
+        with pytest.raises(UrlParseError) as exc:
+            parse_org_url("https://github.enterprise.com/acme")
+        assert "github.com" in str(exc.value)
+
+    def test_non_github_host_rejected(self):
+        with pytest.raises(UrlParseError):
+            parse_org_url("https://gitlab.com/acme")
+
+    def test_github_subdomain_accepted(self):
+        parsed = parse_org_url("https://api.github.com/acme")
+        assert parsed.owner == "acme"
+
+    def test_case_insensitive_host(self):
+        parsed = parse_org_url("https://GitHub.com/Acme")
+        assert parsed.host == "github.com"
+        assert parsed.owner == "Acme"
+
+    def test_leading_whitespace(self):
+        parsed = parse_org_url("  https://github.com/acme  ")
+        assert parsed.owner == "acme"
+
+    def test_frozen(self):
+        parsed = parse_org_url("https://github.com/acme")
+        with pytest.raises(AttributeError):
+            parsed.owner = "other"  # type: ignore[misc]
+
+
+class TestDeriveApiUrls:
+    def test_github_dotcom(self):
+        api, gql = derive_api_urls("github.com")
+        assert api == "https://api.github.com"
+        assert gql == "https://api.github.com/graphql"
+
+    def test_github_subdomain(self):
+        api, gql = derive_api_urls("api.github.com")
+        assert api == "https://api.github.com"
+
+    def test_ghe_host_scaffold(self):
+        api, gql = derive_api_urls("ghe.example.com")
+        assert api == "https://ghe.example.com/api/v3"
+        assert gql == "https://ghe.example.com/api/graphql"
+
+    def test_case_insensitive(self):
+        api, _ = derive_api_urls("GitHub.com")
+        assert api == "https://api.github.com"
+
+
+# ---------------------------------------------------------------------------
+# CLI routing: owner URL -> _handle_org_merge
+# ---------------------------------------------------------------------------
+
+_PERMS_OK = {
+    "approve": {"has_permission": True},
+    "merge": {"has_permission": True},
+    "branch_protection": {"has_permission": True},
+}
+
+
+class TestMergeOrgUrl:
+    runner: CliRunner = CliRunner()
+
+    def setup_method(self):
+        self.runner = CliRunner()
+
+    @patch("dependamerge.cli.GitHubClient")
+    @patch("dependamerge.cli.asyncio.run")
+    def test_owner_url_routes_to_org_handler(self, mock_asyncio_run, mock_client_class):
+        auto_pr = _make_pr(1, repo="acme/widget")
+
+        mock_client = Mock()
+        mock_client.token = "test_token"
+        mock_client_class.return_value = mock_client
+
+        mock_asyncio_run.side_effect = _mock_asyncio_run(
+            [
+                _PERMS_OK,  # permissions check
+                ([auto_pr], []),  # fetch_owner_open_prs -> (prs, errors)
+                [],  # parallel merge preview
+            ]
+        )
+
+        result = self.runner.invoke(
+            app,
+            ["merge", "https://github.com/acme", "--token", "test_token"],
+        )
+
+        assert result.exit_code == 0, f"CLI failed: {result.stdout}"
+        out = _strip_ansi(result.stdout)
+        assert "Owner mode" in out
+        assert "acme" in out
+
+    @patch("dependamerge.cli.GitHubClient")
+    @patch("dependamerge.cli.asyncio.run")
+    def test_owner_url_no_prs(self, mock_asyncio_run, mock_client_class):
+        mock_client = Mock()
+        mock_client.token = "test_token"
+        mock_client_class.return_value = mock_client
+
+        mock_asyncio_run.side_effect = _mock_asyncio_run(
+            [
+                _PERMS_OK,
+                ([], []),  # no PRs, no errors
+            ]
+        )
+
+        result = self.runner.invoke(
+            app,
+            ["merge", "https://github.com/acme", "--token", "test_token"],
+        )
+
+        assert result.exit_code == 0, f"CLI failed: {result.stdout}"
+        out = _strip_ansi(result.stdout)
+        assert "No open" in out
+        assert "PRs found" in out
+
+    @patch("dependamerge.cli.GitHubClient")
+    @patch("dependamerge.cli.asyncio.run")
+    def test_owner_url_groups_by_repo(self, mock_asyncio_run, mock_client_class):
+        prs = [
+            _make_pr(1, repo="acme/alpha"),
+            _make_pr(2, repo="acme/alpha"),
+            _make_pr(1, repo="acme/beta"),
+        ]
+
+        mock_client = Mock()
+        mock_client.token = "test_token"
+        mock_client_class.return_value = mock_client
+
+        mock_asyncio_run.side_effect = _mock_asyncio_run([_PERMS_OK, (prs, []), []])
+
+        result = self.runner.invoke(
+            app,
+            ["merge", "https://github.com/acme", "--token", "test_token"],
+        )
+
+        assert result.exit_code == 0, f"CLI failed: {result.stdout}"
+        out = _strip_ansi(result.stdout)
+        # Per-repository grouped headers.
+        assert "acme/alpha" in out
+        assert "acme/beta" in out
+        assert "2 repositories" in out
+
+    @patch("dependamerge.cli.GitHubClient")
+    @patch("dependamerge.cli.asyncio.run")
+    def test_owner_url_surfaces_scan_errors(self, mock_asyncio_run, mock_client_class):
+        auto_pr = _make_pr(1, repo="acme/widget")
+
+        mock_client = Mock()
+        mock_client.token = "test_token"
+        mock_client_class.return_value = mock_client
+
+        mock_asyncio_run.side_effect = _mock_asyncio_run(
+            [
+                _PERMS_OK,
+                ([auto_pr], ["Error scanning repository acme/broken: boom"]),
+                [],
+            ]
+        )
+
+        result = self.runner.invoke(
+            app,
+            ["merge", "https://github.com/acme", "--token", "test_token"],
+        )
+
+        assert result.exit_code == 0, f"CLI failed: {result.stdout}"
+        out = _strip_ansi(result.stdout)
+        assert "could not be scanned" in out
+        assert "acme/broken" in out
+
+    @patch("dependamerge.cli.GitHubClient")
+    @patch("dependamerge.cli.asyncio.run")
+    def test_orgs_canonical_url_routes_to_org_handler(
+        self, mock_asyncio_run, mock_client_class
+    ):
+        # /orgs/acme must NOT be mis-parsed as repo owner="orgs".
+        mock_client = Mock()
+        mock_client.token = "test_token"
+        mock_client_class.return_value = mock_client
+
+        mock_asyncio_run.side_effect = _mock_asyncio_run([_PERMS_OK, ([], [])])
+
+        result = self.runner.invoke(
+            app,
+            ["merge", "https://github.com/orgs/acme", "--token", "test_token"],
+        )
+
+        assert result.exit_code == 0, f"CLI failed: {result.stdout}"
+        out = _strip_ansi(result.stdout)
+        assert "Owner mode" in out
+        # The scanned owner is "acme", not "orgs".
+        assert "scanning acme" in out
+
+    def test_owner_url_help_mentions_owner(self):
+        result = self.runner.invoke(app, ["merge", "--help"])
+        assert result.exit_code == 0
+        out = _strip_ansi(result.stdout)
+        assert "owner" in out.lower()
+
+
+class TestOrgConfirmationHash:
+    """The owner confirmation token is deterministic and scoped."""
+
+    def test_hash_is_deterministic(self):
+        combined = "org-merge:acme:3"
+        h1 = hashlib.sha256(combined.encode("utf-8")).hexdigest()[:16]
+        h2 = hashlib.sha256(combined.encode("utf-8")).hexdigest()[:16]
+        assert h1 == h2
+
+    def test_hash_varies_with_owner(self):
+        a = hashlib.sha256(b"org-merge:acme:3").hexdigest()[:16]
+        b = hashlib.sha256(b"org-merge:other:3").hexdigest()[:16]
+        assert a != b
+
+    def test_hash_varies_with_count(self):
+        a = hashlib.sha256(b"org-merge:acme:3").hexdigest()[:16]
+        b = hashlib.sha256(b"org-merge:acme:4").hexdigest()[:16]
+        assert a != b
+
+
+# ---------------------------------------------------------------------------
+# Service: fetch_owner_open_prs (fan-out, error isolation, account type)
+# ---------------------------------------------------------------------------
+
+
+class TestFetchOwnerOpenPrs:
+    @pytest.mark.asyncio
+    async def test_fans_out_across_repositories(self):
+        svc = GitHubService(token="test_token")
+
+        async def fake_iter(owner):
+            for name in ("acme/alpha", "acme/beta"):
+                yield {"nameWithOwner": name}
+
+        async def fake_collect(owner, repo, *, only_automation):
+            return [_make_pr(1, repo=f"{owner}/{repo}")]
+
+        svc._iter_owner_repositories = fake_iter  # type: ignore[assignment]
+        svc._collect_repo_open_prs = fake_collect  # type: ignore[assignment]
+
+        prs, errors = await svc.fetch_owner_open_prs("acme")
+        await svc.close()
+
+        repos = sorted(pr.repository_full_name for pr in prs)
+        assert repos == ["acme/alpha", "acme/beta"]
+        assert errors == []
+
+    @pytest.mark.asyncio
+    async def test_per_repo_error_isolation(self):
+        svc = GitHubService(token="test_token")
+
+        async def fake_iter(owner):
+            for name in ("acme/good", "acme/bad"):
+                yield {"nameWithOwner": name}
+
+        async def fake_collect(owner, repo, *, only_automation):
+            if repo == "bad":
+                raise RuntimeError("kaboom")
+            return [_make_pr(1, repo=f"{owner}/{repo}")]
+
+        svc._iter_owner_repositories = fake_iter  # type: ignore[assignment]
+        svc._collect_repo_open_prs = fake_collect  # type: ignore[assignment]
+
+        prs, errors = await svc.fetch_owner_open_prs("acme")
+        await svc.close()
+
+        # The good repo's PRs survive; the bad repo is recorded as an error.
+        assert [pr.repository_full_name for pr in prs] == ["acme/good"]
+        assert len(errors) == 1
+        assert "acme/bad" in errors[0]
+        assert "kaboom" in errors[0]
+
+    @pytest.mark.asyncio
+    async def test_rate_limit_propagates(self):
+        from dependamerge.github_async import RateLimitError
+
+        svc = GitHubService(token="test_token")
+
+        async def fake_iter(owner):
+            yield {"nameWithOwner": "acme/alpha"}
+
+        async def fake_collect(owner, repo, *, only_automation):
+            raise RateLimitError("primary rate limit")
+
+        svc._iter_owner_repositories = fake_iter  # type: ignore[assignment]
+        svc._collect_repo_open_prs = fake_collect  # type: ignore[assignment]
+
+        with pytest.raises(RateLimitError):
+            await svc.fetch_owner_open_prs("acme")
+        await svc.close()
+
+    @pytest.mark.asyncio
+    async def test_resolve_owner_root_org(self):
+        svc = GitHubService(token="test_token")
+
+        async def fake_graphql(query, variables):
+            return {"organization": {"repositories": {"nodes": []}}}
+
+        svc._api.graphql = fake_graphql  # type: ignore[assignment]
+
+        root_key, _query = await svc._resolve_owner_root("acme")
+        await svc.close()
+        assert root_key == "organization"
+
+    @pytest.mark.asyncio
+    async def test_resolve_owner_root_user_fallback(self):
+        svc = GitHubService(token="test_token")
+
+        async def fake_graphql(query, variables):
+            # organization root is null -> owner is a user account
+            return {"organization": None}
+
+        svc._api.graphql = fake_graphql  # type: ignore[assignment]
+
+        root_key, _query = await svc._resolve_owner_root("someuser")
+        await svc.close()
+        assert root_key == "user"
+
+    @pytest.mark.asyncio
+    async def test_resolve_owner_root_cached(self):
+        svc = GitHubService(token="test_token")
+        calls = 0
+
+        async def fake_graphql(query, variables):
+            nonlocal calls
+            calls += 1
+            return {"organization": {"repositories": {"nodes": []}}}
+
+        svc._api.graphql = fake_graphql  # type: ignore[assignment]
+
+        await svc._resolve_owner_root("acme")
+        await svc._resolve_owner_root("acme")
+        await svc.close()
+        # Second call served from cache; only one probe.
+        assert calls == 1
+
+    @pytest.mark.asyncio
+    async def test_iter_owner_repositories_excludes_archived_and_forks(self):
+        svc = GitHubService(token="test_token")
+
+        page = {
+            "organization": {
+                "repositories": {
+                    "totalCount": 4,
+                    "pageInfo": {"hasNextPage": False, "endCursor": None},
+                    "nodes": [
+                        {
+                            "nameWithOwner": "acme/keep",
+                            "isArchived": False,
+                            "isFork": False,
+                        },
+                        {
+                            "nameWithOwner": "acme/arch",
+                            "isArchived": True,
+                            "isFork": False,
+                        },
+                        {
+                            "nameWithOwner": "acme/fork",
+                            "isArchived": False,
+                            "isFork": True,
+                        },
+                        {
+                            "nameWithOwner": "acme/keep2",
+                            "isArchived": False,
+                            "isFork": False,
+                        },
+                    ],
+                }
+            }
+        }
+
+        async def fake_graphql(query, variables):
+            return page
+
+        svc._api.graphql = fake_graphql  # type: ignore[assignment]
+
+        names = []
+        async for repo in svc._iter_owner_repositories("acme"):
+            names.append(repo["nameWithOwner"])
+        await svc.close()
+
+        assert names == ["acme/keep", "acme/keep2"]

--- a/tests/test_repo_merge.py
+++ b/tests/test_repo_merge.py
@@ -719,3 +719,33 @@ class TestRepoConfirmationHash:
         h1 = hashlib.sha256(c1.encode("utf-8")).hexdigest()[:16]
         h2 = hashlib.sha256(c2.encode("utf-8")).hexdigest()[:16]
         assert h1 != h2
+
+
+class TestRepoMergeOrder:
+    """Verify repository-scoped PRs are sequenced oldest-first."""
+
+    def test_orders_ascending_by_number(self):
+        """PRs fetched newest-first are reordered oldest-first."""
+        from dependamerge.cli import _repo_merge_order
+
+        # GraphQL returns CREATED_AT DESC (newest first); simulate that.
+        prs = [_make_pr(7), _make_pr(3), _make_pr(5), _make_pr(1)]
+        ordered = _repo_merge_order(prs)
+        assert [p.number for p in ordered] == [1, 3, 5, 7]
+
+    def test_is_stable_and_non_mutating(self):
+        """Input list is not mutated and already-sorted input is preserved."""
+        from dependamerge.cli import _repo_merge_order
+
+        prs = [_make_pr(1), _make_pr(2), _make_pr(3)]
+        ordered = _repo_merge_order(prs)
+        assert [p.number for p in ordered] == [1, 2, 3]
+        # Original list order is left untouched.
+        assert [p.number for p in prs] == [1, 2, 3]
+        assert ordered is not prs
+
+    def test_empty_list(self):
+        """An empty list orders to an empty list."""
+        from dependamerge.cli import _repo_merge_order
+
+        assert _repo_merge_order([]) == []

--- a/tests/test_stripe_scheduler.py
+++ b/tests/test_stripe_scheduler.py
@@ -1,0 +1,219 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 The Linux Foundation
+
+"""Tests for the owner-wide striped merge scheduler.
+
+The load-bearing guarantee of the striped scheduler is that **no two PRs
+from the same repository are ever in flight simultaneously**, while
+distinct repositories are still processed concurrently.  These tests
+assert that invariant with a deterministic fake that records the set of
+in-flight repositories at every dispatch.
+"""
+
+import asyncio
+
+import pytest
+
+from dependamerge.merge_manager import (
+    AsyncMergeManager,
+    MergeResult,
+    MergeStatus,
+)
+from dependamerge.models import ComparisonResult, PullRequestInfo
+
+# Work-item type accepted by ``merge_prs_parallel``.  Annotating the test
+# fixtures with this (rather than letting the literal narrow to
+# ``tuple[PullRequestInfo, None]``) keeps the invariant ``list`` element
+# type assignable to the method's parameter.
+PRPair = tuple[PullRequestInfo, ComparisonResult | None]
+
+
+def _make_pr(number: int, repo: str) -> PullRequestInfo:
+    """Build a minimal PullRequestInfo for scheduler testing."""
+    return PullRequestInfo(
+        number=number,
+        title=f"Bump dep in {repo} #{number}",
+        body="Automated dependency update",
+        author="dependabot[bot]",
+        head_sha="abc123",
+        base_branch="main",
+        head_branch=f"dependabot/{repo}/{number}",
+        state="open",
+        mergeable=True,
+        mergeable_state="clean",
+        behind_by=0,
+        files_changed=[],
+        repository_full_name=repo,
+        html_url=f"https://github.com/{repo}/pull/{number}",
+    )
+
+
+class _Recorder:
+    """Instrumented replacement for ``_merge_single_pr``.
+
+    Records, for every PR dispatched, the set of repositories that were
+    in flight at that moment, so tests can assert the per-repo
+    single-flight invariant and observe cross-repo concurrency.
+    """
+
+    def __init__(self, hold: float = 0.02) -> None:
+        self._hold = hold
+        self.inflight_by_repo: dict[str, int] = {}
+        self.max_concurrent_per_repo: dict[str, int] = {}
+        self.max_global_inflight = 0
+        self.dispatch_order: list[tuple[str, int]] = []
+
+    async def __call__(self, pr_info: PullRequestInfo) -> MergeResult:
+        repo = pr_info.repository_full_name
+        self.inflight_by_repo[repo] = self.inflight_by_repo.get(repo, 0) + 1
+        self.max_concurrent_per_repo[repo] = max(
+            self.max_concurrent_per_repo.get(repo, 0),
+            self.inflight_by_repo[repo],
+        )
+        self.max_global_inflight = max(
+            self.max_global_inflight,
+            sum(self.inflight_by_repo.values()),
+        )
+        self.dispatch_order.append((repo, pr_info.number))
+        # Hold the "in flight" state long enough that any scheduling
+        # violation (two PRs of one repo, or more than `concurrency`
+        # repos at once) would overlap and be observed.
+        await asyncio.sleep(self._hold)
+        self.inflight_by_repo[repo] -= 1
+        return MergeResult(pr_info=pr_info, status=MergeStatus.MERGED)
+
+
+def _manager(concurrency: int = 10) -> AsyncMergeManager:
+    return AsyncMergeManager(
+        token="test_token",
+        concurrency=concurrency,
+        preview_mode=True,
+    )
+
+
+@pytest.mark.asyncio
+async def test_striped_single_flight_per_repo():
+    """No repository ever has more than one PR in flight at a time."""
+    pr_list: list[PRPair] = [
+        (_make_pr(1, "owner/a"), None),
+        (_make_pr(2, "owner/a"), None),
+        (_make_pr(3, "owner/a"), None),
+        (_make_pr(1, "owner/b"), None),
+        (_make_pr(2, "owner/b"), None),
+        (_make_pr(1, "owner/c"), None),
+    ]
+    mgr = _manager(concurrency=10)
+    recorder = _Recorder()
+    mgr._merge_single_pr = recorder  # type: ignore[assignment]
+
+    results = await mgr.merge_prs_parallel(pr_list, stripe=True)
+
+    # Load-bearing invariant: at most one in-flight PR per repository.
+    assert all(count == 1 for count in recorder.max_concurrent_per_repo.values()), (
+        recorder.max_concurrent_per_repo
+    )
+    # Every PR produced a result.
+    assert len(results) == len(pr_list)
+    assert all(r.status is MergeStatus.MERGED for r in results)
+
+
+@pytest.mark.asyncio
+async def test_striped_runs_distinct_repos_concurrently():
+    """Distinct repositories ARE processed concurrently (not serialised)."""
+    pr_list: list[PRPair] = [
+        (_make_pr(1, "owner/a"), None),
+        (_make_pr(1, "owner/b"), None),
+        (_make_pr(1, "owner/c"), None),
+        (_make_pr(2, "owner/a"), None),
+        (_make_pr(2, "owner/b"), None),
+        (_make_pr(2, "owner/c"), None),
+    ]
+    mgr = _manager(concurrency=10)
+    recorder = _Recorder()
+    mgr._merge_single_pr = recorder  # type: ignore[assignment]
+
+    await mgr.merge_prs_parallel(pr_list, stripe=True)
+
+    # Three distinct repos with available concurrency should overlap.
+    assert recorder.max_global_inflight >= 2
+    # But still never two PRs of the same repo at once.
+    assert all(c == 1 for c in recorder.max_concurrent_per_repo.values())
+
+
+@pytest.mark.asyncio
+async def test_striped_respects_global_concurrency_bound():
+    """Global in-flight never exceeds the configured concurrency."""
+    pr_list: list[PRPair] = [(_make_pr(1, f"owner/r{i}"), None) for i in range(8)]
+    mgr = _manager(concurrency=3)
+    recorder = _Recorder()
+    mgr._merge_single_pr = recorder  # type: ignore[assignment]
+
+    await mgr.merge_prs_parallel(pr_list, stripe=True)
+
+    assert recorder.max_global_inflight <= 3, recorder.max_global_inflight
+
+
+@pytest.mark.asyncio
+async def test_striped_processes_repo_prs_in_order():
+    """Within a repository, PRs are dispatched in first-seen order."""
+    pr_list: list[PRPair] = [
+        (_make_pr(10, "owner/a"), None),
+        (_make_pr(20, "owner/a"), None),
+        (_make_pr(30, "owner/a"), None),
+    ]
+    mgr = _manager(concurrency=5)
+    recorder = _Recorder()
+    mgr._merge_single_pr = recorder  # type: ignore[assignment]
+
+    await mgr.merge_prs_parallel(pr_list, stripe=True)
+
+    a_order = [num for repo, num in recorder.dispatch_order if repo == "owner/a"]
+    assert a_order == [10, 20, 30]
+
+
+@pytest.mark.asyncio
+async def test_striped_preserves_result_ordering():
+    """Results are returned in the caller's original input order."""
+    pr_list: list[PRPair] = [
+        (_make_pr(1, "owner/a"), None),
+        (_make_pr(1, "owner/b"), None),
+        (_make_pr(2, "owner/a"), None),
+        (_make_pr(1, "owner/c"), None),
+    ]
+    mgr = _manager(concurrency=10)
+    recorder = _Recorder()
+    mgr._merge_single_pr = recorder  # type: ignore[assignment]
+
+    results = await mgr.merge_prs_parallel(pr_list, stripe=True)
+
+    returned = [(r.pr_info.repository_full_name, r.pr_info.number) for r in results]
+    expected = [(pr.repository_full_name, pr.number) for pr, _ in pr_list]
+    assert returned == expected
+
+
+@pytest.mark.asyncio
+async def test_striped_isolates_per_pr_failures():
+    """A crash on one PR does not lose results for siblings in its repo."""
+    pr_list: list[PRPair] = [
+        (_make_pr(1, "owner/a"), None),
+        (_make_pr(2, "owner/a"), None),
+        (_make_pr(3, "owner/a"), None),
+    ]
+    mgr = _manager(concurrency=5)
+
+    async def flaky(pr_info: PullRequestInfo) -> MergeResult:
+        if pr_info.number == 2:
+            raise RuntimeError("boom")
+        return MergeResult(pr_info=pr_info, status=MergeStatus.MERGED)
+
+    mgr._merge_single_pr = flaky  # type: ignore[assignment]
+
+    results = await mgr.merge_prs_parallel(pr_list, stripe=True)
+
+    assert len(results) == 3
+    by_number = {r.pr_info.number: r for r in results}
+    assert by_number[1].status is MergeStatus.MERGED
+    assert by_number[2].status is MergeStatus.FAILED
+    assert by_number[2].error and "boom" in by_number[2].error
+    # PR #3 still ran even though #2 (earlier in the same repo) failed.
+    assert by_number[3].status is MergeStatus.MERGED

--- a/tests/test_stripe_scheduler.py
+++ b/tests/test_stripe_scheduler.py
@@ -240,3 +240,34 @@ async def test_striped_handles_duplicate_work_item_objects():
     assert all(r.status is MergeStatus.MERGED for r in results)
     # The repository's three (identical) PRs were each dispatched.
     assert len(recorder.dispatch_order) == 3
+
+
+@pytest.mark.asyncio
+async def test_run_deadline_reset_between_runs_on_reused_manager():
+    """A reused manager must not carry a stale ``_run_deadline``.
+
+    A previous owner-wide run with ``max_wait`` sets ``_run_deadline``.
+    A subsequent run without a ceiling (``max_wait=None``) must clear it
+    so its per-PR waits are not clamped (or instantly expired) by the
+    earlier run's deadline.
+    """
+    pr_list: list[PRPair] = [(_make_pr(1, "owner/a"), None)]
+
+    # First run with a wall-clock ceiling sets a deadline.
+    mgr = AsyncMergeManager(
+        token="test_token",
+        concurrency=5,
+        preview_mode=True,
+        max_wait=900.0,
+    )
+    mgr._merge_single_pr = _Recorder()  # type: ignore[assignment]
+    await mgr.merge_prs_parallel(pr_list, stripe=True)
+    assert mgr._run_deadline is not None
+
+    # Simulate the manager being reconfigured for an uncapped run.
+    mgr._max_wait = None
+    mgr._merge_single_pr = _Recorder()  # type: ignore[assignment]
+    await mgr.merge_prs_parallel(pr_list, stripe=True)
+
+    # The stale deadline from the first run was cleared.
+    assert mgr._run_deadline is None

--- a/tests/test_stripe_scheduler.py
+++ b/tests/test_stripe_scheduler.py
@@ -271,3 +271,35 @@ async def test_run_deadline_reset_between_runs_on_reused_manager():
 
     # The stale deadline from the first run was cleared.
     assert mgr._run_deadline is None
+
+
+@pytest.mark.asyncio
+async def test_no_wait_flag_reset_between_runs_on_reused_manager():
+    """A reused manager must not carry a stale ``_no_wait`` flag.
+
+    ``_no_wait`` (the fire-and-forget ``max_wait == 0`` mode) is derived
+    from ``_max_wait`` in ``__init__`` but must be recomputed at the
+    start of every run: if the same instance is later reconfigured for a
+    blocking run (``max_wait=None`` or ``> 0``), a stale ``_no_wait=True``
+    would otherwise wrongly skip all waits.
+    """
+    pr_list: list[PRPair] = [(_make_pr(1, "owner/a"), None)]
+
+    # First run in fire-and-forget mode sets ``_no_wait`` True.
+    mgr = AsyncMergeManager(
+        token="test_token",
+        concurrency=5,
+        preview_mode=True,
+        max_wait=0,
+    )
+    mgr._merge_single_pr = _Recorder()  # type: ignore[assignment]
+    await mgr.merge_prs_parallel(pr_list, stripe=True)
+    assert mgr._no_wait is True
+
+    # Reconfigure for an uncapped (blocking) run.
+    mgr._max_wait = None
+    mgr._merge_single_pr = _Recorder()  # type: ignore[assignment]
+    await mgr.merge_prs_parallel(pr_list, stripe=True)
+
+    # The stale fire-and-forget flag from the first run was cleared.
+    assert mgr._no_wait is False

--- a/tests/test_stripe_scheduler.py
+++ b/tests/test_stripe_scheduler.py
@@ -217,3 +217,26 @@ async def test_striped_isolates_per_pr_failures():
     assert by_number[2].error and "boom" in by_number[2].error
     # PR #3 still ran even though #2 (earlier in the same repo) failed.
     assert by_number[3].status is MergeStatus.MERGED
+
+
+@pytest.mark.asyncio
+async def test_striped_handles_duplicate_work_item_objects():
+    """Reused tuple objects do not collapse into a single result.
+
+    Results are keyed by input position, not ``id(item)``, so passing the
+    same tuple object multiple times must still yield one result per slot
+    rather than overwriting earlier entries.
+    """
+    shared: PRPair = (_make_pr(1, "owner/a"), None)
+    pr_list: list[PRPair] = [shared, shared, shared]
+    mgr = _manager(concurrency=5)
+    recorder = _Recorder()
+    mgr._merge_single_pr = recorder  # type: ignore[assignment]
+
+    results = await mgr.merge_prs_parallel(pr_list, stripe=True)
+
+    # One result per input slot, despite the shared tuple identity.
+    assert len(results) == len(pr_list)
+    assert all(r.status is MergeStatus.MERGED for r in results)
+    # The repository's three (identical) PRs were each dispatched.
+    assert len(recorder.dispatch_order) == 3

--- a/tests/test_transient_merge_errors.py
+++ b/tests/test_transient_merge_errors.py
@@ -30,7 +30,14 @@ def _make_pr_info(
     number: int = 39,
     repo: str = "org/repo",
 ) -> PullRequestInfo:
-    """Create a PullRequestInfo fixture with sensible defaults."""
+    """Create a PullRequestInfo fixture modelling a pre-commit.ci PR.
+
+    The title/author/branch defaults deliberately describe a
+    ``pre-commit-ci[bot]`` autoupdate PR — the canonical automation PR
+    this module exercises.  Tests whose behaviour depends on author or
+    title should pass those values explicitly rather than relying on
+    these fixture defaults.
+    """
     return PullRequestInfo(
         number=number,
         title="Chore: pre-commit autoupdate",
@@ -52,7 +59,14 @@ def _make_pr_info(
 
 
 def _make_405_exception() -> httpx.HTTPStatusError:
-    """Create a realistic 405 HTTPStatusError."""
+    """Create a realistic 405 HTTPStatusError with no response body.
+
+    The empty body is deliberate: these tests exercise the retry
+    classifier in ``_merge_pr_with_retry``, which keys off the HTTP
+    *status line* ("405 Method Not Allowed") only.  The body-parsing
+    path that surfaces GitHub's ``message`` field is covered separately
+    by ``_make_405_with_body`` / ``TestMergeApiBodyCapture``.
+    """
     request = httpx.Request(
         "PUT",
         "https://api.github.com/repos/org/repo/pulls/39/merge",
@@ -166,6 +180,35 @@ class TestFailureSummaryHTTPErrors:
         # state-based analysis for blocked PRs
         assert "transient 405" not in summary.lower()
 
+    def test_405_with_github_body_surfaces_detail(self):
+        """A 405 carrying GitHub's response body surfaces that detail.
+
+        End-to-end counterpart to ``TestMergeApiBodyCapture`` (which
+        checks the transport layer): ``merge_pull_request`` embeds
+        GitHub's explanation after a ``GitHub: `` marker, and
+        ``_get_failure_summary`` must surface that actionable reason
+        ahead of the state-based inference that a ``blocked`` PR would
+        otherwise yield ("branch protection rules prevent merge").
+        """
+        mgr = self._make_manager()
+        pr = _make_pr_info(mergeable_state="blocked", mergeable=True)
+
+        mgr._last_merge_exception["org/repo#39"] = Exception(
+            "Failed to merge PR #39 in org/repo. Error: Client error "
+            "'405 Method Not Allowed' for url '.../merge'. "
+            "GitHub: Required workflows 'Autolabeler' are not satisfied "
+            "(PR state: open, mergeable: True, mergeable_state: blocked)"
+        )
+
+        summary = mgr._get_failure_summary(pr)
+
+        assert "Required workflows" in summary
+        assert "are not satisfied" in summary
+        # The marker detail must win over generic block-state inference.
+        assert "branch protection" not in summary.lower()
+        # The appended PR-state context must be trimmed off.
+        assert "PR state:" not in summary
+
     def test_502_reports_bad_gateway(self):
         """A 502 error should be reported as Bad Gateway."""
         mgr = self._make_manager()
@@ -240,6 +283,9 @@ class TestTransient405Retry:
 
         assert result is True
         assert client.merge_pull_request.call_count == 2
+        # The first attempt's 405 must be recorded for failure reporting,
+        # even though the retry ultimately succeeded.
+        assert "org/repo#39" in mgr._last_merge_exception
 
     @pytest.mark.asyncio
     async def test_405_on_clean_pr_retries_and_still_fails(self):
@@ -327,11 +373,13 @@ class TestTransient405Retry:
     async def test_405_base_branch_modified_retries_and_succeeds(self):
         """A "Base branch was modified" 405 is a transient race: retry.
 
-        The PR is ``behind`` and ``fix_out_of_date`` is off, so without the
-        dedicated base-modified handling this 405 would fall through to the
-        terminal ``else: break`` and report a false failure.  The race
-        clears on retry (a sibling merge advanced the base), so the second
-        attempt succeeds.
+        The PR is ``behind`` and ``fix_out_of_date`` is off.  The dedicated
+        "base branch was modified" branch in ``_merge_pr_with_retry``
+        recognises this as a transient race and retries via ``continue``
+        (up to ``max_retries``); without it the 405 would instead fall
+        through to the terminal ``else: break`` taken by behind/no-fix PRs
+        and report a false failure.  The race clears on retry (a sibling
+        merge advanced the base), so the second attempt succeeds.
         """
         pr = _make_pr_info(mergeable_state="behind", mergeable=True)
 

--- a/tests/test_workflow_scope.py
+++ b/tests/test_workflow_scope.py
@@ -24,10 +24,15 @@ from dependamerge.github_async import GitHubAsync
 from dependamerge.github_async import PermissionError as GitHubPermissionError
 from dependamerge.models import FileChange, PullRequestInfo
 
+# Test-only dummy token. Centralised in a constant to make clear it is a
+# fixture value, not a real credential, and to keep that intent obvious if
+# more call sites are added.
+_TEST_TOKEN = "test_token"
+
 
 def _make_api() -> GitHubAsync:
     """Construct a client with a dummy token (no network is performed)."""
-    return GitHubAsync(token="test_token")
+    return GitHubAsync(token=_TEST_TOKEN)
 
 
 class _FakeWorkflowResponse:


### PR DESCRIPTION
## Summary

Adds a third scope to the `merge` command so a bare owner URL bulk-merges
every in-scope automation PR across an entire GitHub organisation or user
account:

```
dependamerge https://github.com/lfreleng-actions/
```

Closes #342.

This hybridises the two existing bulk modes:

- **Like repo merge**, it needs no similarity correlation — the existing
  author markers identify automation PRs (`dependabot`, `pre-commit.ci`,
  etc.).
- **Like repo merge**, it must sequence merges carefully: merging one PR
  can change the merge state of sibling PRs in the same repository. That
  hazard is now multiplied across every repository in the owner.

## How it works

- **URL parsing** (`url_parser.py`): `ParsedOrgUrl` + `parse_org_url`
  accept the bare owner, trailing-slash, `orgs/`, and
  `orgs//repositories` forms, behind a single `github.com`-only
  guard. `derive_api_urls()` centralises the dotcom-vs-GHE base-URL rule
  (GHE scaffold only — see #343).
- **Owner enumeration** (`github_service.py`): `fetch_owner_open_prs`
  detects org-vs-user account type at runtime (cached), excludes archived
  repos and forks by default, and isolates per-repo errors (propagating
  only global rate-limit failures). The per-repo "fetch + filter to
  `PullRequestInfo`" body is factored into a shared helper reused by
  `fetch_repo_open_prs` — no duplicated node-to-`PullRequestInfo` logic.
- **Striping scheduler** (`merge_manager.py`):
  `merge_prs_parallel(stripe=True)` runs one serial worker per repository,
  guaranteeing at most one in-flight PR per repo while distinct repos run
  concurrently. This structurally avoids the GitHub data-replication races
  that would otherwise force injected delays or random retries. Global
  concurrency is bounded by the distinct-repo count (cap 10).
- **CLI** (`cli.py`): `_handle_org_merge` renders a repo-grouped preview,
  gates execution behind an `org-merge:{owner}:{count}` SHA confirmation,
  and reaches full parity with every per-PR flag.

Forks are excluded by default; this is documented in the README and the
new `docs/ORG_WIDE_BULK_MERGE.md`.

## Identity hardening, ordering, and the wait model

Owner-wide enumeration runs through GraphQL, which returns App actor
logins in the bare form (`dependabot`) while REST returns the suffixed
form (`dependabot[bot]`). Every login-equality gate written for one form
misclassified the other, so org-mode dependabot conflicts failed fast
instead of rebasing. This PR also:

- **Centralises identity logic** in a new `bot_identity` module
  (`canonical_bot_login`, `normalize_bot_login`, `is_dependabot`,
  `is_copilot`, `is_automation_author`) and routes `github_client`,
  `github_service`, `cli`, `copilot_handler`, `github_async`, and
  `pr_comparator` through it — retiring the divergent exact-match and
  substring classifiers that previously disagreed.
- **Orders merges to drain cleanly**: repositories with the most PRs
  first, oldest PR number first within a repository (matching the order
  dependabot expects to rebase).
- **Detects dependabot's self-rebase banner** so the conflict handler
  holds the PR for auto-merge rather than failing it or firing a
  redundant `@dependabot rebase` macro.
- **Adds `--max-wait SECONDS`** (default 900) as a global wall-clock
  ceiling on an owner-wide run; `--max-wait 0` selects fire-and-forget
  (approve, arm auto-merge, report pending, return without blocking).

## GHE scaffold

Owner-wide merging targets `github.com` for now. The transport layer is
already GHE-capable, but host threading through the service/client/manager
stack is deferred to #343. The parser guard and `derive_api_urls()` are
the single relaxation points for that follow-up.

## Repository-scoped merge ordering

The owner-wide scheduler already drains each repository oldest-first
(`_owner_merge_order`): merging a newer PR ahead of an older sibling
advances the base branch underneath the older one and forces automation
such as dependabot into an avoidable rebase-and-revalidate cycle. The
repository-scoped path (`https://github.com/owner/repo/pulls`) did not
share that ordering — it dispatched PRs in the GraphQL fetch order
(`CREATED_AT` descending, newest first).

`_handle_repo_merge` now sorts a repository's PRs ascending by number
(via a new `_repo_merge_order` helper) before dispatch, so the oldest
drains first. This is the single-repository analogue of the
within-repository key used owner-wide, so both bulk schemes now sequence
a repository's PRs identically. The preview list is derived from the same
order, so the displayed sequence matches the merge sequence.

## Commits

1. **Feat: Add org/owner-wide bulk merge support** — the feature, plus a
   basedpyright complexity refactor of `_merge_single_pr`
   (`_handle_not_mergeable_pr`, `_simulate_preview_merge`).
2. **Chore: Address AI code quality findings** — resolves AI "Code
   Quality" / CodeQL findings on pre-existing files (empty-except comment,
   gitreview CRLF comment, `rebase --abort` logging, precise VS Code
   launcher match) and strengthens the related tests.
3. **Fix: Address Copilot review feedback** — the dedicated Copilot
   feedback commit.
4. **Feat: Harden bot identity and owner-wide waits** — identity
   consolidation, drain ordering, self-rebase detection, and `--max-wait`.
5. **Perf: Order repo merges oldest-first** — applies the owner-wide
   within-repository ordering to repository-scoped merges so the
   oldest PR drains first, sparing newer siblings a needless
   dependabot rebase.

## Testing

- New `tests/test_org_merge.py`, `tests/test_stripe_scheduler.py`, and
  `tests/test_bot_identity.py`; repository-scoped ordering is covered
  by the new `TestRepoMergeOrder` class in `tests/test_repo_merge.py`.
- Full suite: **1159 passed**.
- `ruff`, `ruff format`, `mypy`, `basedpyright`, and all `prek` hooks
  pass.
