### PR TITLE
Fix: support user accounts in owner-wide commands

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -28,8 +28,8 @@ permissions: {}
 jobs:
   build-test:
     permissions:
-      contents: read
-      pull-requests: read
+      contents: read  # Check out the repository to build and test.
+      pull-requests: read  # Read PR metadata for status reporting.
     # Pinned to python-workflows v0.1.0 release commit
     # yamllint disable-line rule:line-length
     uses: lfreleng-actions/python-workflows/.github/workflows/build-test.yaml@518ac92728ff987d1f0edab163b1e328fd7258d7  # v0.1.0

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -29,9 +29,9 @@ jobs:
     with:
       codeql_config: .github/codeql/codeql-config.yml
     permissions:
-      security-events: write
+      security-events: write  # Upload CodeQL results to code scanning.
       # required to fetch internal or private CodeQL packs
-      packages: read
+      packages: read  # Fetch internal or private CodeQL packs.
       # only required for workflows in private repositories
-      actions: read
-      contents: read
+      actions: read  # Read workflow metadata (private repos only).
+      contents: read  # Check out the repository to analyze.

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -1,0 +1,84 @@
+---
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 The Linux Foundation
+
+# Runs the live dry-run integration tests against GitHub (and optionally
+# Gerrit).  Everything runs read-only: report commands are read-only by
+# nature and the merge/close commands use --dry-run, which previews
+# without approving, merging, rebasing or closing and skips the
+# write-permission pre-flight.  The tests self-skip when credentials or
+# open automation PRs are absent, so this workflow never mutates a
+# repository and never fails on an empty target space.
+name: 'Integration Tests (dry-run)'
+
+# yamllint disable-line rule:truthy
+on:
+  workflow_dispatch:
+  pull_request:
+    types: [opened, reopened, synchronize]
+    branches:
+      - main
+      - master
+    paths:
+      - 'src/**'
+      - 'tests/**'
+      - 'pyproject.toml'
+      - '.github/workflows/integration-test.yaml'
+
+concurrency:
+  group: "${{ github.workflow }}-${{ github.ref }}"
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  integration:
+    name: 'Live dry-run integration tests'
+    runs-on: 'ubuntu-latest'
+    timeout-minutes: 20
+    permissions:
+      # Read-only: the dry-run paths never need write scopes.  The
+      # default GITHUB_TOKEN can read public org/user data, which is all
+      # the report commands and PR discovery require for public targets.
+      contents: read
+      pull-requests: read
+    env:
+      # Opt in to the integration suite (otherwise it self-deselects).
+      DEPENDAMERGE_RUN_INTEGRATION: '1'
+      # Prefer a dedicated read-only PAT when provided (needed only to
+      # reach private repositories or to raise rate limits); otherwise
+      # fall back to the workflow token, which suffices for public
+      # targets.  The tests skip cleanly if neither yields a usable token.
+      GITHUB_TOKEN: >-
+        ${{ secrets.INTEGRATION_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
+      # Optional target overrides (defaults: org lfreleng-actions,
+      # user ModeSevenIndustrialSolutions).
+      DEPENDAMERGE_IT_ORG: ${{ vars.DEPENDAMERGE_IT_ORG }}
+      DEPENDAMERGE_IT_USER: ${{ vars.DEPENDAMERGE_IT_USER }}
+      # Optional Gerrit configuration; the Gerrit test skips without it.
+      DEPENDAMERGE_IT_GERRIT_HOST: ${{ vars.DEPENDAMERGE_IT_GERRIT_HOST }}
+      DEPENDAMERGE_IT_GERRIT_BASE_PATH: >-
+        ${{ vars.DEPENDAMERGE_IT_GERRIT_BASE_PATH }}
+      GERRIT_USERNAME: ${{ secrets.GERRIT_USERNAME }}
+      GERRIT_PASSWORD: ${{ secrets.GERRIT_PASSWORD }}
+    steps:
+      - name: 'Checkout repository'
+        # yamllint disable-line rule:line-length
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
+
+      - name: 'Set up uv and Python'
+        # yamllint disable-line rule:line-length
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39  # v8.2.0
+        with:
+          enable-cache: true
+
+      - name: 'Install project with test dependencies'
+        run: uv sync
+
+      - name: 'Run live dry-run integration tests'
+        # --run-integration enables the suite; --no-cov avoids the
+        # coverage gate, which is meaningless for a network-gated subset
+        # that self-skips when targets are empty.
+        run: >-
+          uv run pytest tests/integration
+          --run-integration --no-cov -ra

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -37,11 +37,16 @@ jobs:
     runs-on: 'ubuntu-latest'
     timeout-minutes: 20
     permissions:
-      # Read-only: the dry-run paths never need write scopes.  The
-      # default GITHUB_TOKEN can read public org/user data, which is all
-      # the report commands and PR discovery require for public targets.
-      contents: read
-      pull-requests: read
+      # The dry-run paths never need write scopes; read access to
+      # repository contents is required to check out and run the suite.
+      contents: read  # Checkout and run the test suite (read-only).
+      # Read-only access to pull-request metadata lets the suite discover
+      # open automation PRs to preview in --dry-run mode.
+      pull-requests: read  # Discover open PRs to preview (read-only).
+    # Bind to a dedicated environment so the secrets referenced below are
+    # scoped to (and can be protected by) that environment rather than
+    # being read directly from repository scope (zizmor: secrets-outside-env).
+    environment: integration
     env:
       # Opt in to the integration suite (otherwise it self-deselects).
       DEPENDAMERGE_RUN_INTEGRATION: '1'
@@ -75,6 +80,11 @@ jobs:
       - name: 'Checkout repository'
         # yamllint disable-line rule:line-length
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
+        with:
+          # This job only reads the repository and runs tests; it never
+          # pushes.  Drop the persisted token so it cannot leak via the
+          # local git config or uploaded artifacts (zizmor: artipacked).
+          persist-credentials: false
 
       - name: 'Set up uv and Python'
         # yamllint disable-line rule:line-length

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -45,22 +45,32 @@ jobs:
     env:
       # Opt in to the integration suite (otherwise it self-deselects).
       DEPENDAMERGE_RUN_INTEGRATION: '1'
-      # Prefer a dedicated read-only PAT when provided (needed only to
-      # reach private repositories or to raise rate limits); otherwise
-      # fall back to the workflow token, which suffices for public
-      # targets.  The tests skip cleanly if neither yields a usable token.
+      # Prefer a dedicated read-only PAT only on manual (workflow_dispatch)
+      # runs, where the trigger is operator-controlled.  On pull_request
+      # runs fall back to the automatic workflow token, so a compromised
+      # branch can never exfiltrate the long-lived PAT.  The workflow token
+      # can read public org/user data, which is all the report commands and
+      # PR discovery need for public targets; the tests skip cleanly if the
+      # token cannot reach the target.
       GITHUB_TOKEN: >-
-        ${{ secrets.INTEGRATION_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
+        ${{ (github.event_name == 'workflow_dispatch'
+        && secrets.INTEGRATION_GITHUB_TOKEN) || secrets.GITHUB_TOKEN }}
       # Optional target overrides (defaults: org lfreleng-actions,
       # user ModeSevenIndustrialSolutions).
       DEPENDAMERGE_IT_ORG: ${{ vars.DEPENDAMERGE_IT_ORG }}
       DEPENDAMERGE_IT_USER: ${{ vars.DEPENDAMERGE_IT_USER }}
       # Optional Gerrit configuration; the Gerrit test skips without it.
+      # Inject the Gerrit credentials only on manual runs so they are never
+      # exposed to pull_request runs (where the Gerrit test self-skips).
       DEPENDAMERGE_IT_GERRIT_HOST: ${{ vars.DEPENDAMERGE_IT_GERRIT_HOST }}
       DEPENDAMERGE_IT_GERRIT_BASE_PATH: >-
         ${{ vars.DEPENDAMERGE_IT_GERRIT_BASE_PATH }}
-      GERRIT_USERNAME: ${{ secrets.GERRIT_USERNAME }}
-      GERRIT_PASSWORD: ${{ secrets.GERRIT_PASSWORD }}
+      GERRIT_USERNAME: >-
+        ${{ github.event_name == 'workflow_dispatch'
+        && secrets.GERRIT_USERNAME || '' }}
+      GERRIT_PASSWORD: >-
+        ${{ github.event_name == 'workflow_dispatch'
+        && secrets.GERRIT_PASSWORD || '' }}
     steps:
       - name: 'Checkout repository'
         # yamllint disable-line rule:line-length

--- a/.github/workflows/openssf-scorecard.yaml
+++ b/.github/workflows/openssf-scorecard.yaml
@@ -32,9 +32,9 @@ jobs:
     uses: lfit/releng-reusable-workflows/.github/workflows/reuse-openssf-scorecard.yaml@f43b219b8a91dcd082f26419008c8bf5544ec212 # v0.6.0
     permissions:
       # Needed to upload the results to code-scanning dashboard.
-      security-events: write
+      security-events: write  # Upload Scorecard results to code scanning.
       # Needed to publish results and get a badge (see publish_results below).
-      id-token: write
+      id-token: write  # Publish results and mint the badge.
       # Uncomment the permissions below if installing in a private repository.
       # contents: read
       # actions: read

--- a/.github/workflows/release-drafter.yaml
+++ b/.github/workflows/release-drafter.yaml
@@ -21,7 +21,7 @@ jobs:
     name: 'Update Release Draft'
     permissions:
       # write permission is required to create releases
-      contents: write
+      contents: write  # Create and update the release draft.
     runs-on: 'ubuntu-latest'
     timeout-minutes: 3
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@
 # Secrets
 .secrets.*
 
+# Local commit-message scratch files
+.commit-msg.tmp
+
 # Local node cache
 node_modules
 

--- a/README.md
+++ b/README.md
@@ -654,6 +654,34 @@ Enter the string above to continue (or press Enter to cancel):
 🚀 Final Results: 2 merged, 0 failed
 ```
 
+### Dry Run Mode
+
+Use `--dry-run` to perform a complete analysis and preview without making any
+changes. A dry run never approves, merges, rebases, or closes anything, and it
+skips the write-permission pre-flight check, so it runs successfully under a
+read-only token. This makes it ideal for CI validation and for inspecting what
+the tool *would* do before committing to it:
+
+```bash
+# Preview a single PR (and its similar PRs) without merging
+dependamerge merge https://github.com/owner/repo/pull/123 --dry-run
+
+# Preview an owner-wide run under a read-only token
+dependamerge merge https://github.com/owner --dry-run --no-progress
+
+# Preview which PRs close would target, without closing them
+dependamerge close https://github.com/owner/repo/pull/123 --dry-run
+
+# Preview a Gerrit change without applying +2 or submitting
+dependamerge merge https://gerrit.example.org/c/project/+/12345 --dry-run
+```
+
+The repository's `Integration Tests (dry-run)` workflow exercises every
+sub-command in this mode against live GitHub (and, when configured, Gerrit)
+on each pull request, so owner-resolution and command regressions are caught
+before release. The integration suite self-skips when credentials or open
+automation PRs are absent, so it never fails on an empty target space.
+
 ### Custom Merge Options
 
 ```bash
@@ -687,6 +715,11 @@ dependamerge merge https://github.com/owner/repo/pull/123 \
 
 - `--no-confirm`: Skip confirmation prompt and merge without delay (default is
   interactive mode)
+- `--dry-run`: Analyze and preview only - never approve, merge, rebase, or
+  close anything. Skips the write-permission pre-flight so it runs under a
+  read-only token (e.g. in CI). Implies preview-only and suppresses
+  confirmation prompts. Works for GitHub PR, repository, and owner-wide URLs
+  as well as Gerrit changes.
 - `--threshold FLOAT`: Similarity threshold for matching PRs/changes (0.0-1.0,
   default: 0.8)
 - `--progress/--no-progress`: Show real-time progress updates (default:
@@ -729,6 +762,9 @@ Fallback variables:
 #### Close Command Options
 
 - `--no-confirm`: Skip confirmation prompt and close without preview
+- `--dry-run`: Analyze and preview only - never close anything. Suppresses the
+  confirmation prompt so it runs unattended under a read-only token (e.g. in
+  CI).
 - `--threshold FLOAT`: Similarity threshold for matching PRs (0.0-1.0,
   default: 0.8)
 - `--progress/--no-progress`: Show real-time progress updates (default:
@@ -1045,6 +1081,36 @@ You can pass args as usual:
 ```bash
 uv run pytest -k "similarity and not slow" -vv
 ```
+
+#### Live Integration Tests
+
+Live integration tests (under `tests/integration/`) drive the real CLI in
+`--dry-run` mode against GitHub and Gerrit, exercising every sub-command
+(`status`, `blocked`, `merge`, `close`) against both organization and personal
+accounts and across every supported owner-URL form. They are deselected by
+default and opt in via `--run-integration` (or `DEPENDAMERGE_RUN_INTEGRATION=1`).
+Each test fails safe: it skips when its credentials or an open automation PR are
+not available, so it never mutates a repository and never fails on an empty
+target space.
+
+```bash
+# GitHub integration tests (needs a token; a read-only token suffices)
+GITHUB_TOKEN=... uv run pytest tests/integration --run-integration --no-cov
+
+# Point at different targets (defaults: org lfreleng-actions,
+# user ModeSevenIndustrialSolutions)
+DEPENDAMERGE_IT_ORG=my-org DEPENDAMERGE_IT_USER=my-user \
+  GITHUB_TOKEN=... uv run pytest tests/integration --run-integration --no-cov
+
+# Gerrit integration test (skips unless host + credentials are set)
+DEPENDAMERGE_IT_GERRIT_HOST=gerrit.example.org \
+  DEPENDAMERGE_IT_GERRIT_BASE_PATH=r \
+  GERRIT_USERNAME=... GERRIT_PASSWORD=... \
+  uv run pytest tests/integration/test_live_gerrit.py --run-integration --no-cov
+```
+
+The `Integration Tests (dry-run)` GitHub Actions workflow runs this suite on
+every pull request with read-only permissions.
 
 #### Pre-commit Integration
 

--- a/README.md
+++ b/README.md
@@ -660,15 +660,15 @@ Enter the string above to continue (or press Enter to cancel):
 
 Use `--dry-run` to perform a complete analysis and preview without making any
 changes. A dry run never approves, merges, rebases, or closes anything, and it
-skips the write-permission pre-flight check, so it runs successfully under a
-read-only token. This makes it ideal for CI validation and for inspecting what
+skips the write-permission pre-flight check, so it runs under a token without
+write access. This makes it ideal for CI validation and for inspecting what
 the tool *would* do before committing to it:
 
 ```bash
 # Preview a single PR (and its similar PRs) without merging
 dependamerge merge https://github.com/owner/repo/pull/123 --dry-run
 
-# Preview an owner-wide run under a read-only token
+# Preview an owner-wide run under a token without write access
 dependamerge merge https://github.com/owner --dry-run --no-progress
 
 # Preview which PRs close would target, without closing them
@@ -680,7 +680,7 @@ dependamerge merge https://gerrit.example.org/c/project/+/12345 --dry-run
 
 The repository's `Integration Tests (dry-run)` workflow exercises every
 sub-command in this mode against live GitHub (and, when configured, Gerrit)
-on each pull request, so owner-resolution and command regressions are caught
+on each pull request, so it catches owner-resolution and command regressions
 before release. The integration suite self-skips when credentials or open
 automation PRs are absent, so it never fails on an empty target space.
 
@@ -717,11 +717,11 @@ dependamerge merge https://github.com/owner/repo/pull/123 \
 
 - `--no-confirm`: Skip confirmation prompt and merge without delay (default is
   interactive mode)
-- `--dry-run`: Analyze and preview only - never approve, merge, rebase, or
-  close anything. Skips the write-permission pre-flight so it runs under a
-  read-only token (e.g. in CI). Implies preview-only and suppresses
-  confirmation prompts. Works for GitHub PR, repository, and owner-wide URLs
-  as well as Gerrit changes.
+- `--dry-run`: Analyze and preview without making changes - never approve,
+  merge, rebase, or close anything. Skips the write-permission pre-flight so it
+  runs under a token without write access (e.g. in CI). Implies preview mode and
+  suppresses confirmation prompts. Works for GitHub PR, repository, and
+  owner-wide URLs as well as Gerrit changes.
 - `--threshold FLOAT`: Similarity threshold for matching PRs/changes (0.0-1.0,
   default: 0.8)
 - `--progress/--no-progress`: Show real-time progress updates (default:
@@ -764,9 +764,9 @@ Fallback variables:
 #### Close Command Options
 
 - `--no-confirm`: Skip confirmation prompt and close without preview
-- `--dry-run`: Analyze and preview only - never close anything. Suppresses the
-  confirmation prompt so it runs unattended under a read-only token (e.g. in
-  CI).
+- `--dry-run`: Analyze and preview without making changes - never close
+  anything. Suppresses the confirmation prompt so it runs unattended under a
+  token without write access (e.g. in CI).
 - `--threshold FLOAT`: Similarity threshold for matching PRs (0.0-1.0,
   default: 0.8)
 - `--progress/--no-progress`: Show real-time progress updates (default:
@@ -1089,14 +1089,14 @@ uv run pytest -k "similarity and not slow" -vv
 Live integration tests (under `tests/integration/`) drive the real CLI in
 `--dry-run` mode against GitHub and Gerrit, exercising every sub-command
 (`status`, `blocked`, `merge`, `close`) against both organization and personal
-accounts and across every supported owner-URL form. They are deselected by
-default and opt in via `--run-integration` (or `DEPENDAMERGE_RUN_INTEGRATION=1`).
+accounts and across every supported owner-URL form. Pytest deselects them by
+default; opt in via `--run-integration` (or `DEPENDAMERGE_RUN_INTEGRATION=1`).
 Each test fails safe: it skips when its credentials or an open automation PR are
 not available, so it never mutates a repository and never fails on an empty
 target space.
 
 ```bash
-# GitHub integration tests (needs a token; a read-only token suffices)
+# GitHub integration tests (needs a token; a token without write access works)
 GITHUB_TOKEN=... uv run pytest tests/integration --run-integration --no-cov
 
 # Point at different targets (defaults: org lfreleng-actions,
@@ -1104,7 +1104,7 @@ GITHUB_TOKEN=... uv run pytest tests/integration --run-integration --no-cov
 DEPENDAMERGE_IT_ORG=my-org DEPENDAMERGE_IT_USER=my-user \
   GITHUB_TOKEN=... uv run pytest tests/integration --run-integration --no-cov
 
-# Gerrit integration test (skips unless host + credentials are set)
+# Gerrit integration test (skips unless the host and credentials are present)
 DEPENDAMERGE_IT_GERRIT_HOST=gerrit.example.org \
   DEPENDAMERGE_IT_GERRIT_BASE_PATH=r \
   GERRIT_USERNAME=... GERRIT_PASSWORD=... \
@@ -1112,7 +1112,7 @@ DEPENDAMERGE_IT_GERRIT_HOST=gerrit.example.org \
 ```
 
 The `Integration Tests (dry-run)` GitHub Actions workflow runs this suite on
-every pull request with read-only permissions.
+every pull request with read-scoped permissions.
 
 #### Pre-commit Integration
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ of dependency updates. Supports common automation tools:
 - Dependabot
 - pre-commit.ci
 - Renovate
+- GitHub Copilot
 
 Also works for individual GitHub users when provided with an override flag.
 
@@ -99,6 +100,7 @@ GitHub organisation. Works with the same automation tools as merge:
 - Dependabot
 - pre-commit.ci
 - Renovate
+- GitHub Copilot
 
 Also works for individual GitHub users when provided with an override flag.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -127,6 +127,7 @@ addopts = [
 asyncio_mode = "auto"
 markers = [
   "slow: marks tests as slow (deselected by prek/pre-commit hooks)",
+  "integration: marks live GitHub/Gerrit CLI tests; deselected by default and run only with --run-integration or DEPENDAMERGE_RUN_INTEGRATION=1 (and self-skip without credentials)",
 ]
 
 [tool.coverage.run]

--- a/src/dependamerge/bot_identity.py
+++ b/src/dependamerge/bot_identity.py
@@ -50,17 +50,20 @@ _AUTOMATION_BOT_NAMES = frozenset(
         "allcontributors",
         "copilot",
         "github-copilot",
+        "copilot-swe-agent",
     }
 )
 
 # Known GitHub Copilot actor logins (normalised).  Copilot reports under
 # several identities depending on the surface: the App author
-# (``Copilot`` / ``copilot[bot]`` / ``github-copilot[bot]``) and the
-# review actor (``copilot-pull-request-reviewer``).
+# (``Copilot`` / ``copilot[bot]`` / ``github-copilot[bot]``), the coding
+# agent that raises automated code fixes (``copilot-swe-agent[bot]``), and
+# the review actor (``copilot-pull-request-reviewer``).
 _COPILOT_NAMES = frozenset(
     {
         "copilot",
         "github-copilot",
+        "copilot-swe-agent",
         "copilot-pull-request-reviewer",
     }
 )

--- a/src/dependamerge/cli.py
+++ b/src/dependamerge/cli.py
@@ -3628,7 +3628,7 @@ def _display_status_results(status_result, output_format: str):
     for tool in AUTOMATION_TOOLS:
         # Format tool names nicely
         if tool == "[bot]":
-            console.print("  • Any bot account")
+            console.print("  • Any other [bot] account")
         elif tool == "pre-commit":
             console.print("  • pre-commit.ci")
         elif tool == "github-actions":

--- a/src/dependamerge/cli.py
+++ b/src/dependamerge/cli.py
@@ -1243,14 +1243,15 @@ def _handle_repo_merge(
             console.print("\n❌ Merge cancelled by user.")
             return
     elif human_prs and ctx.dry_run:
+        # Human PRs only reach this branch when --include-human-prs was
+        # supplied (otherwise they are filtered out at fetch time).  A dry
+        # run performs no writes, so keep them in the preview to faithfully
+        # mirror what a real --include-human-prs run would attempt; a real
+        # run would prompt for confirmation first (unless --no-confirm).
         console.print(
-            "\nℹ️ Dry run: excluding human-authored PRs "
-            "(a real run would prompt before including them)."
+            "\nℹ️ Dry run: human-authored PRs are kept in this preview "
+            "(a real run would prompt before merging them)."
         )
-        repo_prs = automation_prs
-        if not repo_prs:
-            console.print("❌ No automation PRs remain to merge.")
-            return
 
     # --- Build the merge list (ComparisonResult is None for repo mode) ---
     all_prs_to_merge: list[tuple[PullRequestInfo, ComparisonResult | None]] = [
@@ -1661,14 +1662,15 @@ def _handle_org_merge(
             console.print("\n❌ Merge cancelled by user.")
             return
     elif human_prs and ctx.dry_run:
+        # Human PRs only reach this branch when --include-human-prs was
+        # supplied (otherwise they are filtered out at fetch time).  A dry
+        # run performs no writes, so keep them in the preview to faithfully
+        # mirror what a real --include-human-prs run would attempt; a real
+        # run would prompt for confirmation first (unless --no-confirm).
         console.print(
-            "\nℹ️ Dry run: excluding human-authored PRs "
-            "(a real run would prompt before including them)."
+            "\nℹ️ Dry run: human-authored PRs are kept in this preview "
+            "(a real run would prompt before merging them)."
         )
-        owner_prs = automation_prs
-        if not owner_prs:
-            console.print("❌ No automation PRs remain to merge.")
-            return
 
     # --- Build the merge list (ComparisonResult is None for owner mode) ---
     all_prs_to_merge: list[tuple[PullRequestInfo, ComparisonResult | None]] = [

--- a/src/dependamerge/cli.py
+++ b/src/dependamerge/cli.py
@@ -711,10 +711,10 @@ def _scan_and_find_similar(ctx: _MergeContext) -> None:
     assert ctx.source_pr is not None
     assert ctx.comparator is not None
 
-    console.print(f"Checking organization: {ctx.owner}")
+    console.print(f"Checking owner: {ctx.owner}")
 
     # Start the progress tracker now — this is where the
-    # long-running org-wide scan begins.
+    # long-running owner-wide scan begins.
     if ctx.progress_tracker:
         ctx.progress_tracker.start()
 
@@ -777,7 +777,7 @@ def _scan_and_find_similar(ctx: _MergeContext) -> None:
         # Not a failure: the supplied PR is simply the only one to
         # merge.  Use a neutral "skip ahead" glyph rather than ❌ so
         # the output does not read like an error.
-        console.print("⏩ No similar PRs found in the organization")
+        console.print("⏩ No similar PRs found for this owner")
 
     for target_pr, comparison in ctx.all_similar_prs:
         console.print(f"  • {target_pr.repository_full_name} #{target_pr.number}")
@@ -2224,7 +2224,7 @@ def merge(
 
     1. Analyze the provided PR
 
-    2. Find similar PRs in the organization
+    2. Find similar PRs across the owner (organization or user account)
 
     3. Approve and merge matching PRs
 
@@ -2768,7 +2768,8 @@ def close(
     ),
 ):
     """
-    Bulk close pull requests across a GitHub organization.
+    Bulk close pull requests across a GitHub owner (organization or user
+    account).
 
     By default, runs in interactive mode showing what changes will apply,
     then prompts to proceed with closing. Use --no-confirm to close immediately.
@@ -2777,7 +2778,7 @@ def close(
 
     1. Analyze the provided PR
 
-    2. Find similar PRs in the organization
+    2. Find similar PRs across the owner (organization or user account)
 
     3. Close matching PRs
 
@@ -2882,11 +2883,11 @@ def close(
                 "Override SHA validated. Proceeding with non-automation PR close."
             )
 
-        # Find similar PRs in the organization
+        # Find similar PRs across the owner (organization or user)
         if progress_tracker:
             console.print()
         else:
-            console.print(f"\nChecking organization: {owner}")
+            console.print(f"\nChecking owner: {owner}")
 
         # Use GitHubService for async PR finding
         from .github_service import GitHubService
@@ -2937,7 +2938,7 @@ def close(
             # Not a failure: the supplied PR is simply the only one to
             # close.  Use a neutral glyph rather than ❌ so the output
             # does not read like an error.
-            console.print("⏩ No similar PRs found in the organization")
+            console.print("⏩ No similar PRs found for this owner")
 
         for target_pr, comparison in all_similar_prs:
             console.print(f"  • {target_pr.repository_full_name} #{target_pr.number}")
@@ -3172,7 +3173,8 @@ def status(
     3. Count open and merged pull requests
     4. Identify PRs affecting actions or workflows
 
-    Automation tools supported: dependabot, pre-commit.ci, GitHub Copilot
+    Automation tools supported: Dependabot, Renovate, pre-commit.ci,
+    GitHub Actions, GitHub Copilot, and any other [bot] account.
     """
     # Parse owner login from input (handles a bare login plus every
     # GitHub owner URL form, including /orgs/owner/repositories).

--- a/src/dependamerge/cli.py
+++ b/src/dependamerge/cli.py
@@ -3640,6 +3640,21 @@ def _display_status_results(status_result, output_format: str):
     summary_table.add_column("Summary", style="cyan")
     summary_table.add_column("Value", style="white")
 
+    # Aggregate open-PR counts across all scanned repositories.  The
+    # per-repository "PRs Open" column shows human / automation, so the
+    # summary totals those same open-PR figures and reports the split
+    # before the combined total.
+    total_automation_prs = sum(
+        repo.open_prs_automation for repo in status_result.repository_statuses
+    )
+    total_human_prs = sum(
+        repo.open_prs_human for repo in status_result.repository_statuses
+    )
+
+    summary_table.add_row("🤖 Automation PRs", str(total_automation_prs))
+    summary_table.add_row("🤷 Human      PRs", str(total_human_prs))
+    summary_table.add_section()
+    summary_table.add_row("Total PRs", str(total_automation_prs + total_human_prs))
     summary_table.add_row("Total Repositories", str(status_result.total_repositories))
 
     # Only show Scanned Repositories if it differs from Total

--- a/src/dependamerge/cli.py
+++ b/src/dependamerge/cli.py
@@ -3172,7 +3172,7 @@ def status(
     3. Count open and merged pull requests
     4. Identify PRs affecting actions or workflows
 
-    Automation tools supported: dependabot, pre-commit.ci
+    Automation tools supported: dependabot, pre-commit.ci, GitHub Copilot
     """
     # Parse owner login from input (handles a bare login plus every
     # GitHub owner URL form, including /orgs/owner/repositories).
@@ -3633,6 +3633,8 @@ def _display_status_results(status_result, output_format: str):
             console.print("  • pre-commit.ci")
         elif tool == "github-actions":
             console.print("  • GitHub Actions")
+        elif tool == "copilot":
+            console.print("  • GitHub Copilot")
         else:
             console.print(f"  • {tool.capitalize()}")
     console.print()

--- a/src/dependamerge/cli.py
+++ b/src/dependamerge/cli.py
@@ -77,6 +77,7 @@ from .url_parser import (
     UrlParseError,
     parse_change_url,
     parse_org_url,
+    parse_owner_arg,
     parse_repo_url,
 )
 
@@ -345,6 +346,12 @@ class _MergeContext:
     github2gerrit_mode: str
     include_human_prs: bool = False
     rebase_local: bool = True
+    # Dry-run: perform the full analysis and preview but never merge,
+    # approve, rebase, or close anything.  Because no write occurs, the
+    # write-permission pre-flight check is skipped so the command can run
+    # under a read-only token (e.g. in CI).  Implies preview-only and
+    # suppresses the interactive confirmation prompt.
+    dry_run: bool = False
     # Owner-wide global wait ceiling (seconds).  Default 900 (15 min);
     # 0 = fire-and-forget (arm auto-merge, report pending, never block).
     # Applies to owner/user-wide runs; ignored for single-PR and
@@ -515,9 +522,7 @@ def _source_pr_modifies_workflows(ctx: _MergeContext) -> bool:
         return False
     for change in source_pr.files_changed:
         path = getattr(change, "filename", "") or ""
-        if path.startswith(".github/workflows/") and path.endswith(
-            (".yml", ".yaml")
-        ):
+        if path.startswith(".github/workflows/") and path.endswith((".yml", ".yaml")):
             return True
     return False
 
@@ -636,6 +641,24 @@ def _check_merge_permissions(ctx: _MergeContext) -> None:
     except Exception as e:
         console.print(f"⚠️ Could not verify permissions: {e}")
         console.print("   Continuing anyway...")
+
+
+def _maybe_check_merge_permissions(ctx: _MergeContext) -> None:
+    """Run the write-permission pre-flight unless this is a dry run.
+
+    A dry run performs no writes (no merge, approve, rebase, or branch
+    update), so the merge/approve/update_branch/branch_protection scopes
+    are not required.  Skipping the check lets the full analysis and
+    preview run under a read-only token — which is exactly what the CI
+    dry-run test matrix needs, since the default workflow token (and
+    other low-privilege tokens) cannot satisfy the write scopes.
+    """
+    if ctx.dry_run:
+        console.print(
+            "🧪 Dry run: skipping token permission check " "(no changes will be made)"
+        )
+        return
+    _check_merge_permissions(ctx)
 
 
 def _validate_automation_author(ctx: _MergeContext) -> None:
@@ -831,9 +854,7 @@ def _run_parallel_merge(
                 console.print(
                     f"{prefix}🚀 Merging {len(prs_to_merge)} pull requests..."
                 )
-            return await merge_manager.merge_prs_parallel(
-                prs_to_merge, stripe=stripe
-            )
+            return await merge_manager.merge_prs_parallel(prs_to_merge, stripe=stripe)
 
     return asyncio.run(_do_merge())
 
@@ -1105,7 +1126,7 @@ def _handle_repo_merge(
     console.print(f"🔍 Repository mode: fetching open PRs in {parsed_repo.project}...")
 
     # --- Token permission check (reuse existing helper) ---
-    _check_merge_permissions(ctx)
+    _maybe_check_merge_permissions(ctx)
 
     # --- Progress tracker ---
     if ctx.show_progress:
@@ -1194,8 +1215,10 @@ def _handle_repo_merge(
 
     # --- Human PR confirmation gate ---
     # Only prompt when human PRs are actually in scope, not merely
-    # because --include-human-prs was supplied.
-    needs_human_confirm = bool(human_prs) and not ctx.no_confirm
+    # because --include-human-prs was supplied.  A dry run never prompts;
+    # it mirrors the safe default (exclude human PRs) so the preview
+    # matches a real run where the operator presses Enter at the prompt.
+    needs_human_confirm = bool(human_prs) and not ctx.no_confirm and not ctx.dry_run
     if needs_human_confirm:
         console.print("\n⚠️ Human-authored PRs are included in this merge operation.")
         console.print("   Review the list above carefully before proceeding.")
@@ -1218,6 +1241,15 @@ def _handle_repo_merge(
                     return
         except (KeyboardInterrupt, EOFError, typer.Abort):
             console.print("\n❌ Merge cancelled by user.")
+            return
+    elif human_prs and ctx.dry_run:
+        console.print(
+            "\nℹ️ Dry run: excluding human-authored PRs "
+            "(a real run would prompt before including them)."
+        )
+        repo_prs = automation_prs
+        if not repo_prs:
+            console.print("❌ No automation PRs remain to merge.")
             return
 
     # --- Build the merge list (ComparisonResult is None for repo mode) ---
@@ -1246,7 +1278,7 @@ def _handle_repo_merge(
         merge_results = _run_parallel_merge(
             ctx,
             all_prs_to_merge,
-            preview=not ctx.no_confirm,
+            preview=ctx.dry_run or not ctx.no_confirm,
             # Allow parallel workers; the merge dispatch itself is
             # serialised per repo by ``AsyncMergeManager`` so PRs
             # parked in Step 5.5's wait loop no longer block other
@@ -1267,6 +1299,11 @@ def _handle_repo_merge(
         return
 
     merged_count = sum(1 for r in merge_results if r.status.value == "merged")
+
+    # Dry run: report the preview and stop before any prompt or merge.
+    if ctx.dry_run:
+        _display_merge_results(merge_results, no_confirm=False)
+        return
 
     if not ctx.no_confirm:
         # In preview mode, show what would happen, then prompt
@@ -1496,9 +1533,7 @@ def _handle_org_merge(
     ctx.owner = parsed_org.owner
     ctx.repo_name = ""
 
-    console.print(
-        f"🔍 Owner mode: scanning {parsed_org.owner} for automation PRs..."
-    )
+    console.print(f"🔍 Owner mode: scanning {parsed_org.owner} for automation PRs...")
 
     # NOTE: the token permission check is deferred until *after*
     # enumeration (see below).  ``_check_merge_permissions`` probes a
@@ -1546,9 +1581,7 @@ def _handle_org_merge(
     if scan_errors:
         error_count = len(scan_errors)
         repo_noun = "repository" if error_count == 1 else "repositories"
-        console.print(
-            f"\n⚠️ {error_count} {repo_noun} could not be scanned:"
-        )
+        console.print(f"\n⚠️ {error_count} {repo_noun} could not be scanned:")
         for err in scan_errors:
             console.print(f"   - {err}")
 
@@ -1570,7 +1603,7 @@ def _handle_org_merge(
     # per-repo permission variance with fine-grained tokens is caught at
     # merge time by the scheduler's per-repository error isolation.
     ctx.repo_name = owner_prs[0].repository_full_name.split("/", 1)[-1]
-    _check_merge_permissions(ctx)
+    _maybe_check_merge_permissions(ctx)
 
     # --- Classify PRs as automation vs human ---
     # Delegated to the shared bot-identity predicate (see _handle_repo_merge).
@@ -1601,7 +1634,7 @@ def _handle_org_merge(
     _print_prs_grouped_by_repo(owner_prs)
 
     # --- Human PR confirmation gate ---
-    needs_human_confirm = bool(human_prs) and not ctx.no_confirm
+    needs_human_confirm = bool(human_prs) and not ctx.no_confirm and not ctx.dry_run
     if needs_human_confirm:
         console.print(
             "\n⚠️ Human-authored PRs across the entire owner "
@@ -1626,6 +1659,15 @@ def _handle_org_merge(
                     return
         except (KeyboardInterrupt, EOFError, typer.Abort):
             console.print("\n❌ Merge cancelled by user.")
+            return
+    elif human_prs and ctx.dry_run:
+        console.print(
+            "\nℹ️ Dry run: excluding human-authored PRs "
+            "(a real run would prompt before including them)."
+        )
+        owner_prs = automation_prs
+        if not owner_prs:
+            console.print("❌ No automation PRs remain to merge.")
             return
 
     # --- Build the merge list (ComparisonResult is None for owner mode) ---
@@ -1653,7 +1695,7 @@ def _handle_org_merge(
         merge_results = _run_parallel_merge(
             ctx,
             all_prs_to_merge,
-            preview=not ctx.no_confirm,
+            preview=ctx.dry_run or not ctx.no_confirm,
             concurrency=concurrency,
             # Owner-wide batches mix many repositories and often contain
             # multiple PRs per repository; stripe to avoid stacking and
@@ -1670,6 +1712,11 @@ def _handle_org_merge(
         return
 
     merged_count = sum(1 for r in merge_results if r.status.value == "merged")
+
+    # Dry run: report the preview and stop before any prompt or merge.
+    if ctx.dry_run:
+        _display_merge_results(merge_results, no_confirm=False)
+        return
 
     if not ctx.no_confirm:
         _handle_org_preview_confirmation(
@@ -1801,6 +1848,7 @@ def _handle_gerrit_merge(
     no_netrc: bool = False,
     netrc_file: Path | None = None,
     netrc_optional: bool = True,
+    dry_run: bool = False,
 ) -> None:
     """
     Handle merge operation for a Gerrit change URL.
@@ -1814,6 +1862,8 @@ def _handle_gerrit_merge(
         no_netrc: If True, skip .netrc credential lookup.
         netrc_file: Explicit path to a .netrc file.
         netrc_optional: If True, don't fail if netrc not found.
+        dry_run: If True, preview only and never review or submit any
+            change, even when ``no_confirm`` is also set.
     """
     # Resolve Gerrit credentials from all sources using centralized function
     try:
@@ -1951,10 +2001,12 @@ def _handle_gerrit_merge(
                 "succeed on some changes."
             )
 
-        if not no_confirm:
+        if not no_confirm or dry_run:
             # Preview mode - show permission status
+            label = "Dry run" if dry_run else "Preview"
             console.print(
-                f"\n📊 Preview: {len(all_changes)} changes would be reviewed and submitted"
+                f"\n📊 {label}: {len(all_changes)} changes would be "
+                "reviewed and submitted"
             )
             if source_change.has_required_permissions():
                 console.print(
@@ -1964,7 +2016,10 @@ def _handle_gerrit_merge(
                 console.print(
                     "   ⚠️ You may not have all required permissions (see warnings above)"
                 )
-            console.print("\nTo proceed, run with --no-confirm flag")
+            if dry_run:
+                console.print("\n🧪 Dry run: no changes were reviewed or submitted.")
+            else:
+                console.print("\nTo proceed, run with --no-confirm flag")
             return
 
         # Create submit manager and submit changes
@@ -2144,6 +2199,16 @@ def merge(
         "--include-human-prs",
         help="Include human-authored PRs when merging a repository (prompts for confirmation when human PRs are found)",
     ),
+    dry_run: bool = typer.Option(
+        False,
+        "--dry-run",
+        help=(
+            "Analyze and preview only: never approve, merge, rebase, or "
+            "close anything. Skips the write-permission pre-flight so it "
+            "runs under a read-only token (e.g. in CI). Implies "
+            "preview-only and suppresses confirmation prompts."
+        ),
+    ),
 ):
     """
     Bulk approve/merge pull requests or Gerrit changes.
@@ -2318,6 +2383,7 @@ def merge(
             no_netrc=no_netrc,
             netrc_file=netrc_file,
             netrc_optional=netrc_optional,
+            dry_run=dry_run,
         )
         return
 
@@ -2344,6 +2410,7 @@ def merge(
             github2gerrit_mode=github2gerrit_mode,
             include_human_prs=include_human_prs,
             rebase_local=rebase_local,
+            dry_run=dry_run,
         )
         try:
             _handle_org_merge(parsed_org, org_ctx)
@@ -2412,6 +2479,7 @@ def merge(
             github2gerrit_mode=github2gerrit_mode,
             include_human_prs=include_human_prs,
             rebase_local=rebase_local,
+            dry_run=dry_run,
         )
         try:
             _handle_repo_merge(parsed_repo, repo_ctx)
@@ -2480,12 +2548,13 @@ def merge(
         github2gerrit_mode=github2gerrit_mode,
         include_human_prs=include_human_prs,
         rebase_local=rebase_local,
+        dry_run=dry_run,
     )
 
     try:
         _init_github_merge(ctx)
         _fetch_and_validate_source_pr(ctx)
-        _check_merge_permissions(ctx)
+        _maybe_check_merge_permissions(ctx)
 
         # Debug matching info for source PR
         if ctx.debug_matching:
@@ -2497,7 +2566,7 @@ def merge(
         # Scan org and find similar PRs
         _scan_and_find_similar(ctx)
 
-        if not ctx.no_confirm:
+        if not ctx.no_confirm or ctx.dry_run:
             console.print("\n🔍 Dependamerge Evaluation\n")
 
         # Build full list and run parallel merge
@@ -2513,21 +2582,27 @@ def merge(
         # For the real merge (``--no-confirm``) the scan has already
         # stopped the progress tracker; stand up a fresh one so the
         # background wait-status ticker has a live display to update
-        # while PRs sit in the Step 5.5 auto-merge wait.  Preview runs
-        # keep the stopped tracker (one line per PR, no wait loop).
-        if ctx.no_confirm:
+        # while PRs sit in the Step 5.5 auto-merge wait.  Preview and
+        # dry runs keep the stopped tracker (one line per PR, no wait
+        # loop) because they never execute a real merge.
+        if ctx.no_confirm and not ctx.dry_run:
             _restart_merge_progress_tracker(ctx, len(all_prs_to_merge))
         try:
             merge_results = _run_parallel_merge(
                 ctx,
                 all_prs_to_merge,
-                preview=not ctx.no_confirm,
+                preview=ctx.dry_run or not ctx.no_confirm,
                 # No similar-PR list was printed when none were found, so
                 # skip the blank line before the merge banner.
                 leading_blank=bool(ctx.all_similar_prs),
             )
         finally:
-            if ctx.no_confirm and ctx.show_progress and ctx.progress_tracker:
+            if (
+                ctx.no_confirm
+                and not ctx.dry_run
+                and ctx.show_progress
+                and ctx.progress_tracker
+            ):
                 ctx.progress_tracker.stop()
 
         # Process and display results
@@ -2536,6 +2611,13 @@ def merge(
             return
 
         merged_count = sum(1 for r in merge_results if r.status.value == "merged")
+
+        # Dry run: report what *would* happen and stop before any prompt
+        # or real merge.  ``no_confirm=False`` selects the "Would …"
+        # preview phrasing in the results summary.
+        if ctx.dry_run:
+            _display_merge_results(merge_results, no_confirm=False)
+            return
 
         if not ctx.no_confirm:
             _handle_preview_confirmation(
@@ -2672,6 +2754,15 @@ def close(
         False,
         "--debug-matching",
         help="Show detailed scoring information for PR matching",
+    ),
+    dry_run: bool = typer.Option(
+        False,
+        "--dry-run",
+        help=(
+            "Analyze and preview only: never close anything. Suppresses "
+            "the confirmation prompt so it runs unattended under a "
+            "read-only token (e.g. in CI)."
+        ),
     ),
 ):
     """
@@ -2874,6 +2965,34 @@ def close(
                 return await close_manager.close_prs_parallel(pr_tuples)
 
         # Perform preview to check which PRs can be closed
+        if dry_run:
+            # Dry run: evaluate in preview mode and report what *would*
+            # be closed, then stop.  No prompt, no actual close — safe to
+            # run unattended under a read-only token.
+            if progress_tracker:
+                progress_tracker.start()
+                console.print()
+            else:
+                console.print(
+                    f"\n🧪 Dry run: evaluating {len(all_prs_to_close)} "
+                    "pull requests..."
+                )
+
+            close_results = asyncio.run(_close_parallel(all_prs_to_close, True))
+
+            if progress_tracker:
+                progress_tracker.stop()
+                console.print()
+
+            closeable_count = sum(
+                1 for r in close_results if r.status.value == "closed"
+            )
+            console.print(
+                f"\n🧪 Dry run: would close {closeable_count}/"
+                f"{len(all_prs_to_close)} PRs (no changes made)"
+            )
+            return
+
         if not no_confirm:
             if progress_tracker:
                 progress_tracker.start()
@@ -3030,7 +3149,7 @@ def close(
 def status(
     org_input: str = typer.Argument(
         ...,
-        help="GitHub organization name or URL (e.g., 'lfreleng-actions' or 'https://github.com/lfreleng-actions/')",
+        help="GitHub owner (organization or user) name or URL (e.g., 'lfreleng-actions' or 'https://github.com/lfreleng-actions/')",
     ),
     token: str | None = typer.Option(
         None, "--token", help="GitHub token (or set GITHUB_TOKEN env var)"
@@ -3046,19 +3165,24 @@ def status(
     Reports repository statistics for tags, releases and pull requests.
 
     This command will:
-    1. Scan all repositories in the organization
+    1. Scan all repositories owned by the organization or user
     2. Gather tag and release information
     3. Count open and merged pull requests
     4. Identify PRs affecting actions or workflows
 
     Automation tools supported: dependabot, pre-commit.ci
     """
-    # Parse organization name from input (handle both URL and plain name)
-    org_name = org_input.rstrip("/").split("/")[-1]
+    # Parse owner login from input (handles a bare login plus every
+    # GitHub owner URL form, including /orgs/owner/repositories).
+    try:
+        org_name = parse_owner_arg(org_input)
+    except UrlParseError:
+        org_name = ""
     if not org_name:
-        console.print("❌ Invalid GitHub organization name or URL")
+        console.print("❌ Invalid GitHub owner name or URL")
         console.print(
-            "   Expected: 'organization-name' or 'https://github.com/organization-name/'"
+            "   Expected an organization or user account, e.g. "
+            "'owner-name' or 'https://github.com/owner-name/'"
         )
         raise typer.Exit(1)
 
@@ -3070,11 +3194,13 @@ def status(
             progress_tracker = ProgressTracker(org_name, show_pr_stats=False)
             progress_tracker.start()
             if not progress_tracker.rich_available:
-                console.print(f"🔍 Scanning organization: {org_name}")
+                console.print(f"🔍 Scanning owner: {org_name}")
                 console.print("Progress updates will be shown as simple text...")
         else:
-            console.print(f"🔍 Scanning organization: {org_name}")
-            console.print("This may take a few minutes for large organizations...")
+            console.print(f"🔍 Scanning owner: {org_name}")
+            console.print(
+                "This may take a few minutes for owners with many repositories..."
+            )
 
         # Perform the scan
         from .github_service import GitHubService
@@ -3121,7 +3247,7 @@ def status(
 def blocked(
     org_input: str = typer.Argument(
         ...,
-        help="GitHub organization name or URL (e.g., 'lfreleng-actions' or 'https://github.com/lfreleng-actions/')",
+        help="GitHub owner (organization or user) name or URL (e.g., 'lfreleng-actions' or 'https://github.com/lfreleng-actions/')",
     ),
     token: str | None = typer.Option(
         None, "--token", help="GitHub token (or set GITHUB_TOKEN env var)"
@@ -3182,22 +3308,27 @@ def blocked(
     ),
 ):
     """
-    Reports blocked pull requests in a GitHub organization.
+    Reports blocked pull requests in a GitHub organization or user account.
 
     This command will:
-    1. Check all repositories in the organization
+    1. Check all repositories owned by the organization or user
     2. Identify pull requests that cannot be merged
     3. Report blocking reasons (conflicts, failing checks, etc.)
     4. Count unresolved Copilot feedback comments
 
     Standard code review requirements are not considered blocking.
     """
-    # Parse organization name from input (handle both URL and plain name)
-    organization = org_input.rstrip("/").split("/")[-1]
+    # Parse owner login from input (handles a bare login plus every
+    # GitHub owner URL form, including /orgs/owner/repositories).
+    try:
+        organization = parse_owner_arg(org_input)
+    except UrlParseError:
+        organization = ""
     if not organization:
-        console.print("❌ Invalid GitHub organization name or URL")
+        console.print("❌ Invalid GitHub owner name or URL")
         console.print(
-            "   Expected: 'organization-name' or 'https://github.com/organization-name/'"
+            "   Expected an organization or user account, e.g. "
+            "'owner-name' or 'https://github.com/owner-name/'"
         )
         raise typer.Exit(1)
 
@@ -3210,11 +3341,13 @@ def blocked(
             progress_tracker.start()
             # Check if Rich display is available
             if not progress_tracker.rich_available:
-                console.print(f"🔍 Checking organization: {organization}")
+                console.print(f"🔍 Checking owner: {organization}")
                 console.print("Progress updates will be shown as simple text...")
         else:
-            console.print(f"🔍 Checking organization: {organization}")
-            console.print("This may take a few minutes for large organizations...")
+            console.print(f"🔍 Checking owner: {organization}")
+            console.print(
+                "This may take a few minutes for owners with many repositories..."
+            )
 
         # Perform the scan
         from .github_service import GitHubService
@@ -3354,7 +3487,7 @@ def blocked(
         else:
             exit_with_error(
                 ExitCode.GENERAL_ERROR,
-                message="❌ Error during organization scan",
+                message="❌ Error during owner scan",
                 details=str(e),
                 exception=e,
             )

--- a/src/dependamerge/github_service.py
+++ b/src/dependamerge/github_service.py
@@ -310,47 +310,29 @@ class GitHubService:
     # -------------------------------------------------
 
     async def _iter_org_repositories(self, org: str) -> AsyncIterator[dict[str, Any]]:
-        """Iterate non-archived repositories, setting the progress total on the first page.
+        """Iterate an owner's non-archived repositories (forks included).
 
-        The ``ORG_REPOS_ONLY`` query now returns ``totalCount`` on
-        the ``repositories`` connection, so the very first page
-        gives us an accurate denominator for the progress bar
-        without a separate counting pass.
+        Despite the historical name, this works for both organizations
+        and personal user accounts: the correct GraphQL root
+        (``organization`` vs ``user``) is resolved once at runtime via
+        :meth:`_resolve_owner_root`, so org-wide *read* operations
+        (``status``, ``blocked``, and ``close``'s similar-PR scan) no
+        longer fail with a ``NOT_FOUND`` error when handed a user
+        account.  This mirrors the owner-aware enumeration the merge
+        path already uses via :meth:`_iter_owner_repositories`.
 
-        This replaces the former two-method design
-        (``_count_org_repositories`` + old ``_iter_org_repositories``)
-        with a single GraphQL pagination pass, cutting API calls by
-        roughly one-third for org-wide operations.
+        Unlike :meth:`_iter_owner_repositories`, fork repositories are
+        *not* skipped here: the read-only reporting commands want a
+        complete picture of every repository the owner has, whereas the
+        bulk-merge path deliberately excludes forks.  The progress total
+        is published from the first page's ``totalCount``, which counts
+        *all* of the owner's repositories — including the archived repos
+        this iterator filters out — so the denominator is approximate and
+        the percentage can finish below 100%.  It is close enough for a
+        progress bar.
         """
-        cursor: str | None = None
-        total_set = False
-        while True:
-            variables = {"org": org, "reposCursor": cursor}
-            data = await self._api.graphql(ORG_REPOS_ONLY, variables)
-            repos = (
-                ((data or {}).get("organization") or {}).get("repositories") or {}
-            )
-
-            # On the first page, publish the total to the progress
-            # tracker so the percentage display is immediately
-            # accurate.  totalCount includes archived repos, but
-            # the denominator is close enough for a progress bar.
-            if not total_set:
-                total_count = repos.get("totalCount")
-                if total_count is not None and self._progress:
-                    self._progress.update_total_repositories(total_count)
-                total_set = True
-
-            nodes: list[dict[str, Any]] = repos.get("nodes", []) or []
-            for repo in nodes:
-                if repo.get("isArchived"):
-                    continue
-                yield repo
-
-            page_info = repos.get("pageInfo") or {}
-            if not page_info.get("hasNextPage"):
-                break
-            cursor = page_info.get("endCursor")
+        async for repo in self._iter_owner_repositories(org, skip_forks=False):
+            yield repo
 
     async def _iter_org_repositories_with_open_prs(
         self, org: str
@@ -443,24 +425,24 @@ class GitHubService:
         return "not_found" in msg and "organization" in msg
 
     async def _iter_owner_repositories(
-        self, owner: str
+        self, owner: str, *, skip_forks: bool = True
     ) -> AsyncIterator[dict[str, Any]]:
-        """Iterate an owner's non-archived, non-fork repositories.
+        """Iterate an owner's non-archived repositories.
 
         Works for both organizations and personal user accounts: the
         correct GraphQL root is resolved once via
         :meth:`_resolve_owner_root` and reused for every page.
 
-        Archived repositories are skipped (consistent with
-        :meth:`_iter_org_repositories`).  Fork repositories are also
-        skipped: owner-wide bulk merges target the owner's own
-        automation PRs, not PRs on mirrored forks.  The progress total
-        is published from the first page's ``totalCount``, which counts
+        Archived repositories are always skipped.  Fork repositories are
+        skipped by default (``skip_forks=True``): owner-wide bulk merges
+        target the owner's own automation PRs, not PRs on mirrored
+        forks.  Read-only reporting paths pass ``skip_forks=False`` to
+        include forks for a complete picture.  The progress total is
+        published from the first page's ``totalCount``, which counts
         *all* of the owner's repositories — including the archived and
-        fork repos this iterator filters out — so the denominator is
-        approximate and the percentage can finish below 100%.  It is
-        close enough for a progress bar, matching
-        :meth:`_iter_org_repositories`.
+        (when filtered) fork repos this iterator skips — so the
+        denominator is approximate and the percentage can finish below
+        100%.  It is close enough for a progress bar.
         """
         root_key, query = await self._resolve_owner_root(owner)
         cursor: str | None = None
@@ -481,7 +463,7 @@ class GitHubService:
             for repo in nodes:
                 if repo.get("isArchived"):
                     continue
-                if repo.get("isFork"):
+                if skip_forks and repo.get("isFork"):
                     continue
                 yield repo
 
@@ -728,9 +710,7 @@ class GitHubService:
             base_repo_clone_url=_clone_url_with_git_suffix(
                 (pr.get("baseRepository") or {}).get("url")
             ),
-            is_fork=_bool_or_none(
-                (pr.get("headRepository") or {}).get("isFork")
-            ),
+            is_fork=_bool_or_none((pr.get("headRepository") or {}).get("isFork")),
         )
 
     async def find_similar_prs(
@@ -990,9 +970,7 @@ class GitHubService:
 
         if self._progress:
             self._progress.start_repository(repo_full_name)
-            self._progress.update_operation(
-                f"Fetching open PRs from {repo_full_name}"
-            )
+            self._progress.update_operation(f"Fetching open PRs from {repo_full_name}")
 
         results = await self._collect_repo_open_prs(
             owner, repo, only_automation=only_automation

--- a/src/dependamerge/github_service.py
+++ b/src/dependamerge/github_service.py
@@ -48,6 +48,7 @@ AUTOMATION_TOOLS = [
     "renovate",
     "pre-commit",
     "github-actions",
+    "copilot",
     "[bot]",
 ]
 

--- a/src/dependamerge/url_parser.py
+++ b/src/dependamerge/url_parser.py
@@ -609,6 +609,10 @@ def parse_owner_arg(value: str) -> str:
     # "lfreleng-actions" and the historical "lfreleng-actions/" form keep
     # working.
     bare = value.rstrip("/")
+    if not bare:
+        # The input was only slashes (e.g. "////"); there is no login to
+        # extract, so treat it the same as an empty value.
+        raise UrlParseError("Owner name or URL cannot be empty")
     if "/" not in bare and "://" not in bare:
         return bare
 

--- a/src/dependamerge/url_parser.py
+++ b/src/dependamerge/url_parser.py
@@ -561,6 +561,60 @@ def parse_org_url(url: str) -> ParsedOrgUrl:
     )
 
 
+def parse_owner_arg(value: str) -> str:
+    """Extract an owner login from a CLI argument.
+
+    The owner-wide *report* commands (``status`` and ``blocked``) accept
+    either a bare login or any of the GitHub owner URL forms that
+    :func:`parse_org_url` understands.  This single helper normalises all
+    of them to a plain login so the commands no longer rely on a naive
+    ``split("/")[-1]`` that silently mis-parses the canonical
+    ``/orgs/owner/repositories`` form (it would return ``repositories``).
+
+    Accepted inputs:
+        owner
+        owner/
+        https://github.com/owner
+        https://github.com/owner/
+        github.com/owner
+        https://github.com/orgs/owner
+        https://github.com/orgs/owner/repositories
+
+    A bare token — optionally with one or more trailing slashes but no
+    other path separator and no scheme — is treated as a login and
+    returned verbatim (minus the trailing slashes).  This preserves the
+    long-standing ability to pass just an organization/user name, and to
+    pass ``owner/`` (the ``status``/``blocked`` commands historically
+    accepted a trailing slash via ``rstrip("/")``).  Anything that still
+    looks like a URL (an embedded ``/`` or a scheme) is delegated to
+    :func:`parse_org_url`, which enforces the github.com-only guard and
+    the canonical forms.
+
+    Args:
+        value: The raw CLI argument.
+
+    Returns:
+        The extracted owner login.
+
+    Raises:
+        UrlParseError: If ``value`` is empty or is a URL that is not a
+            recognised github.com owner URL.
+    """
+    value = (value or "").strip()
+    if not value:
+        raise UrlParseError("Owner name or URL cannot be empty")
+
+    # A bare login has no scheme and no embedded path separator once any
+    # trailing slashes are removed; accept it as-is so plain names like
+    # "lfreleng-actions" and the historical "lfreleng-actions/" form keep
+    # working.
+    bare = value.rstrip("/")
+    if "/" not in bare and "://" not in bare:
+        return bare
+
+    return parse_org_url(value).owner
+
+
 def derive_api_urls(host: str) -> tuple[str, str]:
     """Derive the (REST, GraphQL) API base URLs for a GitHub host.
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -73,10 +73,60 @@ See Also
 
 from __future__ import annotations
 
+import os
 from typing import Any
 from unittest.mock import AsyncMock
 
+import pytest
+
 from dependamerge.merge_manager import AsyncMergeManager
+
+_RUN_INTEGRATION_ENV = "DEPENDAMERGE_RUN_INTEGRATION"
+
+
+def pytest_addoption(parser: pytest.Parser) -> None:
+    """Register the ``--run-integration`` opt-in flag.
+
+    Live integration tests (see ``tests/integration``) hit real GitHub /
+    Gerrit servers.  They already self-skip when credentials are absent,
+    but they must not run as part of the ordinary unit-test suite even
+    when a token happens to be present in the environment, because they
+    are slow and network-dependent.  They run only when explicitly
+    requested via ``--run-integration`` or the
+    ``DEPENDAMERGE_RUN_INTEGRATION`` environment variable.
+    """
+    parser.addoption(
+        "--run-integration",
+        action="store_true",
+        default=False,
+        help="Run live GitHub/Gerrit integration tests (marked 'integration').",
+    )
+
+
+def _integration_enabled(config: pytest.Config) -> bool:
+    if config.getoption("--run-integration"):
+        return True
+    return os.environ.get(_RUN_INTEGRATION_ENV, "").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
+
+
+def pytest_collection_modifyitems(
+    config: pytest.Config, items: list[pytest.Item]
+) -> None:
+    """Skip ``integration`` tests unless explicitly opted in."""
+    if _integration_enabled(config):
+        return
+    skip_integration = pytest.mark.skip(
+        reason="integration tests disabled (pass --run-integration or set "
+        f"{_RUN_INTEGRATION_ENV}=1)"
+    )
+    for item in items:
+        if "integration" in item.keywords:
+            item.add_marker(skip_integration)
 
 
 def make_merge_manager(**overrides: Any) -> tuple[AsyncMergeManager, AsyncMock]:

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 The Linux Foundation

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,206 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 The Linux Foundation
+
+"""Shared fixtures and helpers for the live integration test suite.
+
+Every test in :mod:`tests.integration` is marked ``integration`` and is
+designed to *fail safe*: it runs the real ``dependamerge`` CLI against
+live GitHub / Gerrit servers in **dry-run** mode, and skips cleanly when
+the credentials or target conditions it needs are absent.  This makes the
+suite safe to wire into CI on pull requests with read-only tokens without
+ever mutating a repository.
+
+Configuration is entirely environment-driven so CI and local runs can
+point the tests at different targets without code changes:
+
+GitHub:
+    GITHUB_TOKEN            Required.  A read-only token is sufficient;
+                            the dry-run paths never need write scopes.
+    DEPENDAMERGE_IT_ORG     Organization login to exercise the
+                            "organization account" path against.
+                            Default: ``lfreleng-actions``.
+    DEPENDAMERGE_IT_USER    User login to exercise the "personal
+                            account" path against (the case that
+                            regressed in v0.7.0).
+                            Default: ``ModeSevenIndustrialSolutions``.
+
+Gerrit (all optional; the Gerrit tests skip unless host + creds exist):
+    DEPENDAMERGE_IT_GERRIT_HOST   Gerrit hostname (e.g. ``gerrit.onap.org``).
+    DEPENDAMERGE_IT_GERRIT_BASE_PATH   Optional URL base path when the
+                            server is not mounted at the root
+                            (e.g. ``r`` for ``https://gerrit.onap.org/r/``).
+    GERRIT_USERNAME / GERRIT_PASSWORD   HTTP credentials.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from collections.abc import Iterator
+
+import pytest
+from typer.testing import CliRunner
+
+# Default targets.  ``ModeSevenIndustrialSolutions`` is intentionally a
+# *personal* account (not an organization): it is the exact login whose
+# owner-wide report commands regressed in v0.7.0, so keeping it as the
+# default user target guards against that specific class of bug.
+DEFAULT_ORG = "lfreleng-actions"
+DEFAULT_USER = "ModeSevenIndustrialSolutions"
+
+
+def _env(name: str, default: str) -> str:
+    value = os.environ.get(name, "").strip()
+    return value or default
+
+
+@pytest.fixture(scope="session")
+def github_token() -> str:
+    """Return a GitHub token or skip the whole GitHub integration suite."""
+    token = os.environ.get("GITHUB_TOKEN", "").strip()
+    if not token:
+        pytest.skip("GITHUB_TOKEN not set; skipping live GitHub integration test")
+    return token
+
+
+@pytest.fixture(scope="session")
+def integration_org() -> str:
+    """Login of the organization account to exercise."""
+    return _env("DEPENDAMERGE_IT_ORG", DEFAULT_ORG)
+
+
+@pytest.fixture(scope="session")
+def integration_user() -> str:
+    """Login of the personal (non-organization) account to exercise."""
+    return _env("DEPENDAMERGE_IT_USER", DEFAULT_USER)
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    """A fresh Typer ``CliRunner`` per test.
+
+    Click 8.2 removed the ``mix_stderr`` option, so ``result.output``
+    holds only stdout and stderr is captured separately on
+    ``result.stderr``.  The CLI's report and dry-run output is written
+    through a Rich console to stdout, but tests should still consult both
+    streams (see :func:`combined_output`) so an unexpected message routed
+    to stderr is never silently missed.
+    """
+    return CliRunner()
+
+
+def combined_output(result) -> str:
+    """Return a result's stdout and stderr joined into one string.
+
+    Guards assertions against Click 8.2+ splitting the streams: relevant
+    output normally lands on stdout, but combining both makes the checks
+    robust regardless of which stream a given line uses.
+    """
+    parts = [result.output or ""]
+    try:
+        stderr = result.stderr
+    except (ValueError, AttributeError):
+        # stderr may be unavailable (e.g. not separately captured).
+        stderr = ""
+    if stderr:
+        parts.append(stderr)
+    return "".join(parts)
+
+
+def discover_automation_pr(owner: str, token: str) -> str | None:
+    """Find one open automation PR under ``owner``, or ``None``.
+
+    Automation PRs (dependabot, pre-commit.ci, ...) come and go in the
+    target spaces, so the integration tests must *discover* a live one
+    rather than hard-code a URL that will rot.  This reuses the very same
+    owner-wide enumeration the ``merge`` command relies on, so it also
+    transitively exercises the owner-resolution fix for both org and user
+    accounts.
+
+    Args:
+        owner: Organization or user login to scan.
+        token: GitHub token.
+
+    Returns:
+        The ``html_url`` of an open automation PR, or ``None`` if the
+        owner currently has no open automation PRs (a normal, transient
+        condition the caller should treat as "skip, do not fail").
+    """
+    from dependamerge.github_service import GitHubService
+
+    async def _find() -> str | None:
+        service = GitHubService(token=token)
+        try:
+            prs, _errors = await service.fetch_owner_open_prs(
+                owner, only_automation=True
+            )
+        finally:
+            await service.close()
+        for pr in prs:
+            if pr.html_url:
+                return pr.html_url
+        return None
+
+    return asyncio.run(_find())
+
+
+@pytest.fixture(scope="session")
+def automation_pr_url(github_token: str, integration_user: str, integration_org: str):
+    """Discover a live open automation PR URL, or skip the test.
+
+    Searches the personal account first (its automation PRs are the
+    motivating case for this work) and falls back to the organization.
+    Skips with a clear message when neither space currently has an open
+    automation PR so the suite never fails on an empty target.
+    """
+    for owner in (integration_user, integration_org):
+        url = discover_automation_pr(owner, github_token)
+        if url:
+            return url
+    pytest.skip(
+        "No open automation PRs found in "
+        f"'{integration_user}' or '{integration_org}'; "
+        "skipping dynamic PR integration test"
+    )
+
+
+def gerrit_config() -> dict[str, str] | None:
+    """Return Gerrit connection settings from the environment, or ``None``.
+
+    Requires a host plus HTTP credentials; returns ``None`` (caller
+    should skip) when any piece is missing so the Gerrit integration
+    tests stay dormant in environments without Gerrit access.
+    """
+    host = os.environ.get("DEPENDAMERGE_IT_GERRIT_HOST", "").strip()
+    base_path = os.environ.get("DEPENDAMERGE_IT_GERRIT_BASE_PATH", "").strip()
+    username = (
+        os.environ.get("GERRIT_USERNAME", "").strip()
+        or os.environ.get("GERRIT_HTTP_USER", "").strip()
+    )
+    password = (
+        os.environ.get("GERRIT_PASSWORD", "").strip()
+        or os.environ.get("GERRIT_HTTP_PASSWORD", "").strip()
+    )
+    if not (host and username and password):
+        return None
+    return {
+        "host": host,
+        "base_path": base_path,
+        "username": username,
+        "password": password,
+    }
+
+
+@pytest.fixture
+def gerrit_settings() -> Iterator[dict[str, str]]:
+    """Yield Gerrit settings or skip when Gerrit access is not configured."""
+    config = gerrit_config()
+    if config is None:
+        pytest.skip(
+            "Gerrit not configured (need DEPENDAMERGE_IT_GERRIT_HOST + "
+            "GERRIT_USERNAME/GERRIT_PASSWORD); skipping Gerrit integration test"
+        )
+    # ``pytest.skip`` raises, so ``config`` is non-None here; assert it so
+    # the type checker narrows the Optional before the yield.
+    assert config is not None
+    yield config

--- a/tests/integration/test_live_gerrit.py
+++ b/tests/integration/test_live_gerrit.py
@@ -1,0 +1,73 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 The Linux Foundation
+
+"""Live Gerrit integration test for the ``dependamerge`` CLI.
+
+Mirrors the GitHub dry-run integration test for the Gerrit code path: it
+dynamically discovers an open change on a live Gerrit server and runs
+``merge --dry-run`` against it, asserting that nothing was reviewed or
+submitted.
+
+The test fails safe.  It skips (never fails) when Gerrit is not configured
+(see :func:`tests.integration.conftest.gerrit_config`) or when the server
+currently has no open changes, so it is safe in CI and on contributor
+machines without Gerrit access.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from dependamerge.cli import app
+
+from .conftest import combined_output
+
+pytestmark = pytest.mark.integration
+
+
+def _discover_open_change_url(settings: dict[str, str]) -> str | None:
+    """Return the web URL of one open change, or ``None`` if none exist."""
+    from dependamerge.gerrit.service import create_gerrit_service
+
+    service = create_gerrit_service(
+        host=settings["host"],
+        base_path=settings.get("base_path") or None,
+        username=settings["username"],
+        password=settings["password"],
+    )
+    # A small limit keeps the probe cheap; we only need one usable change.
+    changes = service.get_all_open_changes(limit=25)
+    for change in changes:
+        if change.url:
+            return change.url
+    return None
+
+
+class TestGerritDryRunLive:
+    def test_merge_dry_run_previews_without_submitting(self, runner, gerrit_settings):
+        """`merge --dry-run` previews a real Gerrit change without submitting.
+
+        Discovers a live open change and confirms the dry-run path reports
+        a preview and never reviews or submits anything.  Skips when the
+        server has no open changes so the suite never fails on an empty
+        target.
+        """
+        change_url = _discover_open_change_url(gerrit_settings)
+        if not change_url:
+            pytest.skip(
+                f"No open changes found on '{gerrit_settings['host']}'; "
+                "skipping Gerrit dry-run integration test"
+            )
+
+        result = runner.invoke(
+            app,
+            ["merge", change_url, "--dry-run", "--no-progress"],
+            env={
+                "GERRIT_USERNAME": gerrit_settings["username"],
+                "GERRIT_PASSWORD": gerrit_settings["password"],
+            },
+        )
+        assert result.exit_code == 0, combined_output(result)
+        assert "Dry run: no changes were reviewed or submitted" in combined_output(
+            result
+        )

--- a/tests/integration/test_live_github.py
+++ b/tests/integration/test_live_github.py
@@ -1,0 +1,167 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 The Linux Foundation
+
+"""Live GitHub integration tests for the ``dependamerge`` CLI.
+
+These tests run the real CLI (in-process, via Typer's ``CliRunner``)
+against live GitHub, exercising the read-only report commands and the
+dry-run write commands.  They never mutate anything: the report commands
+are read-only by nature and the ``merge`` / ``close`` invocations all use
+``--dry-run``, which previews without approving, merging, rebasing or
+closing and skips the write-permission pre-flight so a read-only token
+suffices.
+
+The suite is the regression guard for the v0.7.0 defect where the
+owner-wide report commands assumed an *organization* and failed against a
+*personal* account with::
+
+    Could not resolve to an Organization with the login of '<user>'
+
+so every report-command assertion explicitly checks that this error did
+not resurface.
+
+All tests fail safe: they skip (never fail) when ``GITHUB_TOKEN`` is
+absent or when the target space currently has no open automation PRs.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from dependamerge.cli import app
+
+from .conftest import combined_output
+
+pytestmark = pytest.mark.integration
+
+# The exact GitHub GraphQL error fragment emitted by the v0.7.0 bug when a
+# personal account was treated as an organization.  Any report command
+# that resolves the owner correctly must never surface this.
+_ORG_RESOLUTION_ERROR = "Could not resolve to an Organization"
+
+
+# Owner-argument forms the CLI must accept, as ``str.format`` templates
+# with an ``{owner}`` placeholder.  Defined at module scope so the
+# parametrization below iterates the templates directly — there is no
+# hand-maintained index range that can drift out of sync with the list
+# and silently drop a form (the exact ``/orgs/<owner>/repositories`` form
+# that motivated the parsing fix).  Covers the bare login, a bare login
+# with a trailing slash, the bare and trailing-slash URLs, the
+# scheme-less host, and the canonical ``/orgs`` forms.
+OWNER_URL_TEMPLATES = [
+    "{owner}",
+    "{owner}/",
+    "https://github.com/{owner}",
+    "https://github.com/{owner}/",
+    "github.com/{owner}",
+    "https://github.com/orgs/{owner}",
+    "https://github.com/orgs/{owner}/repositories",
+]
+
+
+def _assert_owner_resolved(result, owner: str) -> None:
+    """Assert a report command resolved ``owner`` without the org bug."""
+    output = combined_output(result)
+    assert _ORG_RESOLUTION_ERROR not in output, (
+        f"owner '{owner}' was mis-resolved as an organization:\n{output}"
+    )
+    assert result.exit_code == 0, (
+        f"status/blocked exited {result.exit_code} for owner '{owner}':\n{output}"
+    )
+
+
+class TestStatusCommandLive:
+    """`status` must work for both org and user accounts, every URL form."""
+
+    @pytest.mark.parametrize("url_template", OWNER_URL_TEMPLATES)
+    def test_status_user_account_all_url_forms(
+        self, runner, github_token, integration_user, url_template
+    ):
+        """`status` resolves a *personal* account across every URL form.
+
+        This is the direct regression for the reported v0.7.0 failure.
+        The personal account is intentionally the bounded target so all
+        URL forms can be exercised cheaply.
+        """
+        url = url_template.format(owner=integration_user)
+        result = runner.invoke(
+            app,
+            ["status", url, "--no-progress", "--token", github_token],
+        )
+        _assert_owner_resolved(result, integration_user)
+
+    def test_status_organization_account(self, runner, github_token, integration_org):
+        """`status` resolves a genuine *organization* account.
+
+        Run once against the canonical bare login: the org path is the
+        slower target, and URL-form parsing is target-independent (already
+        covered exhaustively against the user account above).
+        """
+        result = runner.invoke(
+            app,
+            ["status", integration_org, "--no-progress", "--token", github_token],
+        )
+        _assert_owner_resolved(result, integration_org)
+
+
+class TestBlockedCommandLive:
+    """`blocked` shares the owner-resolution path; verify both account types."""
+
+    def test_blocked_user_account(self, runner, github_token, integration_user):
+        result = runner.invoke(
+            app,
+            ["blocked", integration_user, "--no-progress", "--token", github_token],
+        )
+        _assert_owner_resolved(result, integration_user)
+
+    def test_blocked_organization_account(self, runner, github_token, integration_org):
+        result = runner.invoke(
+            app,
+            ["blocked", integration_org, "--no-progress", "--token", github_token],
+        )
+        _assert_owner_resolved(result, integration_org)
+
+
+class TestDryRunWriteCommandsLive:
+    """`merge`/`close` dry-run against a dynamically discovered live PR."""
+
+    def test_merge_dry_run_previews_without_merging(
+        self, runner, github_token, automation_pr_url
+    ):
+        """`merge --dry-run` previews a real PR under a read-only token.
+
+        Asserts the permission pre-flight was skipped (the change that
+        unblocked read-only testing) and that the command completed
+        successfully without attempting a merge.
+        """
+        result = runner.invoke(
+            app,
+            [
+                "merge",
+                automation_pr_url,
+                "--dry-run",
+                "--no-progress",
+                "--token",
+                github_token,
+            ],
+        )
+        assert result.exit_code == 0, combined_output(result)
+        assert "Dry run: skipping token permission check" in combined_output(result)
+
+    def test_close_dry_run_previews_without_closing(
+        self, runner, github_token, automation_pr_url
+    ):
+        """`close --dry-run` previews matching PRs without closing them."""
+        result = runner.invoke(
+            app,
+            [
+                "close",
+                automation_pr_url,
+                "--dry-run",
+                "--no-progress",
+                "--token",
+                github_token,
+            ],
+        )
+        assert result.exit_code == 0, combined_output(result)
+        assert "Dry run: would close" in combined_output(result)

--- a/tests/test_bot_identity.py
+++ b/tests/test_bot_identity.py
@@ -83,6 +83,8 @@ class TestIsCopilot:
             "copilot[bot]",
             "github-copilot",
             "github-copilot[bot]",
+            "copilot-swe-agent",
+            "copilot-swe-agent[bot]",
             "copilot-pull-request-reviewer",
         ],
     )
@@ -110,8 +112,11 @@ class TestIsAutomationAuthor:
             "dependabot",
             "renovate",
             "github-actions",
-            # Copilot is automation too.
+            # Copilot is automation too, including the coding agent that
+            # raises automated code fixes in either login form.
             "github-copilot[bot]",
+            "copilot-swe-agent[bot]",
+            "copilot-swe-agent",
             # Unknown bot caught by the [bot] fallthrough.
             "some-future-bot[bot]",
         ],

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -911,3 +911,262 @@ class TestRestartMergeProgressTracker:
         # ``--no-progress`` keeps the tracker absent; the plain-text
         # ticker provides feedback instead.
         assert ctx.progress_tracker is None
+
+
+class TestMergeDryRun:
+    """``merge --dry-run`` previews without writing or checking scopes.
+
+    Dry run is the mode the CI test matrix uses: it must run under a
+    read-only token (so the write-permission pre-flight is skipped) and
+    must never execute a real merge (so ``_run_parallel_merge`` is always
+    asked for a preview).
+    """
+
+    def setup_method(self):
+        self.runner = CliRunner()
+
+    @patch("dependamerge.cli._run_parallel_merge")
+    @patch("dependamerge.cli._check_merge_permissions")
+    @patch("dependamerge.cli.GitHubClient")
+    @patch("dependamerge.cli.PRComparator")
+    @patch("dependamerge.github_service.GitHubService")
+    def test_dry_run_skips_permission_check_and_previews(
+        self,
+        mock_service_class,
+        mock_comparator_class,
+        mock_client_class,
+        mock_check,
+        mock_run_parallel,
+    ):
+        from dependamerge.merge_manager import MergeResult, MergeStatus
+
+        mock_client = Mock()
+        mock_client_class.return_value = mock_client
+        mock_comparator_class.return_value = Mock()
+        mock_service = Mock()
+        mock_service_class.return_value = mock_service
+
+        mock_client.parse_pr_url.return_value = ("owner", "repo", 22)
+        mock_client.is_automation_author.return_value = True
+        mock_client.get_pr_status_details.return_value = "Ready to merge"
+
+        source_pr = PullRequestInfo(
+            number=22,
+            title="Chore: Bump actions/checkout from 4 to 5",
+            body="Bumps actions/checkout",
+            author="dependabot[bot]",
+            head_sha="abc123",
+            base_branch="main",
+            head_branch="dependabot/github_actions/actions/checkout-5",
+            state="open",
+            mergeable=True,
+            mergeable_state="clean",
+            behind_by=0,
+            files_changed=[],
+            repository_full_name="owner/repo",
+            html_url="https://github.com/owner/repo/pull/22",
+        )
+        mock_client.get_pull_request_info.return_value = source_pr
+
+        async def mock_find_similar_prs(*args, **kwargs):
+            return []
+
+        async def mock_close():
+            return None
+
+        mock_service.find_similar_prs = mock_find_similar_prs
+        mock_service.close = mock_close
+
+        captured: dict[str, object] = {}
+
+        def _capture(ctx, prs, *, preview, **kwargs):
+            captured["preview"] = preview
+            return [MergeResult(pr_info=source_pr, status=MergeStatus.MERGED)]
+
+        mock_run_parallel.side_effect = _capture
+
+        result = self.runner.invoke(
+            app,
+            [
+                "merge",
+                "--dry-run",
+                "https://github.com/owner/repo/pull/22",
+                "--token",
+                "test_token",
+            ],
+        )
+
+        assert result.exit_code == 0, result.stdout
+        # The write-permission pre-flight must be skipped under dry run.
+        mock_check.assert_not_called()
+        # The merge must run in preview mode (no real merge).
+        assert captured.get("preview") is True
+        assert "Dry run" in result.stdout
+
+    @patch("dependamerge.cli._run_parallel_merge")
+    @patch("dependamerge.cli._check_merge_permissions")
+    @patch("dependamerge.cli.GitHubClient")
+    @patch("dependamerge.cli.PRComparator")
+    @patch("dependamerge.github_service.GitHubService")
+    def test_dry_run_forces_preview_even_with_no_confirm(
+        self,
+        mock_service_class,
+        mock_comparator_class,
+        mock_client_class,
+        mock_check,
+        mock_run_parallel,
+    ):
+        """``--dry-run --no-confirm`` must still preview, never merge."""
+        from dependamerge.merge_manager import MergeResult, MergeStatus
+
+        mock_client = Mock()
+        mock_client_class.return_value = mock_client
+        mock_comparator_class.return_value = Mock()
+        mock_service = Mock()
+        mock_service_class.return_value = mock_service
+
+        mock_client.parse_pr_url.return_value = ("owner", "repo", 22)
+        mock_client.is_automation_author.return_value = True
+        mock_client.get_pr_status_details.return_value = "Ready to merge"
+
+        source_pr = PullRequestInfo(
+            number=22,
+            title="Chore: Bump actions/checkout from 4 to 5",
+            body="Bumps actions/checkout",
+            author="dependabot[bot]",
+            head_sha="abc123",
+            base_branch="main",
+            head_branch="dependabot/github_actions/actions/checkout-5",
+            state="open",
+            mergeable=True,
+            mergeable_state="clean",
+            behind_by=0,
+            files_changed=[],
+            repository_full_name="owner/repo",
+            html_url="https://github.com/owner/repo/pull/22",
+        )
+        mock_client.get_pull_request_info.return_value = source_pr
+
+        async def mock_find_similar_prs(*args, **kwargs):
+            return []
+
+        async def mock_close():
+            return None
+
+        mock_service.find_similar_prs = mock_find_similar_prs
+        mock_service.close = mock_close
+
+        captured: dict[str, object] = {}
+
+        def _capture(ctx, prs, *, preview, **kwargs):
+            captured["preview"] = preview
+            return [MergeResult(pr_info=source_pr, status=MergeStatus.MERGED)]
+
+        mock_run_parallel.side_effect = _capture
+
+        result = self.runner.invoke(
+            app,
+            [
+                "merge",
+                "--dry-run",
+                "--no-confirm",
+                "https://github.com/owner/repo/pull/22",
+                "--token",
+                "test_token",
+            ],
+        )
+
+        assert result.exit_code == 0, result.stdout
+        mock_check.assert_not_called()
+        assert captured.get("preview") is True
+        assert "Dry run" in result.stdout
+
+
+class TestCloseDryRun:
+    """``close --dry-run`` previews without closing and without prompting."""
+
+    def setup_method(self):
+        self.runner = CliRunner()
+
+    @patch("dependamerge.cli.AsyncCloseManager")
+    @patch("dependamerge.cli.GitHubClient")
+    @patch("dependamerge.cli.PRComparator")
+    @patch("dependamerge.github_service.GitHubService")
+    def test_close_dry_run_previews_without_closing(
+        self,
+        mock_service_class,
+        mock_comparator_class,
+        mock_client_class,
+        mock_close_manager_class,
+    ):
+        from dependamerge.close_manager import CloseResult, CloseStatus
+
+        mock_client = Mock()
+        mock_client_class.return_value = mock_client
+        mock_client.token = "test_token"
+        mock_comparator_class.return_value = Mock()
+        mock_service = Mock()
+        mock_service_class.return_value = mock_service
+
+        mock_client.parse_pr_url.return_value = ("owner", "repo", 22)
+        mock_client.is_automation_author.return_value = True
+        mock_client.get_pr_status_details.return_value = "Ready to merge"
+
+        source_pr = PullRequestInfo(
+            number=22,
+            title="Chore: Bump actions/checkout from 4 to 5",
+            body="Bumps actions/checkout",
+            author="dependabot[bot]",
+            head_sha="abc123",
+            base_branch="main",
+            head_branch="dependabot/github_actions/actions/checkout-5",
+            state="open",
+            mergeable=True,
+            mergeable_state="clean",
+            behind_by=0,
+            files_changed=[],
+            repository_full_name="owner/repo",
+            html_url="https://github.com/owner/repo/pull/22",
+        )
+        mock_client.get_pull_request_info.return_value = source_pr
+
+        async def mock_find_similar_prs(*args, **kwargs):
+            return []
+
+        async def mock_close():
+            return None
+
+        mock_service.find_similar_prs = mock_find_similar_prs
+        mock_service.close = mock_close
+
+        captured: dict[str, object] = {}
+
+        # Stub the async context-manager close manager so we can assert
+        # it is only ever asked to *preview* (never to actually close).
+        close_manager = AsyncMock()
+        close_manager.close_prs_parallel = AsyncMock(
+            return_value=[CloseResult(pr_info=source_pr, status=CloseStatus.CLOSED)]
+        )
+
+        def _capture_close_manager(*args, **kwargs):
+            captured["preview_mode"] = kwargs.get("preview_mode")
+            return close_manager
+
+        mock_close_manager_class.side_effect = _capture_close_manager
+
+        result = self.runner.invoke(
+            app,
+            [
+                "close",
+                "--dry-run",
+                "--no-progress",
+                "https://github.com/owner/repo/pull/22",
+                "--token",
+                "test_token",
+            ],
+        )
+
+        assert result.exit_code == 0, result.stdout
+        assert "Dry run" in result.stdout
+        # The close manager must have been constructed in preview mode.
+        assert captured.get("preview_mode") is True

--- a/tests/test_owner_account_resolution.py
+++ b/tests/test_owner_account_resolution.py
@@ -1,0 +1,293 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 The Linux Foundation
+
+"""Regression tests for owner-wide commands against personal user accounts.
+
+The owner-wide *read* commands (``status``, ``blocked``, and the
+similar-PR scan behind ``close``) historically assumed the owner login
+resolved to a GitHub *organization*.  When handed a personal user
+account, the GraphQL ``organization(login:)`` root resolves to null and
+GitHub returns a ``NOT_FOUND`` error, which aborted the whole scan with::
+
+    Could not resolve to an Organization with the login of '<user>'.
+
+The merge command never hit this because it enumerates repositories via
+:meth:`GitHubService._iter_owner_repositories`, which probes
+``organization`` first and falls back to ``user``.  These tests lock in
+the fix that routes the read commands through the same owner-aware
+enumeration, so a regression that re-introduces the org-only assumption
+fails fast in CI rather than in production.
+
+The GraphQL transport is mocked to emulate the org→user fallback, so no
+network access or token is required.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from dependamerge.github_async import GraphQLError
+from dependamerge.github_service import GitHubService
+from dependamerge.models import PullRequestInfo
+
+
+def _not_an_org_error(login: str) -> GraphQLError:
+    """Build the GraphQL error GitHub returns for a user login.
+
+    Mirrors the structured ``errors`` payload that
+    ``GitHubAsync.graphql`` re-raises as a ``GraphQLError`` whose string
+    form is the JSON-encoded array.
+    """
+    return GraphQLError(
+        json.dumps(
+            [
+                {
+                    "type": "NOT_FOUND",
+                    "path": ["organization"],
+                    "locations": [{"line": 3, "column": 3}],
+                    "message": (
+                        "Could not resolve to an Organization with the "
+                        f"login of '{login}'."
+                    ),
+                }
+            ]
+        )
+    )
+
+
+def _repos_connection(nodes: list[dict]) -> dict:
+    return {
+        "totalCount": len(nodes),
+        "pageInfo": {"hasNextPage": False, "endCursor": None},
+        "nodes": nodes,
+    }
+
+
+def _make_user_account_graphql(login: str, repo_nodes: list[dict]):
+    """Return an async ``graphql`` stub that behaves like a user account.
+
+    The ``organization(login:)`` probe raises ``NOT_FOUND`` (as GitHub
+    does for a user login); the ``user(login:)`` query returns the
+    supplied repositories.  Anything else returns an empty payload.
+    """
+
+    async def _graphql(query: str, variables: dict | None = None):
+        if "organization(login:" in query:
+            raise _not_an_org_error(login)
+        if "user(login:" in query:
+            return {"user": {"repositories": _repos_connection(repo_nodes)}}
+        return {}
+
+    return _graphql
+
+
+class TestIterReposUserFallback:
+    """Direct tests for the owner-aware repository iterators."""
+
+    @pytest.mark.asyncio
+    async def test_iter_org_repositories_falls_back_to_user(self, mocker):
+        """``_iter_org_repositories`` must enumerate a *user* account.
+
+        This is the core regression: the historical org-only iterator
+        raised ``NOT_FOUND`` here, taking ``status``/``blocked``/``close``
+        down with it.
+        """
+        service = GitHubService(token="test_token")
+        try:
+            repo_nodes = [
+                {"nameWithOwner": "auser/repo-a", "isArchived": False, "isFork": False},
+                {"nameWithOwner": "auser/repo-b", "isArchived": False, "isFork": False},
+            ]
+            mocker.patch.object(
+                service._api,
+                "graphql",
+                side_effect=_make_user_account_graphql("auser", repo_nodes),
+            )
+
+            seen = [repo async for repo in service._iter_org_repositories("auser")]
+
+            names = [r["nameWithOwner"] for r in seen]
+            assert names == ["auser/repo-a", "auser/repo-b"]
+        finally:
+            await service.close()
+
+    @pytest.mark.asyncio
+    async def test_iter_org_repositories_includes_forks(self, mocker):
+        """Read paths include forks; the merge path excludes them.
+
+        ``_iter_org_repositories`` (read commands) keeps forks for a
+        complete picture, whereas ``_iter_owner_repositories`` defaults
+        to ``skip_forks=True`` for owner-wide bulk merges.
+        """
+        service = GitHubService(token="test_token")
+        try:
+            repo_nodes = [
+                {"nameWithOwner": "auser/own", "isArchived": False, "isFork": False},
+                {"nameWithOwner": "auser/forked", "isArchived": False, "isFork": True},
+                {"nameWithOwner": "auser/old", "isArchived": True, "isFork": False},
+            ]
+            mocker.patch.object(
+                service._api,
+                "graphql",
+                side_effect=_make_user_account_graphql("auser", repo_nodes),
+            )
+
+            read_repos = [
+                r["nameWithOwner"]
+                async for r in service._iter_org_repositories("auser")
+            ]
+            # Archived always skipped; fork retained for read commands.
+            assert read_repos == ["auser/own", "auser/forked"]
+
+            # Reset the cached owner-root verdict so the second pass
+            # re-probes cleanly with a fresh stub.
+            service._owner_root_cache.clear()
+            mocker.patch.object(
+                service._api,
+                "graphql",
+                side_effect=_make_user_account_graphql("auser", repo_nodes),
+            )
+            merge_repos = [
+                r["nameWithOwner"]
+                async for r in service._iter_owner_repositories("auser")
+            ]
+            # Both archived and fork skipped for the bulk-merge path.
+            assert merge_repos == ["auser/own"]
+        finally:
+            await service.close()
+
+
+class TestStatusUserAccount:
+    """``gather_organization_status`` against a personal user account."""
+
+    @pytest.mark.asyncio
+    async def test_status_scans_user_repositories(self, mocker):
+        service = GitHubService(token="test_token")
+        try:
+            repo_nodes = [
+                {"nameWithOwner": "auser/repo-a", "isArchived": False, "isFork": False},
+            ]
+            mocker.patch.object(
+                service._api,
+                "graphql",
+                side_effect=_make_user_account_graphql("auser", repo_nodes),
+            )
+            # Short-circuit the per-repo metadata gathering so the test
+            # exercises only the owner-aware enumeration path.
+            mocker.patch.object(
+                service, "_get_latest_tag", return_value=("v1.0.0", "2026/01/01")
+            )
+            mocker.patch.object(
+                service, "_get_latest_release", return_value=("v1.0.0", "2026/01/01")
+            )
+            mocker.patch.object(
+                service,
+                "_gather_pr_statistics",
+                return_value={
+                    "open_prs_human": 0,
+                    "open_prs_automation": 1,
+                    "merged_prs_human": 0,
+                    "merged_prs_automation": 0,
+                    "action_prs_human": 0,
+                    "action_prs_automation": 0,
+                    "workflow_prs_human": 0,
+                    "workflow_prs_automation": 0,
+                },
+            )
+
+            result = await service.gather_organization_status("auser")
+
+            assert result.organization == "auser"
+            assert result.scanned_repositories == 1
+            assert [s.repository_name for s in result.repository_statuses] == ["repo-a"]
+            assert result.errors == []
+        finally:
+            await service.close()
+
+
+class TestBlockedUserAccount:
+    """``scan_organization`` (the ``blocked`` command) against a user."""
+
+    @pytest.mark.asyncio
+    async def test_blocked_scans_user_repositories(self, mocker):
+        service = GitHubService(token="test_token")
+        try:
+            repo_nodes = [
+                {"nameWithOwner": "auser/repo-a", "isArchived": False, "isFork": False},
+            ]
+            mocker.patch.object(
+                service._api,
+                "graphql",
+                side_effect=_make_user_account_graphql("auser", repo_nodes),
+            )
+            # No open PRs in the repo: the scan should complete cleanly
+            # rather than aborting with NOT_FOUND.
+            mocker.patch.object(
+                service,
+                "_fetch_repo_prs_first_page",
+                return_value=([], {"hasNextPage": False, "endCursor": None}),
+            )
+
+            result = await service.scan_organization("auser")
+
+            assert result.organization == "auser"
+            assert result.scanned_repositories == 1
+            assert result.unmergeable_prs == []
+            assert result.errors == []
+        finally:
+            await service.close()
+
+
+class TestFindSimilarUserAccount:
+    """``find_similar_prs`` (behind ``close``) against a user account."""
+
+    @pytest.mark.asyncio
+    async def test_find_similar_scans_user_repositories(self, mocker):
+        service = GitHubService(token="test_token")
+        try:
+            repo_nodes = [
+                {"nameWithOwner": "auser/repo-a", "isArchived": False, "isFork": False},
+            ]
+            mocker.patch.object(
+                service._api,
+                "graphql",
+                side_effect=_make_user_account_graphql("auser", repo_nodes),
+            )
+            mocker.patch.object(
+                service,
+                "_fetch_repo_prs_first_page",
+                return_value=([], {"hasNextPage": False, "endCursor": None}),
+            )
+
+            source_pr = PullRequestInfo(
+                number=1,
+                title="Chore: Bump actions/checkout from 4 to 5",
+                body="Bumps actions/checkout",
+                author="dependabot[bot]",
+                head_sha="abc123",
+                base_branch="main",
+                head_branch="dependabot/github_actions/actions/checkout-5",
+                state="open",
+                mergeable=True,
+                mergeable_state="clean",
+                behind_by=0,
+                files_changed=[],
+                repository_full_name="auser/repo-a",
+                html_url="https://github.com/auser/repo-a/pull/1",
+            )
+
+            class _Comparator:
+                def compare_pull_requests(self, source, target, only_automation):
+                    raise AssertionError("no candidate PRs expected")
+
+            result = await service.find_similar_prs(
+                "auser", source_pr, _Comparator(), only_automation=True
+            )
+
+            # No candidates in the user's single empty repo, but crucially
+            # the owner-wide scan completed without a NOT_FOUND error.
+            assert result == []
+        finally:
+            await service.close()

--- a/tests/test_status_command.py
+++ b/tests/test_status_command.py
@@ -100,6 +100,8 @@ class TestStatusCommand:
         assert "Human" in result.stdout
         assert "Total PRs" in result.stdout
         assert "Total Repositories" in result.stdout
+        # GitHub Copilot is listed among the supported automation tools.
+        assert "GitHub Copilot" in result.stdout
 
     @patch("dependamerge.github_service.GitHubService")
     def test_status_command_json_output(self, mock_service_class):

--- a/tests/test_status_command.py
+++ b/tests/test_status_command.py
@@ -3,6 +3,7 @@
 
 from unittest.mock import Mock, patch
 
+import pytest
 from typer.testing import CliRunner
 
 from dependamerge.cli import app
@@ -160,7 +161,7 @@ class TestStatusCommand:
 
         # Should fail with invalid input
         assert result.exit_code == 1
-        assert "Invalid GitHub organization" in result.stdout
+        assert "Invalid GitHub owner" in result.stdout
 
     @patch("dependamerge.github_service.GitHubService")
     def test_status_command_with_errors(self, mock_service_class):
@@ -212,3 +213,89 @@ class TestStatusCommand:
             "Errors Encountered" in result.stdout
             or "Connection timeout" in result.stdout
         )
+
+
+class TestStatusCommandUrlForms:
+    """Verify ``status`` resolves the owner from every supported URL form.
+
+    Each invocation captures the login handed to
+    ``gather_organization_status`` so we assert the CLI extracts the
+    correct owner from bare names, bare URLs, trailing-slash URLs, and
+    the canonical ``/orgs/owner`` and ``/orgs/owner/repositories`` forms.
+    These forms apply equally to organizations and personal user
+    accounts (the two are only distinguished later at runtime).
+    """
+
+    runner: CliRunner = CliRunner()
+
+    def setup_method(self):
+        self.runner = CliRunner()
+
+    @pytest.mark.parametrize(
+        "argument,expected_owner",
+        [
+            ("lfreleng-actions", "lfreleng-actions"),
+            ("lfreleng-actions/", "lfreleng-actions"),
+            ("ModeSevenIndustrialSolutions", "ModeSevenIndustrialSolutions"),
+            ("https://github.com/lfreleng-actions", "lfreleng-actions"),
+            ("https://github.com/lfreleng-actions/", "lfreleng-actions"),
+            (
+                "https://github.com/ModeSevenIndustrialSolutions",
+                "ModeSevenIndustrialSolutions",
+            ),
+            ("github.com/lfreleng-actions", "lfreleng-actions"),
+            ("https://github.com/orgs/lfreleng-actions", "lfreleng-actions"),
+            (
+                "https://github.com/orgs/lfreleng-actions/repositories",
+                "lfreleng-actions",
+            ),
+        ],
+    )
+    @patch("dependamerge.github_service.GitHubService")
+    def test_status_resolves_owner_from_url_form(
+        self, mock_service_class, argument, expected_owner
+    ):
+        captured: dict[str, str] = {}
+        mock_service = Mock()
+        mock_service_class.return_value = mock_service
+
+        async def mock_gather_status(org_name):
+            captured["owner"] = org_name
+            return OrganizationStatus(
+                organization=org_name,
+                total_repositories=0,
+                scanned_repositories=0,
+                repository_statuses=[],
+                scan_timestamp="2026-01-20T10:00:00",
+                errors=[],
+            )
+
+        async def mock_close():
+            pass
+
+        mock_service.gather_organization_status = mock_gather_status
+        mock_service.close = mock_close
+
+        result = self.runner.invoke(
+            app,
+            ["status", argument, "--no-progress"],
+            env={"GITHUB_TOKEN": "fake-token"},
+        )
+
+        assert result.exit_code == 0, result.stdout
+        assert captured.get("owner") == expected_owner
+
+    @patch("dependamerge.github_service.GitHubService")
+    def test_status_rejects_non_github_owner_url(self, mock_service_class):
+        """A non-github.com owner URL is rejected before any scan starts."""
+        mock_service = Mock()
+        mock_service_class.return_value = mock_service
+
+        result = self.runner.invoke(
+            app,
+            ["status", "https://gitlab.com/some-owner", "--no-progress"],
+            env={"GITHUB_TOKEN": "fake-token"},
+        )
+
+        assert result.exit_code == 1
+        assert "Invalid GitHub owner" in result.stdout

--- a/tests/test_status_command.py
+++ b/tests/test_status_command.py
@@ -94,6 +94,13 @@ class TestStatusCommand:
         assert "repo1" in result.stdout
         assert "repo2" in result.stdout
 
+        # Summary table reports the open-PR human/automation split and a
+        # combined total alongside the repository count.
+        assert "Automation PRs" in result.stdout
+        assert "Human" in result.stdout
+        assert "Total PRs" in result.stdout
+        assert "Total Repositories" in result.stdout
+
     @patch("dependamerge.github_service.GitHubService")
     def test_status_command_json_output(self, mock_service_class):
         """Test status command with JSON output format."""

--- a/tests/test_url_parser.py
+++ b/tests/test_url_parser.py
@@ -580,6 +580,11 @@ class TestParseOwnerArg:
     def test_bare_login_with_multiple_trailing_slashes(self):
         assert parse_owner_arg("lfreleng-actions//") == "lfreleng-actions"
 
+    def test_slashes_only_raises(self):
+        """Input consisting only of slashes has no login to extract."""
+        with pytest.raises(UrlParseError, match="cannot be empty"):
+            parse_owner_arg("////")
+
     def test_https_owner_url(self):
         assert (
             parse_owner_arg("https://github.com/lfreleng-actions") == "lfreleng-actions"

--- a/tests/test_url_parser.py
+++ b/tests/test_url_parser.py
@@ -16,6 +16,8 @@ from dependamerge.url_parser import (
     _host_matches,
     detect_source,
     parse_change_url,
+    parse_org_url,
+    parse_owner_arg,
 )
 
 
@@ -539,3 +541,117 @@ class TestUrlBypassPrevention:
         url = "https://not-a-gerrit-server.evil.org/dashboard"
         with pytest.raises(UrlParseError, match="Cannot determine platform"):
             parse_change_url(url)
+
+
+class TestParseOwnerArg:
+    """Tests for ``parse_owner_arg`` owner-login extraction.
+
+    These cover every owner URL form the ``status`` and ``blocked``
+    commands advertise support for.  An organization login and a
+    personal user login are indistinguishable at parse time (the account
+    type is resolved later at runtime), so the same parsing applies to
+    both — the cases below intentionally mix org-style and user-style
+    logins.
+    """
+
+    def test_bare_login(self):
+        """A plain login is returned verbatim."""
+        assert parse_owner_arg("lfreleng-actions") == "lfreleng-actions"
+
+    def test_bare_login_user_account(self):
+        """A personal user login parses identically to an org login."""
+        assert (
+            parse_owner_arg("ModeSevenIndustrialSolutions")
+            == "ModeSevenIndustrialSolutions"
+        )
+
+    def test_bare_login_with_surrounding_whitespace(self):
+        assert parse_owner_arg("  lfreleng-actions  ") == "lfreleng-actions"
+
+    def test_bare_login_with_trailing_slash(self):
+        """A bare login plus a trailing slash stays a login.
+
+        Regression guard: ``status``/``blocked`` historically accepted
+        ``owner/`` via ``rstrip("/")``, so it must not be misread as a
+        URL whose host is ``owner``.
+        """
+        assert parse_owner_arg("lfreleng-actions/") == "lfreleng-actions"
+
+    def test_bare_login_with_multiple_trailing_slashes(self):
+        assert parse_owner_arg("lfreleng-actions//") == "lfreleng-actions"
+
+    def test_https_owner_url(self):
+        assert (
+            parse_owner_arg("https://github.com/lfreleng-actions") == "lfreleng-actions"
+        )
+
+    def test_https_owner_url_trailing_slash(self):
+        assert (
+            parse_owner_arg("https://github.com/lfreleng-actions/")
+            == "lfreleng-actions"
+        )
+
+    def test_https_user_url(self):
+        assert (
+            parse_owner_arg("https://github.com/ModeSevenIndustrialSolutions")
+            == "ModeSevenIndustrialSolutions"
+        )
+
+    def test_owner_url_without_scheme(self):
+        assert parse_owner_arg("github.com/lfreleng-actions") == "lfreleng-actions"
+
+    def test_orgs_owner_url(self):
+        assert (
+            parse_owner_arg("https://github.com/orgs/lfreleng-actions")
+            == "lfreleng-actions"
+        )
+
+    def test_orgs_owner_repositories_url(self):
+        """The canonical ``/orgs/owner/repositories`` form must resolve.
+
+        The old naive ``split('/')[-1]`` parsing returned
+        ``repositories`` here — this case guards against that regression.
+        """
+        assert (
+            parse_owner_arg("https://github.com/orgs/lfreleng-actions/repositories")
+            == "lfreleng-actions"
+        )
+
+    def test_empty_string_raises(self):
+        with pytest.raises(UrlParseError):
+            parse_owner_arg("")
+
+    def test_whitespace_only_raises(self):
+        with pytest.raises(UrlParseError):
+            parse_owner_arg("   ")
+
+    def test_non_github_host_url_raises(self):
+        with pytest.raises(UrlParseError):
+            parse_owner_arg("https://gitlab.com/some-owner")
+
+    def test_pr_url_is_rejected(self):
+        """A full PR URL is not an owner URL and must be rejected."""
+        with pytest.raises(UrlParseError):
+            parse_owner_arg("https://github.com/owner/repo/pull/1")
+
+
+class TestParseOrgUrlForms:
+    """Tests for ``parse_org_url`` across the supported owner URL forms."""
+
+    def test_bare_owner(self):
+        result = parse_org_url("https://github.com/lfreleng-actions")
+        assert result.owner == "lfreleng-actions"
+        assert result.host == "github.com"
+        assert result.is_github is True
+
+    def test_orgs_owner_repositories(self):
+        result = parse_org_url("https://github.com/orgs/lfreleng-actions/repositories")
+        assert result.owner == "lfreleng-actions"
+
+    def test_user_account_owner(self):
+        result = parse_org_url("https://github.com/ModeSevenIndustrialSolutions")
+        assert result.owner == "ModeSevenIndustrialSolutions"
+
+    def test_non_github_host_rejected(self):
+        with pytest.raises(UrlParseError):
+            parse_org_url("https://gitlab.com/some-owner")


### PR DESCRIPTION
## Summary

The v0.7.0 owner-wide feature let `status`, `blocked`, and `close`
operate on a whole GitHub owner, but those report paths assumed the owner
was an **organization**. Running them against a **personal account**
(e.g. `https://github.com/ModeSevenIndustrialSolutions`) failed with:

```
Could not resolve to an Organization with the login of ''
```

Only `merge` resolved the owner correctly, because it alone used the
owner-aware repository enumeration. This slipped through because there
was no integration coverage exercising the sub-commands end-to-end.

## What changed

### Bug fix (owner resolution)
- `_iter_org_repositories` now delegates to the owner-aware
  `_iter_owner_repositories`, which resolves the GraphQL root
  (`organization` vs `user`) once at runtime and falls back from org to
  user on `NOT_FOUND`. This fixes `status`, `blocked`, and the `close`
  similar-PR scan in one place.
- Read-only report paths include forks (`skip_forks=False`) for a
  complete picture; the bulk-merge path keeps excluding forks.
- A new `parse_owner_arg` helper normalises every supported owner URL
  form (bare login, bare URL, trailing slash, scheme-less host, and the
  canonical `/orgs/owner` and `/orgs/owner/repositories` forms),
  replacing a naive `split("/")[-1]` that mis-parsed
  `/orgs/owner/repositories`. Slashes-only input (e.g. `////`) now
  raises rather than yielding an empty login.
- User-facing wording across `merge`, `close`, `status`, and `blocked`
  (help text and runtime output) now refers to a GitHub **owner
  (organization or user account)** rather than assuming an organization.

### `--dry-run` for `merge` and `close`
- Performs the full analysis and preview but never approves, merges,
  rebases, closes, or submits, and **skips the write-permission
  pre-flight** so it runs under a read-only token. The Gerrit merge path
  honours dry-run too.
- This unblocks read-only CI testing of the write commands.
- `merge --dry-run --include-human-prs` keeps human-authored PRs in the
  preview (a dry run performs no writes) with an informational note that
  a real run would prompt before merging them, so the preview faithfully
  mirrors the real operation.

### Live integration tests (fail-safe)
- New `tests/integration/` suite drives the **real CLI in dry-run mode**
  against GitHub (and optionally Gerrit):
  - `status`/`blocked` for **both organization and personal accounts**,
    across **every URL form**.
  - `merge`/`close` dry-run against a **dynamically discovered** open
    automation PR.
  - Gerrit `merge --dry-run` against a dynamically discovered open change.
- Every test **fails safe**: it skips (never fails) when credentials or
  open automation PRs/changes are absent, so it cannot mutate a
  repository or fail on an empty target space.
- Deselected by default; opt in via `--run-integration` or
  `DEPENDAMERGE_RUN_INTEGRATION=1`.
- A new read-only `Integration Tests (dry-run)` workflow runs the suite
  on pull requests (`contents: read`, `pull-requests: read`).

### `status` summary enhancement
- The status summary table now reports the open-PR human/automation
  split alongside the combined total, surfacing the headline figure
  operators actually scan for:

  ```
  │ 🤖 Automation PRs  │ 26    │
  │ 🤷 Human      PRs  │ 1     │
  ├────────────────────┼───────┤
  │ Total PRs          │ 27    │
  │ Total Repositories │ 40    │
  ```

### GitHub Copilot as a supported automation tool
- Copilot is now an explicit, first-class supported automation tool
  (it increasingly raises automated code fixes and other changes).
- The Copilot coding-agent login (`copilot-swe-agent`) is recognised as
  automation in both the REST (`copilot-swe-agent[bot]`) and GraphQL
  (bare) login forms, not just via the generic `[bot]` fallthrough.
- `status` lists "GitHub Copilot" among the recognised automation tools,
  and the README merge/close tool lists name it too.

### CI / supply-chain hardening
- The new integration-test workflow and the pre-existing workflows are
  now **zizmor-clean at the strict `auditor` persona** (the rest of the
  repo already met that bar):
  - `artipacked`: the integration job checks out with
    `persist-credentials: false` (it only reads and never pushes).
  - `secrets-outside-env`: the integration job is bound to a dedicated
    `integration` environment so its secrets are environment-scoped.
  - `undocumented-permissions`: every `permissions:` entry across the
    workflows carries an explanatory same-line comment.

### Docs
- README documents `--dry-run`, how to run the integration suite, and
  lists GitHub Copilot among the supported automation tools.

## Verification
- Full unit suite: **1207 passed, 13 skipped** (integration deselected),
  coverage 64.87%.
- Integration suite run live and **all passed** against the org
  (`lfreleng-actions`), the user account (`ModeSevenIndustrialSolutions`,
  all URL forms), discovered automation PRs (`merge`/`close --dry-run`),
  and a live Gerrit change (`gerrit.onap.org`).
- `status` summary table and Copilot tool listing verified live against
  the user account.
- `zizmor --persona=auditor .github/workflows/` reports **no findings**.
- Lint clean: ruff, ruff-format, mypy, basedpyright, yamllint,
  markdownlint, actionlint, reuse, codespell, gitlint, GitHub workflow
  validators.
