### PR TITLE
Fix(deps): Remove uv exclude-newer cooldown

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,14 +103,6 @@ dev = [
   "types-requests>=2.32.4.20260107",
 ]
 
-[tool.uv]
-# Supply-chain cooldown: refuse to resolve anything published in the
-# last 7 days, giving the community time to catch a compromised release
-# before it can be locked. Rolling window, re-evaluated on every
-# `uv lock` (no manual date bump). The relative-duration form requires
-# uv >= 0.9.17.
-exclude-newer = "7 days"
-
 [tool.pytest.ini_options]
 testpaths = [
   "tests/",

--- a/uv.lock
+++ b/uv.lock
@@ -6,10 +6,6 @@ resolution-markers = [
     "python_full_version < '3.15'",
 ]
 
-[options]
-exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
-exclude-newer-span = "P7D"
-
 [[package]]
 name = "aiolimiter"
 version = "1.2.1"


### PR DESCRIPTION
## Summary

The relative `exclude-newer = "7 days"` cooldown in `[tool.uv]` is baked
into `uv.lock` as `exclude-newer-span = "P7D"`. Dependabot's `uv` updater
re-resolves against that rolling window, regenerates a byte-identical
lockfile, and fails with **"Dependency file content did not change"** —
blocking automated and priority security updates.

## Change

- Remove the `exclude-newer` supply-chain cooldown from `pyproject.toml`.
- Regenerate `uv.lock` (drops the `[options]` `exclude-newer-span` block);
  deletion-only, no dependency versions moved.

The supply-chain auditing tool that originally recommended this cooldown
has updated its guidance — Dependabot cooldowns now cover the same
concern without breaking priority security fixes.

## Validation

- `uv lock` regenerates cleanly.
- `pre-commit` (including the test suite) passes.