### PR TITLE
Feat: add park-aware merge orchestration engine

### DIFF
--- a/docs/MERGE_ENGINE_DESIGN.md
+++ b/docs/MERGE_ENGINE_DESIGN.md
@@ -1,0 +1,246 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- SPDX-FileCopyrightText: 2026 The Linux Foundation -->
+
+# Merge Orchestration Engine — Design
+
+Package: `src/dependamerge/engine/`
+
+Status: **Phase 1 — engine landed standalone (this document's PR).**
+Nothing in the production merge path uses it yet; wiring happens in a
+follow-up PR (see [Migration plan](#migration-plan)).
+
+## Motivation
+
+The current orchestration (`merge_prs_parallel` → `_merge_single_pr`)
+grew a series of inline waiting loops, each added for a specific
+scenario. Three structural problems fell out of that growth, all
+observed in production bulk-merge runs:
+
+### 1. Waiting pins concurrency slots
+
+Every waiting loop (`_wait_for_auto_merge`, the conflict-recovery
+poll, the post-rebase REST poll, the recreate poll, the
+recreated-checks wait, the pre-commit.ci re-trigger wait) runs inside
+the worker task that holds one of the N global concurrency slots. A PR
+that needs a `@dependabot rebase` occupies a slot for the full wait
+(rebase turnaround is routinely 3–5 minutes; CI adds more).
+
+Worked example from a real run: 41 repositories all needed a rebase to
+re-run a required org check. With 10 slots and a five-minute wait
+each, the batch drains in ceil(41/10) × ~5 min ≈ **20–25 minutes of
+idle waiting**, while runnable PRs in other repositories queue
+behind parked ones. With parking (waiting holds no slot), the same
+batch issues all 41 rebases in one scheduling pass and total
+wall time collapses to ~one rebase+CI latency.
+
+### 2. Budgets are per-loop, not per-run
+
+A single loop — `_wait_for_auto_merge` — honours `--max-wait` (the run
+deadline) and `--no-wait`. The pre-commit.ci poll, the recreate poll,
+the recreated-checks wait, and the post-rebase poll each
+independently burn up to `--merge-timeout` (default 300 s) — a single
+unlucky PR can stack ~5 of these sequentially. So the run deadline
+does not bound the run.
+
+### 3. Scattered, incomplete recovery routing
+
+Recovery decisions live in four places (`_merge_single_pr` Steps
+0.5/5/5.5/6, `_handle_merge_conflict`, `_report_merge_failure`, the
+rebase module), each with its own entry conditions. Gaps fall through
+the cracks; the motivating incident: an org-required workflow-audit
+check failed against **stale branch content** (the base branch
+already carried the fix). The legacy code classified "completed failing
+required check" as terminal and reported failure for 88 of 92 PRs —
+when a rebase would have re-run the check against current base and
+allowed every one of them to merge.
+
+Related accounting bugs (fixed by construction here): two failure
+paths return a `MergeResult` without ever calling the progress
+tracker, so the ticker over-counts in-flight PRs; and
+`_merge_pr_with_retry` sleeps while holding the per-repo dispatch
+lock.
+
+## Architecture
+
+Three small, independently testable pieces:
+
+```mermaid
+graph TD
+    E[Engine - scheduler.py] -->|drives phases via| P[PhaseRunner]
+    P --- PA[pipeline adapter, phase 2]
+    E -->|parks items in| R[Reconciler - reconciler.py]
+    R -->|snapshot per tick| S[SnapshotSource - one GET per parked PR]
+    P -->|asks for next action| L[Recovery ladder - ladder.py]
+    L -->|pure decision, no I/O| P
+```
+
+### Work items and phases (`model.py`)
+
+Each PR becomes a `WorkItem` (opaque `payload`, stable `key`,
+caller-order `index`, per-repo `lane`). A `PhaseRunner` executes named
+phases; each phase does bounded active work and returns a transition:
+
+- `Advance(phase)` — run another phase next, without waiting.
+- `Park(reason, wake, on_wake, on_timeout, timeout)` — wait for an
+  external event without holding a slot.
+- `Finish(outcome)` — terminal.
+
+The engine is generic: it imports no GitHub types and never inspects
+payloads or outcomes. This keeps it free of import cycles and lets
+stub pipelines exercise the whole scheduling kernel in tests.
+
+### Scheduler (`scheduler.py`)
+
+- **Lanes** — items sharing a lane run strictly sequentially, FIFO.
+  Lane = repository, preserving the ≤1-in-flight-per-repo invariant
+  (avoids mergeability-propagation races and dependabot rebase
+  storms). `flat_lanes()` reproduces legacy flat-scheduler semantics
+  when other code handles per-repo serialisation.
+- **Slots** — a global semaphore bounds *active* phases and nothing
+  else. A parked
+  item holds no slot, so waiting never starves runnable work. (API
+  protection is not the semaphore's job: the shared `GitHubAsync`
+  client has its own concurrency cap, RPS limiter and adaptive
+  throttle.)
+- **Parking** — the engine clamps every park deadline to the run
+  deadline (`max_wait`), uniformly — fixing the per-loop budget
+  problem. `max_wait == 0` is fire-and-forget: the parking phase's
+  side effects (rebase requested, auto-merge armed) still happen, then
+  `on_timeout` runs straight away.
+- **Failure model** — a phase exception becomes a terminal outcome via
+  `PhaseRunner.on_error` (never raises); the lane continues with its
+  next item. `MAX_PHASE_EXECUTIONS` (100) converts a transition-cycle
+  bug into a per-item failure instead of a hang.
+- **Finalization** — `on_item_done` fires once per item, the
+  single place to update the progress tracker. This closes the
+  "result returned but tracker never told" class of bug.
+
+### Reconciler (`reconciler.py`)
+
+One background coroutine watches **all** parked items. Each tick
+(fixed interval) it refreshes one `Snapshot` per parked item — batched
+through the shared HTTP client — evaluates each item's wake predicate,
+and resolves the item's future: `True` (condition fired → `on_wake`)
+or `False` (deadline passed → `on_timeout`).
+
+API cost matches the status quo (one GET per waiting PR per
+poll interval); what changes is that waiting consumes zero
+concurrency. A failed or partial refresh (`None`/exception) keeps the
+previous snapshot and never wakes or expires an item by itself.
+
+This is also what makes the engine correct when **auto-merge is
+unavailable** (org/repo setting): the engine parks on "PR became
+clean" and performs the merge itself on wake, rather than depending on
+GitHub's auto-merge to fire. Fire-and-forget (`max_wait 0`) with
+auto-merge unavailable still reports the PR as blocked, matching
+legacy behaviour.
+
+### Recovery ladder (`ladder.py`)
+
+All "not mergeable yet" routing is a single pure decision table:
+`decide(LadderInput) -> Action`. No I/O — every rung is unit-testable.
+Rungs in priority order:
+
+1. `dirty` (conflict) — dependabot: `@dependabot rebase`; anyone
+   else: terminal `merge conflicts`.
+2. `behind` — rebase (macro / update-branch), else arm auto-merge.
+3. `blocked` + **failing required check** + **behind base** —
+   **rebase**. The verdict is stale; a rebase alone re-runs the check
+   against current base.
+4. `blocked` + stuck required check — dependabot: recreate; stale
+   pre-commit.ci: re-trigger. Stuck outranks the pending-wait rung:
+   waiting on a check that will never report cannot succeed.
+5. `blocked` + pending required checks — arm auto-merge, park until
+   they land.
+6. `blocked`, no recovery applies — terminal, with
+   `analyze_block_reason`'s phrase.
+7. `unstable` — merge while the merge button is live (`mergeable` is
+   True, e.g. a red non-required check); otherwise wait once
+   for mergeability to settle, then fail.
+8. `clean` / unknown — attempt the merge.
+
+Rung 3 is the rung the legacy code lacks (the 88-PR incident). Guards:
+the rung requires proof of `behind_by > 0` (`None` fails closed to
+rung 6), and every recovery rung fires **at most once per item per
+run** (`attempted` markers), so a recovery that doesn't change the
+observed state degrades to the next rung instead of looping. The rung
+defaults to on —
+no new CLI flag — consistent with the tool's hands-off philosophy.
+
+## Behavioural contracts preserved
+
+The existing test suite asserts the following legacy contracts, and
+the engine preserves them (Phase 1 proves them against stub
+pipelines; Phase 2 re-asserts them end-to-end):
+
+- Results return in input order.
+- ≤1 in-flight PR per repository, FIFO within the repo.
+- A phase exception fails that item with its message; sibling items
+  keep running.
+- `AUTO_MERGE_PENDING` outcomes get `pr_completed()`, and no other
+  tracker call (no
+  started/failed double-count).
+- Exact user-facing strings: `merge conflicts`,
+  `stuck check: <name>`, `already merged externally`,
+  `auto-merge unavailable`, `🔀 Merge conflict` (no duplicate
+  `❌ Failed`).
+- Approval happens strictly after a conflict clears, never before.
+- `update_branch` is never called on the local-rebase path.
+- CLI seam `cli._run_parallel_merge(ctx, prs, preview=...)` returns
+  `list[MergeResult]` unchanged.
+
+## Migration plan
+
+### Phase 1 (this PR)
+
+Engine package + tests. Standalone: no production code path imports
+it, no behaviour change, full legacy suite must pass untouched.
+
+### Phase 2 (follow-up PR)
+
+1. **Pipeline adapter** implementing `PhaseRunner` with phases mapping
+   the legacy steps: `intake` (github2gerrit detection, merge-method
+   resolution) → `assess` (mergeability refresh,
+   `_check_merge_requirements`) → `recover` (build `LadderInput` from
+   `analyze_block_reason` + `compare.behind_by` +
+   `_detect_stuck_required_check` + check-run classification; execute
+   the ladder's action; park) → `dispatch` (approve +
+   `_merge_pr_with_retry`, sleeping *outside* any lane lock) →
+   `complete`.
+2. The adapter reuses leaf operations as-is, calling them **through
+   the manager
+   instance** (`_approve_pr`, `_merge_pr_with_retry`,
+   `_detect_github2gerrit`, `_get_merge_method_for_repo`,
+   `_trigger_stale_precommit_ci`, `_check_merge_requirements`), so the
+   existing patch-bundle test seam survives.
+3. Wire `merge_prs_parallel`: striped scheduler → lane = repo; flat
+   scheduler → `flat_lanes()`.
+4. Move all tracker accounting into `on_item_done`.
+5. Rework the ~96 orchestration-level test functions (of ~600) that
+   assert on the old loop internals, preserving their behavioural
+   assertions through the same patch seam.
+
+### Phase 3 (optional cleanup)
+
+Delete the superseded waiting loops and the per-loop timeout
+parameters they carried; collapse `_handle_merge_conflict` /
+`_report_merge_failure` routing into the ladder.
+
+## Testing
+
+`tests/engine/` covers the three pieces in isolation with stub
+pipelines and snapshot sources (no GitHub mocks needed):
+
+- **Ladder** — table-driven: every rung, every guard (`behind_by`
+  `None`/0/positive, attempt markers, dependabot vs human), priority
+  between overlapping conditions.
+- **Scheduler** — ordering, lane FIFO/isolation, slot release while
+  parked (parked > concurrency items make progress), run-deadline
+  clamping, no-wait mode, exception conversion, phase-budget guard,
+  `on_item_done` (including observer exceptions), `flat_lanes`.
+- **Reconciler** — wake on predicate, timeout on deadline, failed
+  refresh keeps waiting, predicate exception tolerated, `flush`,
+  `parked_view`.
+
+Timing style matches repo conventions: real short sleeps with short
+timeouts (`asyncio_mode = "auto"`), no fake clocks.

--- a/docs/MERGE_ENGINE_DESIGN.md
+++ b/docs/MERGE_ENGINE_DESIGN.md
@@ -5,9 +5,11 @@
 
 Package: `src/dependamerge/engine/`
 
-Status: **Phase 1 — engine landed standalone (this document's PR).**
-Nothing in the production merge path uses it yet; wiring happens in a
-follow-up PR (see [Migration plan](#migration-plan)).
+Status: **Phase 1 landed standalone; Phase 2 (park-aware slots) wired
+into the production path via `slot_lease.py`.** The engine package
+itself remains standalone; Phase 2 ports its central scheduling
+semantic — waiting holds no concurrency slot — into the legacy
+orchestration directly (see [Migration plan](#migration-plan)).
 
 ## Motivation
 
@@ -196,7 +198,39 @@ pipelines; Phase 2 re-asserts them end-to-end):
 Engine package + tests. Standalone: no production code path imports
 it, no behaviour change, full legacy suite must pass untouched.
 
-### Phase 2 (follow-up PR)
+### Phase 2 (landed: park-aware slots via `slot_lease.py`)
+
+Phase 2 as originally sketched (a full pipeline adapter decomposing
+`_merge_single_pr` into engine phases) would rework ~96
+orchestration-level test functions in one step. Instead, the phase
+delivers the engine's highest-value semantic — **slot-free waiting**
+— as a minimal, surgical port that leaves the legacy control flow
+(and its test seams) intact:
+
+1. `slot_lease.py` — `holding_slot(semaphore)` replaces the bare
+   `async with semaphore:` in `_merge_single_pr_with_semaphore` and
+   publishes a re-acquirable `SlotLease` through a `ContextVar`;
+   `parked()` releases the current task's slot while a wait runs and
+   re-acquires it before active work resumes. Nested parks
+   and parks outside a lease are no-ops, so helpers stay safe from
+   any call site.
+2. Every long waiting loop in the merge path now runs inside
+   `parked()`: the auto-merge wait (`_wait_for_auto_merge`, which
+   also serves both conflict-recovery phases), the pre-commit.ci
+   re-trigger poll, the dependabot recreate poll (including the
+   nested recreated-PR checks wait), and the post-rebase settle +
+   poll in the rebase module.
+3. Invariants preserved: ≤1 in-flight PR per repository (the striped
+   scheduler's serial repo workers stay as-is — parking releases
+   the *global* slot, never the per-repo serialisation), per-repo
+   merge-dispatch locks are never held across a park, and the
+   `_waiting_prs` ticker still tracks every waiting PR.
+
+This fixes structural problem 1 (waiting pins concurrency slots)
+for the production path. Problems 2 (per-loop budgets) and 3
+(scattered recovery routing) remain engine-phase work — the original
+pipeline-adapter plan below still applies if/when we want full
+decomposition:
 
 1. **Pipeline adapter** implementing `PhaseRunner` with phases mapping
    the legacy steps: `intake` (github2gerrit detection, merge-method

--- a/src/dependamerge/cli.py
+++ b/src/dependamerge/cli.py
@@ -1033,23 +1033,36 @@ def _format_failure_reason(reason: str) -> list[str]:
 def _print_failed_pr_details(
     merge_results: list[MergeResult],
 ) -> None:
-    """Print URL and reason for each failed PR in the result list.
+    """Print URL and reason for every non-merged PR in the result list.
 
     A bare ``Failed: 1`` line in the summary forces the user to
     scroll back through the merge output to find which PR failed
-    and why.  Surface that information directly so the failure is
-    actionable from the final summary alone.
+    and why.  During a real merge run the per-PR status lines are
+    no longer printed to the console at all (progress is conveyed
+    by the live tracker counters), so this end-of-run report is
+    the *only* place reasons appear.  It therefore covers every
+    non-merged terminal outcome — failed, blocked, skipped and
+    auto-merge pending — one section per outcome.
     """
-    failed = [r for r in merge_results if r.status.value == "failed"]
-    if not failed:
-        return
-    console.print("\n❌ Failed PRs:")
-    for r in failed:
-        url = getattr(r.pr_info, "html_url", "<unknown>")
-        reason = r.error or "no reason reported"
-        body = "\n".join(f"     {line}" for line in _format_failure_reason(reason))
-        # markup=False so bracketed reasons are not eaten by Rich.
-        console.print(f"   • {url}\n{body}", markup=False)
+    sections: list[tuple[str, str]] = [
+        ("failed", "\n❌ Failed PRs:"),
+        ("blocked", "\n🛑 Blocked PRs:"),
+        ("skipped", "\n⏭️ Skipped PRs:"),
+        ("auto_merge_pending", "\n🤖 Auto-merge pending PRs:"),
+    ]
+    for status_value, heading in sections:
+        matching = [r for r in merge_results if r.status.value == status_value]
+        if not matching:
+            continue
+        console.print(heading)
+        for r in matching:
+            url = getattr(r.pr_info, "html_url", "<unknown>")
+            reason = r.error or "no reason reported"
+            body = "\n".join(
+                f"     {line}" for line in _format_failure_reason(reason)
+            )
+            # markup=False so bracketed reasons are not eaten by Rich.
+            console.print(f"   • {url}\n{body}", markup=False)
 
 
 def _display_merge_results(

--- a/src/dependamerge/engine/__init__.py
+++ b/src/dependamerge/engine/__init__.py
@@ -1,0 +1,42 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 The Linux Foundation
+
+"""Merge orchestration engine.
+
+A lane-serialised, slot-bounded, park-aware scheduler for bulk PR
+merging, plus the central recovery ladder.  See
+``docs/MERGE_ENGINE_DESIGN.md`` for the architecture and migration
+plan.
+"""
+
+from .ladder import Action, ActionKind, LadderInput, decide
+from .model import (
+    Advance,
+    Finish,
+    ItemState,
+    Park,
+    Snapshot,
+    Transition,
+    WorkItem,
+)
+from .reconciler import Reconciler, SnapshotSource
+from .scheduler import Engine, PhaseRunner, flat_lanes
+
+__all__ = [
+    "Action",
+    "ActionKind",
+    "Advance",
+    "Engine",
+    "Finish",
+    "ItemState",
+    "LadderInput",
+    "Park",
+    "PhaseRunner",
+    "Reconciler",
+    "Snapshot",
+    "SnapshotSource",
+    "Transition",
+    "WorkItem",
+    "decide",
+    "flat_lanes",
+]

--- a/src/dependamerge/engine/ladder.py
+++ b/src/dependamerge/engine/ladder.py
@@ -1,0 +1,239 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 The Linux Foundation
+
+"""Recovery ladder: one decision table for every "not mergeable yet" PR.
+
+The legacy orchestration scatters recovery routing across
+``_merge_single_pr`` (Steps 0.5/5/5.5/6), ``_handle_merge_conflict``,
+``_report_merge_failure`` and the rebase module, each with its own
+entry conditions and waits.  The ladder centralises the *decision*:
+given a pure :class:`LadderInput` describing a PR's observed state, it
+returns the single next :class:`Action` to take.  Executing the action
+(API calls, parking) is the pipeline's job — the ladder itself does no
+I/O, which makes every rung unit-testable in isolation.
+
+Rungs, in priority order:
+
+1.  ``dirty``      → dependabot: request ``@dependabot rebase`` and
+    wait; anyone else: terminal failure (no macro can regenerate a
+    conflicted lockfile for a human PR).
+2.  ``behind``     → rebase (dependabot macro, else update-branch /
+    local rebase) when fixing is enabled; otherwise arm auto-merge
+    and wait.
+3.  ``blocked`` with a **failing required check** while the branch is
+    **behind base** → rebase.  The check verdict is stale: it ran
+    against pre-rebase content, and only a rebase can re-trigger it
+    against current base.  (This is the rung the legacy code lacks —
+    it classifies a completed failing check as unrecoverable and
+    reports failure without attempting the rebase that would fix it.)
+4.  ``blocked`` with a **stuck** required check (queued/pending far
+    beyond normal startup) → dependabot: recreate the PR; a stale
+    pre-commit.ci check instead gets a ``pre-commit.ci run``
+    re-trigger.  Stuck outranks the pending-wait rung below: waiting
+    on a check that will never report cannot succeed.
+5.  ``blocked`` with **pending** required checks → arm auto-merge and
+    wait for them to land.
+6.  ``blocked`` for a reason that cannot self-resolve (missing
+    approvals we cannot supply, genuinely failing checks on an
+    up-to-date branch) → terminal failure with that reason.
+7.  ``unstable`` → merge while the merge button is live
+    (``mergeable`` is True — e.g. only a non-required check is red);
+    otherwise wait once for mergeability to settle, then fail.
+8.  ``clean`` / unknown / "" → attempt the merge and let the merge
+    call itself be the arbiter.
+
+Forward progress: every recovery rung is attempted at most once per
+item per run (tracked via ``attempted``), so a recovery that does not
+change the observed state degrades to the next rung instead of
+looping.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+
+
+class ActionKind(Enum):
+    """What the pipeline should do next for a PR."""
+
+    MERGE = "merge"  # attempt the merge now
+    WAIT_CHECKS = "wait_checks"  # arm auto-merge, park until checks land
+    REBASE_DEPENDABOT = "rebase_dependabot"  # post @dependabot rebase, park
+    REBASE_BRANCH = "rebase_branch"  # update-branch / local rebase, park
+    RECREATE = "recreate"  # post @dependabot recreate, park
+    RETRIGGER_PRECOMMIT = "retrigger_precommit"  # post pre-commit.ci run, park
+    FAIL = "fail"  # terminal: no recovery applies
+
+
+@dataclass
+class Action:
+    kind: ActionKind
+    reason: str
+
+    def __repr__(self) -> str:  # pragma: no cover - trivial
+        return f"Action({self.kind.value}, {self.reason!r})"
+
+
+# ``attempted`` markers, shared with WorkItem.attempts.
+ATTEMPT_REBASE = "rebase"
+ATTEMPT_RECREATE = "recreate"
+ATTEMPT_PRECOMMIT = "precommit-retrigger"
+ATTEMPT_WAIT = "wait-checks"
+
+
+@dataclass
+class LadderInput:
+    """Pure, observed facts about one PR.  No I/O objects.
+
+    ``behind_by`` is the commit count the PR branch is behind its base
+    (``compare.behind_by``); ``None`` means unknown.  ``block_reason``
+    is the phrase from ``analyze_block_reason`` when the PR is
+    ``blocked``.  The three check classifications describe the PR's
+    *required* checks only and may co-occur (a stuck check is also a
+    pending one); ``decide`` resolves overlaps by rung priority.
+    """
+
+    mergeable_state: str  # clean/dirty/blocked/behind/unstable/unknown/""
+    mergeable: bool | None
+    is_dependabot: bool
+    behind_by: int | None = None
+    block_reason: str | None = None
+    has_failing_required_check: bool = False
+    has_pending_required_check: bool = False
+    stuck_required_check: str | None = None  # check name when stuck
+    stale_precommit_check: bool = False
+    fix_out_of_date: bool = True
+    attempted: set[str] = field(default_factory=set)
+
+
+def decide(facts: LadderInput) -> Action:
+    """Return the next action for a PR in the given observed state."""
+    state = facts.mergeable_state
+
+    if state == "dirty":
+        return _decide_dirty(facts)
+
+    if state == "behind":
+        return _decide_behind(facts)
+
+    if state == "blocked":
+        return _decide_blocked(facts)
+
+    if state == "unstable":
+        return _decide_unstable(facts)
+
+    # clean, unknown, "" — attempt the merge and let the merge call
+    # itself be the arbiter.  This mirrors the legacy Step 6 routing.
+    return Action(ActionKind.MERGE, f"state {state or 'unknown'!r}: attempt merge")
+
+
+def _decide_unstable(facts: LadderInput) -> Action:
+    # ``unstable`` merges directly only while the merge button is
+    # live (mergeable is True — e.g. a non-required check is red).
+    # When mergeability is still computing or reads False, wait once
+    # for it to settle rather than firing a premature merge call.
+    if facts.mergeable is True:
+        return Action(
+            ActionKind.MERGE,
+            "unstable but mergeable: attempt merge",
+        )
+    if ATTEMPT_WAIT not in facts.attempted:
+        return Action(
+            ActionKind.WAIT_CHECKS,
+            "unstable and not mergeable: wait for mergeability to settle",
+        )
+    return Action(ActionKind.FAIL, "unstable and never became mergeable")
+
+
+def _decide_dirty(facts: LadderInput) -> Action:
+    if facts.is_dependabot and ATTEMPT_REBASE not in facts.attempted:
+        return Action(
+            ActionKind.REBASE_DEPENDABOT,
+            "merge conflict: dependabot rebase regenerates the branch",
+        )
+    return Action(ActionKind.FAIL, "merge conflicts")
+
+
+def _decide_behind(facts: LadderInput) -> Action:
+    if facts.fix_out_of_date and ATTEMPT_REBASE not in facts.attempted:
+        if facts.is_dependabot:
+            return Action(
+                ActionKind.REBASE_DEPENDABOT,
+                "behind base: dependabot rebase",
+            )
+        return Action(ActionKind.REBASE_BRANCH, "behind base: update branch")
+    if ATTEMPT_WAIT not in facts.attempted:
+        # Not fixing (or already fixed once): arm auto-merge so GitHub
+        # completes the merge when the branch catches up.
+        return Action(
+            ActionKind.WAIT_CHECKS,
+            "behind base: defer to auto-merge",
+        )
+    return Action(ActionKind.FAIL, "behind base and rebase did not converge")
+
+
+def _decide_blocked(facts: LadderInput) -> Action:
+    # Rung 3: stale failing verdict.  A required check that *failed*
+    # on a branch that is *behind base* was judged against pre-rebase
+    # content (e.g. an org-required workflow audit that the base
+    # branch has since fixed).  Only a rebase re-runs it against
+    # current base.  Guard: branch demonstrably behind, one attempt.
+    if (
+        facts.has_failing_required_check
+        and (facts.behind_by or 0) > 0
+        and ATTEMPT_REBASE not in facts.attempted
+    ):
+        if facts.is_dependabot:
+            return Action(
+                ActionKind.REBASE_DEPENDABOT,
+                "failing required check on stale branch: rebase to "
+                "re-run checks against current base",
+            )
+        return Action(
+            ActionKind.REBASE_BRANCH,
+            "failing required check on stale branch: update branch to "
+            "re-run checks against current base",
+        )
+
+    # Rung 4a: a required check stuck in queued/pending far beyond
+    # normal startup.  Recreating is the only reliable recovery for a
+    # dependabot PR whose required check will never report.
+    if facts.stuck_required_check and ATTEMPT_RECREATE not in facts.attempted:
+        if facts.is_dependabot:
+            return Action(
+                ActionKind.RECREATE,
+                f"stuck required check: {facts.stuck_required_check}",
+            )
+        # Non-dependabot PRs have no recreate macro; fall through to
+        # the pending/terminal rungs below.
+
+    # Rung 4b: a hung pre-commit.ci run gets its own re-trigger.
+    if facts.stale_precommit_check and ATTEMPT_PRECOMMIT not in facts.attempted:
+        return Action(
+            ActionKind.RETRIGGER_PRECOMMIT,
+            "stale pre-commit.ci check: re-trigger",
+        )
+
+    # Rung 5: checks are genuinely running — arm auto-merge and wait.
+    if facts.has_pending_required_check and ATTEMPT_WAIT not in facts.attempted:
+        return Action(
+            ActionKind.WAIT_CHECKS,
+            "pending required checks: defer to auto-merge",
+        )
+
+    # Rung 6: blocked for a reason no recovery addresses.
+    reason = facts.block_reason or "blocked and cannot resolve on its own"
+    return Action(ActionKind.FAIL, reason)
+
+
+__all__ = [
+    "Action",
+    "ActionKind",
+    "LadderInput",
+    "decide",
+    "ATTEMPT_REBASE",
+    "ATTEMPT_RECREATE",
+    "ATTEMPT_PRECOMMIT",
+    "ATTEMPT_WAIT",
+]

--- a/src/dependamerge/engine/model.py
+++ b/src/dependamerge/engine/model.py
@@ -1,0 +1,133 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 The Linux Foundation
+
+"""Core data model for the merge orchestration engine.
+
+The engine executes a batch of *work items* (one per pull request)
+through a pipeline of named *phases*.  Each phase performs bounded
+active work (API calls) and returns a :class:`Transition` telling the
+engine what to do next:
+
+- :class:`Advance` — run another phase immediately.
+- :class:`Park` — the item is waiting on an external event (a
+  dependabot rebase, CI checks, auto-merge).  The engine releases the
+  item's concurrency slot while it waits; the reconciler wakes it when
+  its wake predicate fires or its deadline passes.
+- :class:`Finish` — the item reached a terminal outcome.
+
+The engine is deliberately generic: it does not import GitHub types or
+``MergeResult``.  Payloads and outcomes are opaque to it, which keeps
+the scheduling kernel free of import cycles and independently testable.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any
+
+
+class ItemState(Enum):
+    """Lifecycle state of a work item inside the engine."""
+
+    QUEUED = "queued"
+    ACTIVE = "active"
+    PARKED = "parked"
+    DONE = "done"
+
+
+@dataclass
+class Snapshot:
+    """A point-in-time view of a pull request's merge-relevant state.
+
+    Produced by the reconciler's snapshot source once per tick for
+    every parked item, and consumed by :class:`Park` wake predicates.
+    All fields are optional so a failed or partial refresh degrades
+    gracefully — predicates must treat ``None`` as "unknown, keep
+    waiting".
+    """
+
+    state: str | None = None  # "open" / "closed"
+    merged: bool | None = None
+    mergeable: bool | None = None
+    mergeable_state: str | None = None  # clean/dirty/blocked/behind/...
+    head_sha: str | None = None
+
+
+@dataclass
+class WorkItem:
+    """One unit of work (a single pull request) tracked by the engine.
+
+    ``index`` preserves the caller's input ordering so results can be
+    reassembled positionally even when items complete out of order.
+    ``lane`` groups items that must run strictly sequentially (one
+    in-flight PR per repository).  ``payload`` carries the caller's PR
+    object; ``outcome`` carries the terminal result.  Both are opaque
+    to the engine.
+    """
+
+    index: int
+    lane: str
+    key: str  # stable identity, e.g. "owner/repo#123"
+    payload: Any
+    phase: str = ""
+    state: ItemState = ItemState.QUEUED
+    outcome: Any = None
+    snapshot: Snapshot | None = None
+    # Names of recovery actions already attempted for this item, used
+    # by the recovery ladder to guarantee forward progress (each rung
+    # fires at most once per item per run).
+    attempts: set[str] = field(default_factory=set)
+    # Diagnostic trail of (phase, transition-repr) tuples.
+    history: list[tuple[str, str]] = field(default_factory=list)
+
+
+@dataclass
+class Advance:
+    """Immediately run ``phase`` next (the item stays active)."""
+
+    phase: str
+
+    def __repr__(self) -> str:  # pragma: no cover - trivial
+        return f"Advance({self.phase!r})"
+
+
+@dataclass
+class Park:
+    """Release the slot and wait for an external event.
+
+    ``wake`` is evaluated by the reconciler against a fresh
+    :class:`Snapshot` each tick; when it returns True the item is
+    rescheduled on ``on_wake``.  When ``timeout`` elapses first (or
+    the run-wide deadline passes, or the engine runs in no-wait mode)
+    the item is rescheduled on ``on_timeout`` instead.  ``on_timeout``
+    phases should be cheap: in no-wait mode they run immediately after
+    the parking phase, and at the run deadline many of them may run
+    back-to-back.
+    """
+
+    reason: str
+    wake: Callable[[WorkItem], bool]
+    on_wake: str
+    on_timeout: str
+    timeout: float | None = None  # None → engine default (merge timeout)
+
+    def __repr__(self) -> str:  # pragma: no cover - trivial
+        return (
+            f"Park({self.reason!r}, on_wake={self.on_wake!r}, "
+            f"on_timeout={self.on_timeout!r})"
+        )
+
+
+@dataclass
+class Finish:
+    """The item reached a terminal outcome."""
+
+    outcome: Any
+
+    def __repr__(self) -> str:  # pragma: no cover - trivial
+        return "Finish(...)"
+
+
+Transition = Advance | Park | Finish

--- a/src/dependamerge/engine/reconciler.py
+++ b/src/dependamerge/engine/reconciler.py
@@ -1,0 +1,179 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 The Linux Foundation
+
+"""Reconciler: one batched poller for every parked work item.
+
+Today each waiting PR runs its own polling loop while holding a global
+concurrency slot (``_wait_for_auto_merge``, the conflict-recovery
+phases, post-rebase polls, recreate waits, …), so a handful of slow
+external operations — a five-minute ``@dependabot rebase``, a CI
+re-run — can pin the entire run's capacity.
+
+The reconciler inverts that: parked items hold **no** slot.  A single
+coroutine ticks at a fixed cadence, refreshes one :class:`Snapshot`
+per parked item per tick (batched through the shared HTTP client,
+whose own semaphore/RPS limiter is the real API-protection layer),
+evaluates each item's wake predicate, and resolves the item's parked
+future with:
+
+- ``True``  → the wake condition fired; the engine reschedules the
+  item's ``on_wake`` phase.
+- ``False`` → the item's deadline (or the run-wide deadline) passed;
+  the engine reschedules ``on_timeout``.
+
+API cost is unchanged from the status quo (one GET per waiting PR per
+interval); what changes is that waiting consumes zero concurrency.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+
+from .model import Park, Snapshot, WorkItem
+
+# A callable that fetches a fresh snapshot for a work item.  Returning
+# ``None`` means "refresh failed, keep the previous snapshot" — the
+# reconciler never wakes or times an item out based on a failed read
+# alone.
+SnapshotSource = Callable[[WorkItem], Awaitable[Snapshot | None]]
+
+# Floor for the tick cadence: one snapshot request per parked item is
+# issued per tick, so smaller intervals would hot-loop against the API.
+MIN_INTERVAL = 0.05
+
+
+@dataclass
+class _Parked:
+    item: WorkItem
+    park: Park
+    deadline: float  # monotonic; already clamped to the run deadline
+    waiter: asyncio.Future[bool]
+
+
+class Reconciler:
+    """Watches parked work items and wakes them on state changes.
+
+    Owned and driven by the engine: the engine calls :meth:`park` to
+    suspend an item (awaiting the returned future *without* holding a
+    slot) and runs :meth:`run` as a background task for the duration
+    of the batch.
+
+    ``interval`` is the tick cadence in seconds.  Values below
+    :data:`MIN_INTERVAL` are clamped up to it: each tick issues one
+    snapshot request per parked item, so an arbitrarily small
+    interval would turn the poller into a hot loop against the API.
+    """
+
+    def __init__(
+        self,
+        snapshot_source: SnapshotSource,
+        *,
+        interval: float,
+        log: logging.Logger | None = None,
+    ) -> None:
+        self._snapshot_source = snapshot_source
+        self._interval = max(MIN_INTERVAL, interval)
+        self._parked: dict[str, _Parked] = {}
+        self._log = log or logging.getLogger(__name__)
+
+    # -- engine-facing API -------------------------------------------------
+
+    async def park(self, item: WorkItem, park: Park, deadline: float) -> bool:
+        """Suspend ``item`` until its wake predicate fires or times out.
+
+        Returns True when the wake condition fired, False on timeout.
+        The caller must not hold a concurrency slot while awaiting.
+        """
+        loop = asyncio.get_running_loop()
+        # An already-expired deadline resolves immediately as a
+        # timeout; this is what makes no-wait/late parks cheap.
+        if loop.time() >= deadline:
+            return False
+        # Defensive: the engine enforces key uniqueness, but if a
+        # duplicate park slips through anyway, time the previous
+        # waiter out rather than orphaning it (a silently overwritten
+        # entry would leave its task suspended forever).
+        stale = self._parked.pop(item.key, None)
+        if stale is not None and not stale.waiter.done():
+            self._log.warning(
+                "reconciler: duplicate park for %s; timing out the " "previous waiter",
+                item.key,
+            )
+            stale.waiter.set_result(False)
+        waiter: asyncio.Future[bool] = loop.create_future()
+        entry = _Parked(item=item, park=park, deadline=deadline, waiter=waiter)
+        self._parked[item.key] = entry
+        try:
+            return await waiter
+        finally:
+            # Pop only our own entry: a duplicate park may have
+            # replaced it while we were suspended.
+            if self._parked.get(item.key) is entry:
+                self._parked.pop(item.key, None)
+
+    def parked_view(self) -> dict[str, tuple[str, float]]:
+        """Snapshot of parked items: key → (reason, deadline).
+
+        Consumed by progress/ticker UIs; the returned dict is a copy.
+        """
+        return {
+            key: (entry.park.reason, entry.deadline)
+            for key, entry in self._parked.items()
+        }
+
+    def flush(self) -> None:
+        """Time out every parked item immediately (run teardown)."""
+        for entry in list(self._parked.values()):
+            if not entry.waiter.done():
+                entry.waiter.set_result(False)
+
+    # -- background loop ---------------------------------------------------
+
+    async def run(self) -> None:
+        """Tick until cancelled: refresh, evaluate, wake/expire."""
+        while True:
+            await asyncio.sleep(self._interval)
+            await self._tick()
+
+    async def _tick(self) -> None:
+        entries = list(self._parked.values())
+        if not entries:
+            return
+        # Refresh all parked snapshots concurrently; the shared HTTP
+        # client's own concurrency/RPS limits pace the actual requests.
+        snapshots = await asyncio.gather(
+            *(self._refresh(entry) for entry in entries),
+            return_exceptions=True,
+        )
+        loop = asyncio.get_running_loop()
+        now = loop.time()
+        for entry, snap in zip(entries, snapshots, strict=False):
+            if entry.waiter.done():
+                continue
+            if isinstance(snap, BaseException):
+                self._log.debug(
+                    "reconciler: snapshot refresh failed for %s: %s",
+                    entry.item.key,
+                    snap,
+                )
+            elif snap is not None:
+                entry.item.snapshot = snap
+            woke = False
+            try:
+                woke = bool(entry.park.wake(entry.item))
+            except Exception as exc:  # predicate bugs must not kill the loop
+                self._log.warning(
+                    "reconciler: wake predicate failed for %s: %s",
+                    entry.item.key,
+                    exc,
+                )
+            if woke:
+                entry.waiter.set_result(True)
+            elif now >= entry.deadline:
+                entry.waiter.set_result(False)
+
+    async def _refresh(self, entry: _Parked) -> Snapshot | None:
+        return await self._snapshot_source(entry.item)

--- a/src/dependamerge/engine/scheduler.py
+++ b/src/dependamerge/engine/scheduler.py
@@ -1,0 +1,292 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 The Linux Foundation
+
+"""Engine: lane-serialised, slot-bounded, park-aware scheduler.
+
+Scheduling model
+----------------
+
+- **Lanes** — items sharing a lane key (one lane per repository) run
+  strictly sequentially, first-in-first-out.  This preserves the
+  invariant that at most one PR per repository is in flight, which
+  keeps same-repo merges from racing GitHub's mergeability
+  propagation and prevents dependabot rebase storms.
+- **Slots** — a global semaphore bounds how many items execute an
+  *active* phase concurrently.  Unlike the legacy orchestration, a
+  slot is held only while a phase is actually running: a parked item
+  (waiting on a rebase, CI, or auto-merge) holds no slot, so waiting
+  never starves runnable work.
+- **Parking** — a phase that starts a slow external operation returns
+  :class:`~dependamerge.engine.model.Park`; the engine releases the
+  slot and hands the item to the :class:`Reconciler`, which wakes it
+  when its predicate fires or its deadline passes.
+
+Budget model
+------------
+
+- ``default_park_timeout`` bounds each individual park (the legacy
+  ``--merge-timeout`` role) — but since parked items are free, this is
+  a responsiveness bound, not a capacity trade-off.
+- ``max_wait`` bounds the whole run: every park deadline is clamped to
+  it, and once it passes new parks resolve immediately as timeouts.
+  Unlike the legacy code (where only ``_wait_for_auto_merge`` honoured
+  the run deadline) the clamp here applies to *every* wait uniformly.
+- ``max_wait == 0`` is fire-and-forget: parks never wait — the parking
+  phase's side effects (rebase requested, auto-merge armed) still
+  happen, then ``on_timeout`` runs immediately to produce the
+  fire-and-forget outcome.
+
+Failure model
+-------------
+
+A phase that raises does not crash the run: the exception is converted
+to a terminal outcome via ``PhaseRunner.on_error`` and the item's lane
+continues with its next item.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import Callable
+from typing import Any, Protocol
+
+from .model import Advance, Finish, ItemState, Park, Transition, WorkItem
+from .reconciler import Reconciler, SnapshotSource
+
+
+class PhaseRunner(Protocol):
+    """The pipeline the engine drives.
+
+    ``run`` executes one named phase for an item and returns the next
+    transition.  ``on_error`` converts an unexpected phase exception
+    into a terminal outcome (never raises).
+    """
+
+    async def run(self, item: WorkItem, phase: str) -> Transition: ...
+
+    def on_error(self, item: WorkItem, exc: Exception) -> Any: ...
+
+
+# Safety valve: an item may not execute more than this many phases.
+# Well-formed pipelines terminate long before this; the cap converts a
+# transition cycle bug into a per-item failure instead of a hang.
+MAX_PHASE_EXECUTIONS = 100
+
+
+class Engine:
+    """Run a batch of work items through a :class:`PhaseRunner`.
+
+    ``reconcile_interval`` sets the reconciler's tick cadence and is
+    clamped to :data:`~dependamerge.engine.reconciler.MIN_INTERVAL`
+    (see :class:`Reconciler`).
+    """
+
+    def __init__(
+        self,
+        runner: PhaseRunner,
+        snapshot_source: SnapshotSource,
+        *,
+        concurrency: int,
+        default_park_timeout: float,
+        reconcile_interval: float,
+        max_wait: float | None = None,
+        log: logging.Logger | None = None,
+        on_item_done: Callable[[WorkItem], None] | None = None,
+    ) -> None:
+        if concurrency < 1:
+            raise ValueError("concurrency must be >= 1")
+        self._runner = runner
+        self._slots = asyncio.Semaphore(concurrency)
+        self._default_park_timeout = default_park_timeout
+        self._max_wait = max_wait
+        self._no_wait = max_wait is not None and max_wait <= 0
+        self._run_deadline: float | None = None
+        self._log = log or logging.getLogger(__name__)
+        self._on_item_done = on_item_done
+        self._reconciler = Reconciler(
+            snapshot_source,
+            interval=reconcile_interval,
+            log=self._log,
+        )
+
+    # -- observability -----------------------------------------------------
+
+    @property
+    def reconciler(self) -> Reconciler:
+        return self._reconciler
+
+    def parked_view(self) -> dict[str, tuple[str, float]]:
+        """Parked items: key → (reason, deadline).  For progress UIs."""
+        return self._reconciler.parked_view()
+
+    # -- run ---------------------------------------------------------------
+
+    async def run(self, items: list[WorkItem]) -> list[WorkItem]:
+        """Process ``items``; returns them in input (index) order.
+
+        Every item is guaranteed to come back with ``state == DONE``
+        and an ``outcome`` set (phase exceptions are converted by
+        ``PhaseRunner.on_error``).
+
+        Raises ``ValueError`` when two items share a ``key``: the
+        reconciler and progress views index parked items by key, so
+        duplicates would silently shadow each other.
+        """
+        if not items:
+            return []
+
+        seen_keys: set[str] = set()
+        for item in items:
+            if item.key in seen_keys:
+                raise ValueError(f"duplicate work item key: {item.key!r}")
+            seen_keys.add(item.key)
+
+        loop = asyncio.get_running_loop()
+        self._run_deadline = None
+        if self._max_wait is not None and self._max_wait > 0:
+            self._run_deadline = loop.time() + self._max_wait
+
+        lanes: dict[str, list[WorkItem]] = {}
+        for item in items:
+            lanes.setdefault(item.lane, []).append(item)
+
+        reconciler_task = asyncio.create_task(
+            self._reconciler.run(), name="engine-reconciler"
+        )
+        lane_tasks = [
+            asyncio.create_task(
+                self._lane_worker(lane_items),
+                name=f"engine-lane-{lane}",
+            )
+            for lane, lane_items in lanes.items()
+        ]
+        try:
+            await asyncio.gather(*lane_tasks)
+        finally:
+            self._reconciler.flush()
+            reconciler_task.cancel()
+            try:
+                await reconciler_task
+            except asyncio.CancelledError:
+                pass
+            except Exception as exc:  # pragma: no cover - defensive
+                self._log.warning("engine reconciler exited unexpectedly: %s", exc)
+
+        return sorted(items, key=lambda item: item.index)
+
+    # -- internals ---------------------------------------------------------
+
+    async def _lane_worker(self, lane_items: list[WorkItem]) -> None:
+        """Drive one lane's items strictly sequentially."""
+        for item in lane_items:
+            try:
+                await self._drive(item)
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:  # pragma: no cover - _drive is total
+                # _drive already routes phase exceptions through
+                # on_error; anything surfacing here is an engine bug.
+                # Fail the item, keep the lane alive.
+                self._log.error("engine: internal error driving %s: %s", item.key, exc)
+                item.outcome = self._runner.on_error(item, exc)
+                item.state = ItemState.DONE
+            if self._on_item_done is not None:
+                try:
+                    self._on_item_done(item)
+                except Exception as exc:  # observer bugs must not kill lanes
+                    self._log.warning(
+                        "engine: on_item_done observer failed for %s: %s",
+                        item.key,
+                        exc,
+                    )
+
+    async def _drive(self, item: WorkItem) -> None:
+        """Run one item to a terminal outcome."""
+        loop = asyncio.get_running_loop()
+        executions = 0
+        while True:
+            executions += 1
+            if executions > MAX_PHASE_EXECUTIONS:
+                item.outcome = self._runner.on_error(
+                    item,
+                    RuntimeError(
+                        f"phase budget exhausted after "
+                        f"{MAX_PHASE_EXECUTIONS} transitions "
+                        f"(last phase: {item.phase!r})"
+                    ),
+                )
+                item.state = ItemState.DONE
+                return
+
+            # Active phase: slot held only for the duration of the
+            # call.  The item stays QUEUED while it waits for a slot
+            # so observers can tell "waiting for capacity" apart from
+            # "executing".
+            item.state = ItemState.QUEUED
+            async with self._slots:
+                item.state = ItemState.ACTIVE
+                try:
+                    transition: Transition = await self._runner.run(item, item.phase)
+                except asyncio.CancelledError:
+                    raise
+                except Exception as exc:
+                    item.outcome = self._runner.on_error(item, exc)
+                    item.state = ItemState.DONE
+                    return
+            item.history.append((item.phase, repr(transition)))
+
+            if isinstance(transition, Finish):
+                item.outcome = transition.outcome
+                item.state = ItemState.DONE
+                return
+
+            if isinstance(transition, Advance):
+                item.phase = transition.phase
+                continue
+
+            if isinstance(transition, Park):
+                # No-wait mode: the parking phase's side effects have
+                # already happened; resolve the wait instantly.
+                if self._no_wait:
+                    item.phase = transition.on_timeout
+                    continue
+                timeout = (
+                    transition.timeout
+                    if transition.timeout is not None
+                    else self._default_park_timeout
+                )
+                deadline = loop.time() + max(0.0, timeout)
+                if self._run_deadline is not None:
+                    deadline = min(deadline, self._run_deadline)
+                item.state = ItemState.PARKED
+                woke = await self._reconciler.park(item, transition, deadline)
+                item.phase = transition.on_wake if woke else transition.on_timeout
+                continue
+
+            # Unknown transition type — treat as a pipeline bug.
+            item.outcome = self._runner.on_error(
+                item,
+                RuntimeError(f"unknown transition {transition!r}"),
+            )
+            item.state = ItemState.DONE
+            return
+
+
+def flat_lanes(items: list[WorkItem]) -> None:
+    """Give every item its own lane (legacy flat-scheduler semantics).
+
+    Mutates ``item.lane`` in place.  Use when the batch is known to
+    contain at most one PR per repository, or when per-repo
+    serialisation is handled elsewhere.
+    """
+    for item in items:
+        item.lane = f"{item.lane}#{item.index}"
+
+
+__all__ = [
+    "Engine",
+    "PhaseRunner",
+    "flat_lanes",
+    "MAX_PHASE_EXECUTIONS",
+]

--- a/src/dependamerge/github_async.py
+++ b/src/dependamerge/github_async.py
@@ -268,6 +268,20 @@ class GitHubAsync:
         # Cache for the authenticated user's login (never changes during a session)
         self._authenticated_user_login: str | None = None
 
+        # Session caches for repo/branch-scoped configuration.  Branch
+        # protection, required status checks, and a repo's default
+        # branch are effectively immutable for the lifetime of a merge
+        # run, yet the merge pipeline consults them repeatedly — once
+        # per PR (or several times per *blocked* PR via
+        # ``analyze_block_reason``).  Caching them here collapses those
+        # repeats into one fetch per repo/branch.  No locking: a
+        # concurrent first miss may fetch twice, which is harmless and
+        # no worse than the uncached behaviour.
+        self._default_branch_cache: dict[str, str | None] = {}
+        self._required_checks_cache: dict[str, list[dict[str, Any]]] = {}
+        self._branch_protection_cache: dict[str, dict[str, Any]] = {}
+        self._requires_signatures_cache: dict[str, bool] = {}
+
         # Cache for the token's OAuth scopes.  ``_token_scopes_fetched``
         # distinguishes "not looked up yet" from "looked up, but this token
         # type does not expose scopes" (fine-grained PAT / app token, which
@@ -1171,7 +1185,25 @@ class GitHubAsync:
 
         Returns:
             True if signed commits are required by *either* mechanism.
+
+        Results are cached per ``owner/repo@branch`` for the session:
+        the requirement is branch-protection/ruleset configuration that
+        does not change while dependamerge runs, and the uncached path
+        costs up to 3 + N requests (classic-protection probe, repo
+        metadata, ruleset list, one detail GET per ruleset).
         """
+        cache_key = f"{owner}/{repo}@{branch}"
+        cached = self._requires_signatures_cache.get(cache_key)
+        if cached is not None:
+            return cached
+        result = await self._requires_commit_signatures_uncached(owner, repo, branch)
+        self._requires_signatures_cache[cache_key] = result
+        return result
+
+    async def _requires_commit_signatures_uncached(
+        self, owner: str, repo: str, branch: str
+    ) -> bool:
+        """Uncached implementation of :meth:`requires_commit_signatures`."""
         # --- 1. Classic branch protection ---
         try:
             # The signatures endpoint returns 200 with {"enabled": true/false}
@@ -1374,20 +1406,28 @@ class GitHubAsync:
         are not available.
         Returns a list of dicts with 'context' and optionally 'integration_id'.
         Results are deduplicated by ``context``.
+
+        Results are cached per ``owner/repo@branch`` for the session:
+        required-check configuration is repo/branch-level state that does
+        not change while dependamerge runs, and the block-reason analysis
+        consults it repeatedly (several times per blocked PR).  The
+        uncached path costs 2 + N requests (repo + ruleset list + one
+        detail GET per ruleset), so the cache saves a burst of API
+        traffic on every repeat.
         """
+        cache_key = f"{owner}/{repo}@{branch}"
+        cached = self._required_checks_cache.get(cache_key)
+        if cached is not None:
+            # Return a copy so callers cannot mutate the cached list.
+            return list(cached)
+
         required_checks: list[dict[str, Any]] = []
         seen_contexts: set[str] = set()
 
         # Resolve the repo's actual default branch so that ~DEFAULT_BRANCH
         # ruleset conditions are evaluated correctly (not hardcoded to
         # main/master).
-        default_branch: str | None = None
-        try:
-            repo_data = await self.get(f"/repos/{owner}/{repo}")
-            if isinstance(repo_data, dict):
-                default_branch = repo_data.get("default_branch")
-        except Exception:
-            pass  # Will fall through to conservative matching
+        default_branch = await self._resolve_default_branch(owner, repo)
 
         # Try rulesets first (org-level and repo-level)
         try:
@@ -1459,6 +1499,7 @@ class GitHubAsync:
                 # the current token; treat as no required checks.
                 pass
 
+        self._required_checks_cache[cache_key] = list(required_checks)
         return required_checks
 
     async def get_branch_protection(
@@ -1468,18 +1509,53 @@ class GitHubAsync:
         Get branch protection rules for a branch.
 
         REST: GET /repos/{owner}/{repo}/branches/{branch}/protection
+
+        Results (including the empty "no protection" result) are cached
+        per ``owner/repo@branch`` for the session: the merge pipeline
+        calls this once per PR via ``_check_merge_requirements``, but
+        protection config is branch-level state that does not change
+        mid-run.  Errors other than 404 are not cached so a transient
+        failure can succeed on retry.
         """
+        cache_key = f"{owner}/{repo}@{branch}"
+        cached = self._branch_protection_cache.get(cache_key)
+        if cached is not None:
+            return cached
         try:
             protection_data = await self.get(
                 f"/repos/{owner}/{repo}/branches/{branch}/protection"
             )
             # Branch protection data should always be a dict, not a list
-            return protection_data if isinstance(protection_data, dict) else {}
+            result = protection_data if isinstance(protection_data, dict) else {}
+            self._branch_protection_cache[cache_key] = result
+            return result
         except Exception as e:
             # Branch protection might not be enabled, return empty dict
             if "404" in str(e):
+                self._branch_protection_cache[cache_key] = {}
                 return {}
             raise
+
+    async def get_authenticated_user_login(self) -> str | None:
+        """Return the authenticated user's login, cached for the session.
+
+        The login never changes for a given token, so the ``/user``
+        round-trip is paid at most once per client instance.  Returns
+        ``None`` when the lookup fails (callers should degrade
+        gracefully); failures are not cached so a transient error can
+        recover on the next call.
+        """
+        if self._authenticated_user_login is None:
+            try:
+                user_data = await self.get("/user")
+            except Exception as e:
+                self.log.debug("Could not resolve authenticated user: %s", e)
+                return None
+            if isinstance(user_data, dict):
+                login = user_data.get("login")
+                if isinstance(login, str) and login:
+                    self._authenticated_user_login = login
+        return self._authenticated_user_login
 
     async def check_user_can_bypass_protection(
         self, owner: str, repo: str, force_level: str = "code-owners"
@@ -1898,12 +1974,23 @@ class GitHubAsync:
         return None
 
     async def analyze_block_reason(
-        self, owner: str, repo: str, number: int, head_sha: str
+        self,
+        owner: str,
+        repo: str,
+        number: int,
+        head_sha: str,
+        base_branch: str | None = None,
     ) -> str:
         """
         Analyze why a PR is blocked and return appropriate status.
 
         This is the async version that should be used from async contexts.
+
+        ``base_branch`` lets callers that already know the PR's base ref
+        (e.g. the merge pipeline, which carries it on ``PullRequestInfo``)
+        skip the PR-detail fetch this method otherwise performs just to
+        read ``base.ref`` — one request saved per invocation, and this
+        method runs several times per blocked PR.
         """
         # Reviews
         approved = False
@@ -2014,21 +2101,21 @@ class GitHubAsync:
         # required status-check lookup and the final guard-kind
         # classification, so a wrong value (e.g. assuming "main" on a repo
         # that defaults to "master") produces a misleading block reason.
-        # Prefer the PR's own base ref; if that cannot be read, fall back
-        # to the repository's real default branch rather than a hardcoded
-        # name, and only give up (leaving it ``None``) when neither is
-        # available.
-        base_branch: str | None = None
-        try:
-            pr_data = await self.get(f"/repos/{owner}/{repo}/pulls/{number}")
-            if isinstance(pr_data, dict):
-                ref = pr_data.get("base", {}).get("ref")
-                if isinstance(ref, str) and ref:
-                    base_branch = ref
-        except Exception as pr_err:
-            self.log.debug(
-                f"Could not read base branch for {owner}/{repo}#{number}: {pr_err}"
-            )
+        # Prefer the caller-supplied value, then the PR's own base ref; if
+        # neither is available, fall back to the repository's real default
+        # branch rather than a hardcoded name, and only give up (leaving
+        # it ``None``) when nothing can be determined.
+        if base_branch is None:
+            try:
+                pr_data = await self.get(f"/repos/{owner}/{repo}/pulls/{number}")
+                if isinstance(pr_data, dict):
+                    ref = pr_data.get("base", {}).get("ref")
+                    if isinstance(ref, str) and ref:
+                        base_branch = ref
+            except Exception as pr_err:
+                self.log.debug(
+                    f"Could not read base branch for {owner}/{repo}#{number}: {pr_err}"
+                )
 
         if base_branch is None:
             base_branch = await self._resolve_default_branch(owner, repo)
@@ -2145,7 +2232,14 @@ class GitHubAsync:
         ``None`` when it cannot be determined (the repo is unreadable or
         the field is absent), letting callers degrade gracefully instead
         of operating on a wrong branch.
+
+        Successful lookups are cached per ``owner/repo`` for the
+        session (a repo's default branch does not change mid-run);
+        failures are not cached so a transient error can recover.
         """
+        cache_key = f"{owner}/{repo}"
+        if cache_key in self._default_branch_cache:
+            return self._default_branch_cache[cache_key]
         try:
             repo_data = await self.get(f"/repos/{owner}/{repo}")
         except Exception as e:
@@ -2156,6 +2250,7 @@ class GitHubAsync:
         if isinstance(repo_data, dict):
             default_branch = repo_data.get("default_branch")
             if isinstance(default_branch, str) and default_branch:
+                self._default_branch_cache[cache_key] = default_branch
                 return default_branch
         return None
 

--- a/src/dependamerge/github_async.py
+++ b/src/dependamerge/github_async.py
@@ -1852,6 +1852,51 @@ class GitHubAsync:
                 raise perm_error from e
             raise
 
+    async def get_behind_by(
+        self, owner: str, repo: str, base_ref: str, head_sha: str
+    ) -> int | None:
+        """Return how many commits ``head_sha`` is behind ``base_ref``.
+
+        GitHub's ``mergeable_state`` is a single value, so ``blocked``
+        (a failing required check) masks ``behind`` (a stale head).
+        This helper answers the staleness question independently via
+        the compare API, which works regardless of the reported
+        mergeable state and regardless of whether the head lives on a
+        fork (the SHA is resolvable in the base repository's network).
+
+        Args:
+            owner: Base repository owner
+            repo: Base repository name
+            base_ref: Base branch name (e.g. ``main``)
+            head_sha: Head commit SHA of the pull request
+
+        Returns:
+            The ``behind_by`` commit count, or ``None`` when the
+            comparison could not be performed (API error, unexpected
+            payload).  Callers must treat ``None`` as "unknown", not
+            as "up to date".
+        """
+        encoded_base = quote(base_ref, safe="")
+        try:
+            comparison = await self.get(
+                f"/repos/{owner}/{repo}/compare/{encoded_base}...{head_sha}"
+            )
+        except Exception as exc:
+            self.log.debug(
+                "Compare %s...%s failed for %s/%s: %s",
+                base_ref,
+                head_sha,
+                owner,
+                repo,
+                exc,
+            )
+            return None
+        if isinstance(comparison, dict):
+            behind = comparison.get("behind_by")
+            if isinstance(behind, int):
+                return behind
+        return None
+
     async def analyze_block_reason(
         self, owner: str, repo: str, number: int, head_sha: str
     ) -> str:

--- a/src/dependamerge/github_async.py
+++ b/src/dependamerge/github_async.py
@@ -1981,8 +1981,12 @@ class GitHubAsync:
         Returns:
             The ``behind_by`` commit count, or ``None`` when the
             comparison could not be performed (API error, unexpected
-            payload).  Callers must treat ``None`` as "unknown", not
-            as "up to date".
+            payload).  ``None`` means "unknown": callers must not
+            interpret it as ``behind_by == 0`` ("up to date"), and
+            staleness-driven write actions (e.g. requesting a rebase)
+            should require positive evidence (``behind_by > 0``)
+            rather than acting on an unknown — the pattern used by
+            ``AsyncMergeManager._blocked_pr_needs_rebase``.
         """
         encoded_base = quote(base_ref, safe="")
         try:

--- a/src/dependamerge/github_async.py
+++ b/src/dependamerge/github_async.py
@@ -1190,20 +1190,35 @@ class GitHubAsync:
         the requirement is branch-protection/ruleset configuration that
         does not change while dependamerge runs, and the uncached path
         costs up to 3 + N requests (classic-protection probe, repo
-        metadata, ruleset list, one detail GET per ruleset).
+        metadata, ruleset list, one detail GET per ruleset).  Verdicts
+        derived from transient API errors are *not* cached, so a
+        momentary outage cannot pin a wrong answer for the whole run.
         """
         cache_key = f"{owner}/{repo}@{branch}"
         cached = self._requires_signatures_cache.get(cache_key)
         if cached is not None:
             return cached
-        result = await self._requires_commit_signatures_uncached(owner, repo, branch)
-        self._requires_signatures_cache[cache_key] = result
+        result, reliable = await self._requires_commit_signatures_uncached(
+            owner, repo, branch
+        )
+        if reliable:
+            self._requires_signatures_cache[cache_key] = result
         return result
 
     async def _requires_commit_signatures_uncached(
         self, owner: str, repo: str, branch: str
-    ) -> bool:
-        """Uncached implementation of :meth:`requires_commit_signatures`."""
+    ) -> tuple[bool, bool]:
+        """Uncached implementation of :meth:`requires_commit_signatures`.
+
+        Returns:
+            Tuple of ``(requires_signatures, reliable)``.  ``reliable``
+            is False when a transient (non-404) API error prevented a
+            definitive verdict — a ``True`` verdict is always reliable
+            (positive evidence), but an error-derived ``False`` must
+            not be cached because the requirement may simply have been
+            unreadable at that moment.
+        """
+        reliable = True
         # --- 1. Classic branch protection ---
         try:
             # The signatures endpoint returns 200 with {"enabled": true/false}
@@ -1219,10 +1234,11 @@ class GitHubAsync:
                     repo,
                     branch,
                 )
-                return True
+                return True, True
         except Exception as e:
             # 404 → not enabled; other errors → continue checking rulesets
             if "404" not in str(e):
+                reliable = False
                 self.log.debug(
                     "Error checking classic signature requirement for %s/%s:%s: %s",
                     owner,
@@ -1273,6 +1289,10 @@ class GitHubAsync:
                     if not isinstance(detail, dict):
                         continue
                 except Exception as detail_err:
+                    # An unreadable ruleset could hide a
+                    # required_signatures rule — the eventual False
+                    # verdict is no longer definitive.
+                    reliable = False
                     self.log.debug(
                         "Could not fetch ruleset %s for %s/%s: %s",
                         ruleset_id,
@@ -1307,8 +1327,9 @@ class GitHubAsync:
                                 branch,
                                 detail.get("name", "unknown"),
                             )
-                            return True
+                            return True, True
         except Exception as e:
+            reliable = False
             self.log.debug(
                 "Error checking rulesets for signature requirement on %s/%s:%s: %s",
                 owner,
@@ -1317,7 +1338,7 @@ class GitHubAsync:
                 e,
             )
 
-        return False
+        return False, reliable
 
     @staticmethod
     def _ruleset_applies_to_branch(
@@ -1413,7 +1434,11 @@ class GitHubAsync:
         consults it repeatedly (several times per blocked PR).  The
         uncached path costs 2 + N requests (repo + ruleset list + one
         detail GET per ruleset), so the cache saves a burst of API
-        traffic on every repeat.
+        traffic on every repeat.  Results assembled while any of those
+        requests failed are *not* cached: the fetch treats errors as
+        "no required checks", and pinning that error-derived verdict
+        for the whole session could misclassify blocked PRs long after
+        a transient outage has passed.
         """
         cache_key = f"{owner}/{repo}@{branch}"
         cached = self._required_checks_cache.get(cache_key)
@@ -1423,6 +1448,7 @@ class GitHubAsync:
 
         required_checks: list[dict[str, Any]] = []
         seen_contexts: set[str] = set()
+        reliable = True
 
         # Resolve the repo's actual default branch so that ~DEFAULT_BRANCH
         # ruleset conditions are evaluated correctly (not hardcoded to
@@ -1471,10 +1497,12 @@ class GitHubAsync:
                                             seen_contexts.add(ctx)
                                             required_checks.append(check)
                     except Exception as detail_err:
+                        reliable = False
                         self.log.debug(
                             f"Could not fetch ruleset {ruleset_id} details: {detail_err}"
                         )
         except Exception as e:
+            reliable = False
             self.log.debug(f"Could not fetch rulesets for {owner}/{repo}: {e}")
 
         # Fall back to branch protection if no ruleset checks found
@@ -1494,12 +1522,16 @@ class GitHubAsync:
                             if ctx not in seen_contexts:
                                 seen_contexts.add(ctx)
                                 required_checks.append(check)
-            except Exception:
+            except Exception as e:
                 # Branch protection may be absent or inaccessible with
-                # the current token; treat as no required checks.
-                pass
+                # the current token; treat as no required checks.  A
+                # plain 404 is the definitive "no protection" answer;
+                # anything else leaves the verdict unreliable.
+                if "404" not in str(e):
+                    reliable = False
 
-        self._required_checks_cache[cache_key] = list(required_checks)
+        if reliable:
+            self._required_checks_cache[cache_key] = list(required_checks)
         return required_checks
 
     async def get_branch_protection(

--- a/src/dependamerge/merge_manager.py
+++ b/src/dependamerge/merge_manager.py
@@ -66,6 +66,15 @@ DEFAULT_MERGE_RECHECK_INTERVAL: float = 10.0  # seconds between polls
 # (possibly stale) fetch-time snapshot.
 MERGEABILITY_REFRESH_TIMEOUT_SECONDS: float = 10.0
 
+# First-poll delay for the auto-merge wait loop.  The loop's steady
+# cadence is ``DEFAULT_MERGE_RECHECK_INTERVAL`` (10s), but the *first*
+# refresh happens after this much shorter delay: when auto-merge fires
+# the moment it is armed (checks were already green and approval was
+# the only blocker) a full-interval first sleep would discover the
+# merge ~8 seconds late — per PR, serialized per repository in striped
+# runs.  One extra lightweight GET is a fair trade for that.
+MERGE_WAIT_FIRST_POLL_SECONDS: float = 2.0
+
 # Required verification checks (DCO, lint, build, etc.) normally
 # start reporting within a few seconds.  When a *required* check has
 # been pending for longer than this on a PR that itself was created
@@ -561,6 +570,9 @@ class AsyncMergeManager:
                         status=MergeStatus.FAILED,
                         error=str(e),
                     )
+                    # The exception escaped before the semaphore
+                    # wrapper could record a terminal outcome.
+                    self._record_terminal_outcome(pr_info, MergeStatus.FAILED)
                     self.log.error(
                         "Unexpected error merging PR %s#%s: %s",
                         pr_info.repository_full_name,
@@ -604,6 +616,10 @@ class AsyncMergeManager:
                     pr_info=pr_info, status=MergeStatus.FAILED, error=str(result)
                 )
                 final_results.append(error_result)
+                # The exception escaped ``_merge_single_pr_with_semaphore``
+                # before it could record a terminal outcome, so record
+                # the failure here to keep the tracker counters exact.
+                self._record_terminal_outcome(pr_info, MergeStatus.FAILED)
                 self.log.error(
                     f"Unexpected error merging PR {pr_info.repository_full_name}#{pr_info.number}: {result}"
                 )
@@ -612,25 +628,73 @@ class AsyncMergeManager:
                 final_results.append(cast(MergeResult, result))
         return final_results
 
+    def _record_terminal_outcome(
+        self, pr_info: PullRequestInfo, status: MergeStatus
+    ) -> None:
+        """Record a PR's terminal outcome on the progress tracker.
+
+        This is the **single** place terminal outcomes reach the
+        tracker: every PR ends in exactly one counter (merged /
+        failed / skipped / blocked / pending), its transitory
+        display state (rebasing, waiting, …) is cleared, and the
+        PR-level completion percentage advances.  Centralising the
+        accounting here closes the historical "result returned but
+        tracker never told" and double-count bug classes.
+        """
+        tracker = self.progress_tracker
+        if not tracker:
+            return
+        pr_key = f"{pr_info.repository_full_name}#{pr_info.number}"
+        if status == MergeStatus.MERGED:
+            tracker.merge_success(pr_key)
+        elif status == MergeStatus.FAILED:
+            tracker.merge_failure(pr_key)
+        elif status == MergeStatus.SKIPPED:
+            tracker.merge_skipped(pr_key)
+        elif status == MergeStatus.BLOCKED:
+            tracker.merge_blocked(pr_key)
+        elif status == MergeStatus.AUTO_MERGE_PENDING:
+            tracker.merge_pending(pr_key)
+        else:
+            # Defensive: an unexpected terminal status still counts
+            # toward completion so the percentage reaches 100%.
+            tracker.pr_completed()
+
+    def _track_pr_state(self, pr_info: PullRequestInfo, state: str | None) -> None:
+        """Move a PR between transitory tracker states (or clear)."""
+        tracker = self.progress_tracker
+        if not tracker:
+            return
+        pr_key = f"{pr_info.repository_full_name}#{pr_info.number}"
+        tracker.track_pr_state(pr_key, state)
+
+    def _pr_status(self, message: str, *, level: str = "info") -> None:
+        """Emit a per-PR status line.
+
+        Preview mode prints the line (the \"🔍 Dependamerge
+        Evaluation\" section requires exactly one line per PR).  Real
+        merges keep the console clean — progress is conveyed by the
+        Rich tracker counters and the reasons are reported in the
+        end-of-run summary — so the message goes to the log only.
+        """
+        if self.preview_mode:
+            log_and_print(self.log, self._console, message, level=level)
+        else:
+            log_func = getattr(self.log, level.lower(), self.log.info)
+            log_func(message)
+
     async def _merge_single_pr_with_semaphore(
         self, pr_info: PullRequestInfo
     ) -> MergeResult:
         """Merge a single PR with concurrency control."""
         async with self._merge_semaphore:
             result = await self._merge_single_pr(pr_info)
-            # merge_success() and merge_failure() already increment
-            # completed_prs for MERGED/FAILED outcomes.  Catch the
-            # remaining terminal states here so PR-level progress
-            # reaches 100% even when some PRs are blocked, skipped,
-            # or have auto-merge pending (where neither merge_success
-            # nor merge_failure is called because the merge hasn't
-            # actually happened yet — GitHub will merge it later).
-            if self.progress_tracker and result.status in (
-                MergeStatus.BLOCKED,
-                MergeStatus.SKIPPED,
-                MergeStatus.AUTO_MERGE_PENDING,
-            ):
-                self.progress_tracker.pr_completed()
+            # Single terminal-accounting point: map the result status
+            # onto the tracker counters (see _record_terminal_outcome).
+            # Uses the *original* pr_info so the transitory state keyed
+            # on it is cleared even when the result carries a
+            # recreated PR.
+            self._record_terminal_outcome(pr_info, result.status)
             return result
 
     async def _wait_status_ticker(self) -> None:
@@ -1101,12 +1165,10 @@ class AsyncMergeManager:
             result.error = (
                 f"token lacks required permissions on {pr_info.repository_full_name}"
             )
-            if self.progress_tracker:
-                self.progress_tracker.merge_failure()
-            self._console.print(
+            self._pr_status(
                 f"❌ Failed: {pr_info.html_url} "
                 "[token lacks permissions on this repository]",
-                markup=False,
+                level="error",
             )
             result.duration = time.time() - start_time
             return result
@@ -1134,9 +1196,7 @@ class AsyncMergeManager:
                         # Skip this PR entirely
                         result.status = MergeStatus.SKIPPED
                         result.error = f"Skipped: {skip_msg}"
-                        log_and_print(
-                            self.log,
-                            self._console,
+                        self._pr_status(
                             f"⏩ Skipped: {pr_info.html_url} [{skip_msg}]",
                             level="info",
                         )
@@ -1144,22 +1204,18 @@ class AsyncMergeManager:
 
                     # Default: "submit" mode - submit the Gerrit change
                     if self.preview_mode:
-                        log_and_print(
-                            self.log,
-                            self._console,
+                        self._pr_status(
                             f"🔄 Gerrit submit: {pr_info.html_url} [{skip_msg}]",
                             level="info",
                         )
                         result.status = MergeStatus.MERGED
-                        if self.progress_tracker:
-                            self.progress_tracker.merge_success()
                         return result
 
                     # Attempt to submit the Gerrit change
-                    self._console.print(
+                    self._pr_status(
                         f"🔄 Submitting Gerrit change for {pr_info.html_url} "
                         f"[{skip_msg}]",
-                        markup=False,
+                        level="info",
                     )
                     submitted = await self._submit_gerrit_change(
                         mapping, pr_info, repo_owner, repo_name
@@ -1167,11 +1223,7 @@ class AsyncMergeManager:
 
                     if submitted:
                         result.status = MergeStatus.MERGED
-                        if self.progress_tracker:
-                            self.progress_tracker.merge_success()
-                        log_and_print(
-                            self.log,
-                            self._console,
+                        self._pr_status(
                             f"✅ Gerrit submitted: {pr_info.html_url}",
                             level="info",
                         )
@@ -1180,12 +1232,10 @@ class AsyncMergeManager:
                     # Gerrit submission failed - report as failed
                     result.status = MergeStatus.FAILED
                     result.error = f"Failed to submit Gerrit change ({skip_msg})"
-                    if self.progress_tracker:
-                        self.progress_tracker.merge_failure()
-                    self._console.print(
+                    self._pr_status(
                         f"❌ Failed: {pr_info.html_url} "
                         f"[Gerrit submit failed for {skip_msg}]",
-                        markup=False,
+                        level="error",
                     )
                     return result
 
@@ -1202,19 +1252,16 @@ class AsyncMergeManager:
                 if already_merged:
                     result.status = MergeStatus.SKIPPED
                     result.error = "already merged externally"
-                    if self.progress_tracker:
-                        self.progress_tracker.merge_skipped()
-                    log_and_print(
-                        self.log,
-                        self._console,
-                        (f"⏭️ Skipped: {pr_info.html_url} [already merged externally]"),
+                    self._pr_status(
+                        f"⏭️ Skipped: {pr_info.html_url} [already merged externally]",
                         level="info",
                     )
                     return result
                 result.status = MergeStatus.FAILED
                 result.error = "PR is already closed"
-                self._console.print(
-                    f"🛑 Failed: {pr_info.html_url} [already closed]", markup=False
+                self._pr_status(
+                    f"🛑 Failed: {pr_info.html_url} [already closed]",
+                    level="info",
                 )
                 return result
 
@@ -1243,9 +1290,7 @@ class AsyncMergeManager:
                 if self.force_level != "all":
                     result.status = MergeStatus.SKIPPED
                     result.error = "PR has reviews requesting changes - will not override human feedback"
-                    log_and_print(
-                        self.log,
-                        self._console,
+                    self._pr_status(
                         f"⏭️ Skipped: {pr_info.html_url} [has reviews requesting changes]",
                         level="debug",
                     )
@@ -1291,9 +1336,7 @@ class AsyncMergeManager:
             if not can_merge:
                 result.status = MergeStatus.SKIPPED
                 result.error = f"Merge requirements not met: {merge_check_reason}"
-                log_and_print(
-                    self.log,
-                    self._console,
+                self._pr_status(
                     f"⏭️ Skipped: {pr_info.html_url} [{merge_check_reason.lower()}]",
                     level="debug",
                 )
@@ -1333,9 +1376,9 @@ class AsyncMergeManager:
             if not copilot_processing_successful:
                 result.status = MergeStatus.FAILED
                 result.error = "Copilot review processing incomplete - not approving to avoid pollution"
-                self._console.print(
+                self._pr_status(
                     f"❌ Failed: {pr_info.html_url} [copilot processing incomplete]",
-                    markup=False,
+                    level="error",
                 )
                 return result
 
@@ -1380,6 +1423,7 @@ class AsyncMergeManager:
                     console=self._console,
                     rebased_prs=self._rebased_prs,
                     enable_auto_merge=self._enable_auto_merge_with_approval,
+                    track_pr_state=self._track_pr_state,
                 )
                 outcome = await rebase.perform_step5_rebase(
                     ctx=rebase_ctx,
@@ -1390,8 +1434,6 @@ class AsyncMergeManager:
                 if outcome.failed:
                     result.status = MergeStatus.FAILED
                     result.error = outcome.error_message
-                    if self.progress_tracker:
-                        self.progress_tracker.merge_failure()
                     return result
 
             # Step 5.5: If the PR is still blocked (e.g. by a pending
@@ -1473,6 +1515,7 @@ class AsyncMergeManager:
                         repo_name,
                         pr_info.number,
                         pr_info.head_sha,
+                        base_branch=pr_info.base_branch,
                     )
                 except Exception as exc:
                     self.log.debug(
@@ -1511,9 +1554,7 @@ class AsyncMergeManager:
                         pr_info, repo_owner, repo_name
                     )
                     if auto_ok_pre:
-                        log_and_print(
-                            self.log,
-                            self._console,
+                        self._pr_status(
                             f"🤖 Auto-merge: {pr_info.html_url}",
                             level="debug",
                         )
@@ -1522,6 +1563,7 @@ class AsyncMergeManager:
                 # checks to complete and auto-merge to fire.  The
                 # continue-states mirror the ``base_should_wait`` entry
                 # condition above (blocked / behind / unstable).
+                self._track_pr_state(pr_info, "waiting")
                 (
                     closed_during_wait,
                     merged_during_wait,
@@ -1531,6 +1573,7 @@ class AsyncMergeManager:
                     repo_name,
                     continue_states=("blocked", "behind", "unstable"),
                 )
+                self._track_pr_state(pr_info, None)
 
                 # If the wait revealed the PR is already closed,
                 # short-circuit before attempting a manual merge.
@@ -1540,11 +1583,7 @@ class AsyncMergeManager:
                 if closed_during_wait:
                     if merged_during_wait:
                         result.status = MergeStatus.MERGED
-                        if self.progress_tracker:
-                            self.progress_tracker.merge_success()
-                        log_and_print(
-                            self.log,
-                            self._console,
+                        self._pr_status(
                             f"✅ Merged (auto-merge): {pr_info.html_url}",
                             level="debug",
                         )
@@ -1553,10 +1592,9 @@ class AsyncMergeManager:
                         result.error = (
                             "PR closed without merging during auto-merge wait"
                         )
-                        if self.progress_tracker:
-                            self.progress_tracker.merge_failure()
-                        self._console.print(
-                            f"🛑 Closed without merging: {pr_info.html_url}"
+                        self._pr_status(
+                            f"🛑 Closed without merging: {pr_info.html_url}",
+                            level="warning",
                         )
                     return result
 
@@ -1630,6 +1668,7 @@ class AsyncMergeManager:
                                         repo_name,
                                         pr_info.number,
                                         pr_info.head_sha,
+                                        base_branch=pr_info.base_branch,
                                     )
                                 )
                             except Exception as exc:
@@ -1734,13 +1773,9 @@ class AsyncMergeManager:
 
                 if merged is None:
                     # Auto-merge is active — PR will merge asynchronously.
-                    # The enable was already announced earlier ("🤖 Auto-merge:
-                    # <url>" or via the rebase path); use a neutral
-                    # "Waiting" line here to avoid duplicating that
-                    # announcement. Tailor the bracketed reason to
-                    # the actual ``mergeable_state`` so users see
-                    # what auto-merge is waiting on, rather than
-                    # always reporting "pending checks".
+                    # Tailor the reason to the actual ``mergeable_state``
+                    # so the end-of-run summary shows what auto-merge is
+                    # waiting on, rather than always "pending checks".
                     result.status = MergeStatus.AUTO_MERGE_PENDING
                     if pr_info.mergeable_state == "behind":
                         wait_reason = "behind base branch"
@@ -1753,19 +1788,14 @@ class AsyncMergeManager:
                         # classified as pending required checks by
                         # ``_block_reason_indicates_pending_checks``.
                         wait_reason = "pending checks"
-                    log_and_print(
-                        self.log,
-                        self._console,
+                    result.error = f"auto-merge pending: {wait_reason}"
+                    self._pr_status(
                         f"⏳ Waiting: {pr_info.html_url} [{wait_reason}]",
                         level="debug",
                     )
                 elif merged:
                     result.status = MergeStatus.MERGED
-                    if self.progress_tracker:
-                        self.progress_tracker.merge_success()
-                    log_and_print(
-                        self.log,
-                        self._console,
+                    self._pr_status(
                         f"✅ Merged: {pr_info.html_url}",
                         level="debug",
                     )
@@ -1785,15 +1815,9 @@ class AsyncMergeManager:
                     if already_merged:
                         result.status = MergeStatus.SKIPPED
                         result.error = "already merged externally"
-                        if self.progress_tracker:
-                            self.progress_tracker.merge_skipped()
-                        log_and_print(
-                            self.log,
-                            self._console,
-                            (
-                                f"⏭️ Skipped: {pr_info.html_url} "
-                                "[already merged externally]"
-                            ),
+                        self._pr_status(
+                            f"⏭️ Skipped: {pr_info.html_url} "
+                            "[already merged externally]",
                             level="info",
                         )
                         return result
@@ -1855,23 +1879,22 @@ class AsyncMergeManager:
                                 stuck_check = None
                                 stuck_age = 0.0
                             if is_stuck:
-                                # Use markup=False so a check name
-                                # containing characters that look like
-                                # Rich markup (e.g. ``[required]``) does
-                                # not get silently swallowed by the
-                                # console parser.
-                                self._console.print(
+                                self._pr_status(
                                     f"⏳ Stuck required check detected: "
                                     f"{pr_info.html_url} "
                                     f"[{stuck_check} pending for "
                                     f"{stuck_age:.0f}s, requesting recreate]",
-                                    markup=False,
+                                    level="info",
                                 )
                                 should_recreate = True
                         if should_recreate:
-                            recreated_pr = await self._trigger_dependabot_recreate(
-                                pr_info
-                            )
+                            self._track_pr_state(pr_info, "recreating")
+                            try:
+                                recreated_pr = (
+                                    await self._trigger_dependabot_recreate(pr_info)
+                                )
+                            finally:
+                                self._track_pr_state(pr_info, None)
 
                     if recreated_pr is not None:
                         # We have a fresh PR — approve and merge it
@@ -1913,11 +1936,7 @@ class AsyncMergeManager:
                         if new_merged:
                             result.status = MergeStatus.MERGED
                             result.pr_info = recreated_pr
-                            if self.progress_tracker:
-                                self.progress_tracker.merge_success()
-                            log_and_print(
-                                self.log,
-                                self._console,
+                            self._pr_status(
                                 f"✅ Merged (recreated): {recreated_pr.html_url}",
                                 level="debug",
                             )
@@ -1927,17 +1946,15 @@ class AsyncMergeManager:
                                 f"Dependabot recreated PR #{recreated_pr.number} "
                                 "but merge still failed"
                             )
-                            if self.progress_tracker:
-                                self.progress_tracker.merge_failure()
                             self.log.error(
                                 "Failed to merge recreated PR %s#%s",
                                 recreated_pr.repository_full_name,
                                 recreated_pr.number,
                             )
-                            self._console.print(
+                            self._pr_status(
                                 f"❌ Failed: {recreated_pr.html_url} "
                                 "[recreated PR merge failed]",
-                                markup=False,
+                                level="error",
                             )
                     else:
                         await self._report_merge_failure(
@@ -1959,8 +1976,6 @@ class AsyncMergeManager:
             # see the failure for a given repository.
             result.status = MergeStatus.FAILED
             result.error = str(e)
-            if self.progress_tracker:
-                self.progress_tracker.merge_failure()
 
             first_failure_for_repo = (
                 pr_info.repository_full_name not in self._permission_failed_repos
@@ -1969,9 +1984,9 @@ class AsyncMergeManager:
 
             # Extract operation-specific error message
             operation_desc = e.operation.replace("_", " ")
-            self._console.print(
+            self._pr_status(
                 f"❌ Failed: {pr_info.html_url} [permission denied: {operation_desc}]",
-                markup=False,
+                level="error",
             )
 
             if not first_failure_for_repo:
@@ -2001,8 +2016,6 @@ class AsyncMergeManager:
         except Exception as e:
             result.status = MergeStatus.FAILED
             result.error = str(e)
-            if self.progress_tracker:
-                self.progress_tracker.merge_failure()
 
             # Provide clean single-line error messages for other errors.
             # The stack trace is attached only when the logger is in
@@ -2019,8 +2032,9 @@ class AsyncMergeManager:
                 e,
                 exc_info=self.log.isEnabledFor(logging.DEBUG),
             )
-            self._console.print(
-                f"❌ Failed: {pr_info.html_url} [processing error: {e}]"
+            self._pr_status(
+                f"❌ Failed: {pr_info.html_url} [processing error: {e}]",
+                level="error",
             )
 
         finally:
@@ -2048,7 +2062,11 @@ class AsyncMergeManager:
         if pr_info.mergeable_state == "blocked" and self._github_client:
             try:
                 detailed_status = await self._github_client.analyze_block_reason(
-                    repo_owner, repo_name, pr_info.number, pr_info.head_sha
+                    repo_owner,
+                    repo_name,
+                    pr_info.number,
+                    pr_info.head_sha,
+                    base_branch=pr_info.base_branch,
                 )
             except Exception:
                 detailed_status = f"Blocked (state: {pr_info.mergeable_state})"
@@ -2096,9 +2114,7 @@ class AsyncMergeManager:
             icon = "⏭️"
             status = "Skipped"
 
-        log_and_print(
-            self.log,
-            self._console,
+        self._pr_status(
             f"{icon} {status}: {pr_info.html_url} [{skip_reason}]",
             level="info",
         )
@@ -2133,8 +2149,6 @@ class AsyncMergeManager:
             # Use ``warning`` (not ``error``) so the MERGED result
             # does not carry a contradictory error message.
             result.warning = "behind base branch"
-            if self.progress_tracker:
-                self.progress_tracker.merge_success()
             self._console.print(
                 f"⚠️ Rebase/merge: {pr_info.html_url} [behind base branch]",
                 markup=False,
@@ -2156,8 +2170,6 @@ class AsyncMergeManager:
         else:
             # Simulate successful merge in preview mode
             result.status = MergeStatus.MERGED
-            if self.progress_tracker:
-                self.progress_tracker.merge_success()
             # Single line summary for successful preview
             log_and_print(
                 self.log,
@@ -2308,6 +2320,7 @@ class AsyncMergeManager:
                 repo_name,
                 pr_info.number,
                 pr_info.head_sha,
+                base_branch=pr_info.base_branch,
             )
         except Exception as exc:
             self.log.debug(
@@ -2330,9 +2343,7 @@ class AsyncMergeManager:
             return False
 
         pr_info.behind_by = behind_by
-        log_and_print(
-            self.log,
-            self._console,
+        self._pr_status(
             f"\U0001f504 Stale head: {pr_info.html_url} "
             f"[blocked ({block_reason}); {behind_by} commit(s) behind "
             f"base — rebasing to re-run checks]",
@@ -2514,11 +2525,10 @@ class AsyncMergeManager:
 
         # Both attempts failed — surface a single line so the
         # user knows the PR-side audit trail is incomplete.
-        try:
-            self._console.print(f"⚠️ Unable to add pull request comment: {html_url}")
-        except Exception:
-            # Console output is best-effort; ignore write errors.
-            pass
+        self._pr_status(
+            f"⚠️ Unable to add pull request comment: {html_url}",
+            level="warning",
+        )
         return False
 
     async def _enable_auto_merge_for_pr(
@@ -2642,7 +2652,12 @@ class AsyncMergeManager:
         return True
 
     async def _ensure_pr_approved(
-        self, pr_info: PullRequestInfo, owner: str, repo: str
+        self,
+        pr_info: PullRequestInfo,
+        owner: str,
+        repo: str,
+        *,
+        propagation_delay: bool = True,
     ) -> bool:
         """Approve the current PR head on demand and track the approval.
 
@@ -2654,6 +2669,13 @@ class AsyncMergeManager:
         the current head — so this is safe to call unconditionally at any
         approve-on-demand trigger.
 
+        ``propagation_delay=False`` skips the post-approval sleep.  The
+        delay exists to let GitHub propagate the approval into branch-
+        protection evaluation before an *immediate* merge dispatch; when
+        the caller is arming auto-merge instead (GitHub re-evaluates
+        protection when checks complete, typically minutes later) the
+        sleep is pure dead time on the critical path.
+
         Returns:
             True if a *new* approval was submitted, False if the PR was
             already approved (or approval was declined).
@@ -2664,7 +2686,7 @@ class AsyncMergeManager:
             self._recently_approved.add(pr_key)
             # Give GitHub time to propagate the approval to the branch
             # protection evaluation before a merge is attempted.
-            if self._post_approval_delay > 0:
+            if propagation_delay and self._post_approval_delay > 0:
                 self.log.debug(
                     f"Waiting {self._post_approval_delay}s for approval "
                     f"propagation on {pr_key}"
@@ -2697,7 +2719,14 @@ class AsyncMergeManager:
         """
         if not self.preview_mode:
             try:
-                await self._ensure_pr_approved(pr_info, owner, repo)
+                # No propagation delay here: we are arming auto-merge,
+                # not dispatching an immediate merge.  GitHub re-checks
+                # branch protection when the required checks complete
+                # (≫ the propagation window), so sleeping now would
+                # only stall the pipeline.
+                await self._ensure_pr_approved(
+                    pr_info, owner, repo, propagation_delay=False
+                )
             except GitHubPermissionError:
                 # Surface token permission problems to the caller's
                 # dedicated handler rather than masking them here.
@@ -2786,7 +2815,11 @@ class AsyncMergeManager:
 
         try:
             block_reason = await self._github_client.analyze_block_reason(
-                owner, repo, pr_info.number, pr_info.head_sha
+                owner,
+                repo,
+                pr_info.number,
+                pr_info.head_sha,
+                base_branch=pr_info.base_branch,
             )
         except Exception as exc:
             self.log.debug(
@@ -3175,9 +3208,7 @@ class AsyncMergeManager:
             # trigger anyway.
             pass
 
-        log_and_print(
-            self.log,
-            self._console,
+        self._pr_status(
             f"🔄 Re-triggering pre-commit.ci: {pr_info.html_url}",
             level="info",
         )
@@ -3212,17 +3243,13 @@ class AsyncMergeManager:
                             continue
                         state = s.get("state")
                         if state == "success":
-                            log_and_print(
-                                self.log,
-                                self._console,
+                            self._pr_status(
                                 f"✅ pre-commit.ci passed: {pr_info.html_url}",
                                 level="info",
                             )
                             return True
                         elif state in ("failure", "error"):
-                            log_and_print(
-                                self.log,
-                                self._console,
+                            self._pr_status(
                                 f"❌ pre-commit.ci failed: {pr_info.html_url}",
                                 level="warning",
                             )
@@ -3593,9 +3620,7 @@ class AsyncMergeManager:
             return None
 
         # 5. Post the recreate comment
-        log_and_print(
-            self.log,
-            self._console,
+        self._pr_status(
             f"🔄 Requesting dependabot recreate: {pr_info.html_url} "
             f"[unverified commits: {', '.join(unverified_shas)}]",
             level="info",
@@ -3632,9 +3657,7 @@ class AsyncMergeManager:
                     if isinstance(old_pr_data, dict):
                         if old_pr_data.get("state") == "closed":
                             old_pr_closed = True
-                            log_and_print(
-                                self.log,
-                                self._console,
+                            self._pr_status(
                                 f"✅ Old PR closed by dependabot: "
                                 f"{pr_info.html_url} "
                                 f"({(attempt + 1) * self._merge_recheck_interval:.0f}s elapsed)",
@@ -3743,9 +3766,7 @@ class AsyncMergeManager:
             "html_url", f"https://github.com/{full_name}/pull/{new_number}"
         )
 
-        log_and_print(
-            self.log,
-            self._console,
+        self._pr_status(
             f"🔍 Found recreated PR, waiting for checks: {html_url}",
             level="info",
         )
@@ -3791,9 +3812,7 @@ class AsyncMergeManager:
                 if mergeable_state == "clean" or (
                     mergeable is True and mergeable_state in ("clean", "unstable")
                 ):
-                    log_and_print(
-                        self.log,
-                        self._console,
+                    self._pr_status(
                         f"✅ Recreated PR is ready to merge: {html_url}",
                         level="info",
                     )
@@ -3903,10 +3922,11 @@ class AsyncMergeManager:
             )
 
             if isinstance(pr_data, dict):
-                # Get current user login
-                user_data = await self._github_client.get("/user")
+                # Get current user login (cached on the client after the
+                # first call — the login is session-constant, so this
+                # costs one round-trip per run instead of one per PR).
                 current_user = (
-                    user_data.get("login") if isinstance(user_data, dict) else None
+                    await self._github_client.get_authenticated_user_login()
                 )
 
                 if current_user:
@@ -4550,6 +4570,7 @@ class AsyncMergeManager:
         # superseded it, etc.).
         closed_during_wait = False
         merged_during_wait = False
+        first_poll = True
         try:
             while loop.time() < deadline:
                 if stop_on_clean and pr_info.mergeable_state == "clean":
@@ -4558,9 +4579,19 @@ class AsyncMergeManager:
                 # overshoot the deadline.  Clamp to non-negative: the
                 # ``while`` check and this ``time()`` call are not
                 # atomic, so a near-deadline crossing could otherwise
-                # pass ``asyncio.sleep`` a tiny negative value.
+                # pass ``asyncio.sleep`` a tiny negative value.  The
+                # first poll uses a much shorter delay (see
+                # ``MERGE_WAIT_FIRST_POLL_SECONDS``) so a PR that
+                # resolved the moment the wait started is detected
+                # promptly instead of a full interval late.
+                interval = (
+                    min(MERGE_WAIT_FIRST_POLL_SECONDS, self._merge_recheck_interval)
+                    if first_poll
+                    else self._merge_recheck_interval
+                )
+                first_poll = False
                 remaining = max(0.0, deadline - loop.time())
-                await asyncio.sleep(min(self._merge_recheck_interval, remaining))
+                await asyncio.sleep(min(interval, remaining))
                 try:
                     refreshed_wait = await wait_client.get(
                         f"/repos/{owner}/{repo}/pulls/{pr_info.number}"
@@ -4705,20 +4736,17 @@ class AsyncMergeManager:
         """
         if merged:
             result.status = MergeStatus.MERGED
-            if self.progress_tracker:
-                self.progress_tracker.merge_success()
-            log_and_print(
-                self.log,
-                self._console,
+            self._pr_status(
                 f"✅ Merged (auto-merge): {pr_info.html_url}",
                 level="debug",
             )
         else:
             result.status = MergeStatus.FAILED
             result.error = "PR closed without merging during conflict rebase"
-            if self.progress_tracker:
-                self.progress_tracker.merge_failure()
-            self._console.print(f"🛑 Closed without merging: {pr_info.html_url}")
+            self._pr_status(
+                f"🛑 Closed without merging: {pr_info.html_url}",
+                level="warning",
+            )
         return result
 
     def _dependabot_is_rebasing(self, body: str | None) -> bool:
@@ -4761,16 +4789,12 @@ class AsyncMergeManager:
         # the approval chain (this org forbids self-merge of pushed
         # commits).  Report the conflict and fail fast.
         if not is_dependabot(pr_info.author):
-            log_and_print(
-                self.log,
-                self._console,
+            self._pr_status(
                 f"🔀 Merge conflict: {pr_info.html_url}",
                 level="info",
             )
             result.status = MergeStatus.FAILED
             result.error = "merge conflicts"
-            if self.progress_tracker:
-                self.progress_tracker.merge_failure()
             return result
 
         # Detect whether dependabot is already self-rebasing this PR.
@@ -4803,9 +4827,8 @@ class AsyncMergeManager:
             auto_ok = await self._enable_auto_merge_for_pr(pr_info, owner, repo)
             if auto_ok:
                 result.status = MergeStatus.AUTO_MERGE_PENDING
-                log_and_print(
-                    self.log,
-                    self._console,
+                result.error = "auto-merge pending: conflict rebase requested (no-wait)"
+                self._pr_status(
                     f"⏳ Auto-merge armed (no-wait): {pr_info.html_url}",
                     level="info",
                 )
@@ -4820,9 +4843,7 @@ class AsyncMergeManager:
                     "auto-merge unavailable (no-wait); PR approved and "
                     "rebase requested but not merged"
                 )
-                log_and_print(
-                    self.log,
-                    self._console,
+                self._pr_status(
                     f"🛑 Auto-merge unavailable (no-wait): {pr_info.html_url}",
                     level="warning",
                 )
@@ -4831,30 +4852,22 @@ class AsyncMergeManager:
         # Dependabot: request a rebase (regenerates the lockfile +
         # signs the commit) unless it is already rebasing on its own.
         if already_rebasing:
-            log_and_print(
-                self.log,
-                self._console,
+            self._pr_status(
                 f"🔄 Dependabot already rebasing: {pr_info.html_url}",
                 level="info",
             )
         else:
-            log_and_print(
-                self.log,
-                self._console,
+            self._pr_status(
                 f"🔄 Requesting dependabot rebase: {pr_info.html_url}",
                 level="info",
             )
             if not await self._request_dependabot_rebase(pr_info, owner, repo):
-                log_and_print(
-                    self.log,
-                    self._console,
+                self._pr_status(
                     f"🔀 Merge conflict: {pr_info.html_url}",
                     level="info",
                 )
                 result.status = MergeStatus.FAILED
                 result.error = "merge conflicts"
-                if self.progress_tracker:
-                    self.progress_tracker.merge_failure()
                 return result
 
         # Share a single ``merge_timeout`` budget across both wait
@@ -4865,28 +4878,28 @@ class AsyncMergeManager:
         # Keep waiting while still ``dirty`` or while GitHub recomputes
         # mergeability (a transient null is preserved as the prior
         # ``dirty`` by ``_wait_for_auto_merge``).
-        closed, merged = await self._wait_for_auto_merge(
-            pr_info,
-            owner,
-            repo,
-            continue_states=("dirty", "unknown", ""),
-            deadline=deadline,
-        )
+        self._track_pr_state(pr_info, "rebasing")
+        try:
+            closed, merged = await self._wait_for_auto_merge(
+                pr_info,
+                owner,
+                repo,
+                continue_states=("dirty", "unknown", ""),
+                deadline=deadline,
+            )
+        finally:
+            self._track_pr_state(pr_info, None)
         if closed:
             return self._finish_conflict_close(pr_info, result, merged)
         if pr_info.mergeable_state == "dirty":
             # Timed out still conflicting — the rebase did not happen
             # or could not resolve the conflict.
-            log_and_print(
-                self.log,
-                self._console,
+            self._pr_status(
                 f"🔀 Merge conflict: {pr_info.html_url}",
                 level="info",
             )
             result.status = MergeStatus.FAILED
             result.error = "merge conflicts"
-            if self.progress_tracker:
-                self.progress_tracker.merge_failure()
             return result
 
         # Conflict cleared.  Approve the rebased commit *now* (not
@@ -4908,15 +4921,11 @@ class AsyncMergeManager:
             )
             result.status = MergeStatus.FAILED
             result.error = f"rebase cleared the conflict but approval failed: {exc}"
-            if self.progress_tracker:
-                self.progress_tracker.merge_failure()
-            self._console.print(f"❌ Failed: {pr_info.html_url}", markup=False)
+            self._pr_status(f"❌ Failed: {pr_info.html_url}", level="error")
             return result
         auto_ok = await self._enable_auto_merge_for_pr(pr_info, owner, repo)
         if auto_ok:
-            log_and_print(
-                self.log,
-                self._console,
+            self._pr_status(
                 f"🤖 Auto-merge: {pr_info.html_url}",
                 level="debug",
             )
@@ -4939,14 +4948,18 @@ class AsyncMergeManager:
             )
         else:
             continue_states = ("blocked", "behind", "unstable", "unknown", "")
-        closed, merged = await self._wait_for_auto_merge(
-            pr_info,
-            owner,
-            repo,
-            continue_states=continue_states,
-            deadline=deadline,
-            stop_on_clean=not auto_ok,
-        )
+        self._track_pr_state(pr_info, "rebased")
+        try:
+            closed, merged = await self._wait_for_auto_merge(
+                pr_info,
+                owner,
+                repo,
+                continue_states=continue_states,
+                deadline=deadline,
+                stop_on_clean=not auto_ok,
+            )
+        finally:
+            self._track_pr_state(pr_info, None)
         if closed:
             return self._finish_conflict_close(pr_info, result, merged)
 
@@ -4954,9 +4967,8 @@ class AsyncMergeManager:
             # Auto-merge is armed: GitHub will complete the merge once
             # the required checks pass (often after our run ends).
             result.status = MergeStatus.AUTO_MERGE_PENDING
-            log_and_print(
-                self.log,
-                self._console,
+            result.error = "auto-merge pending: checks after conflict rebase"
+            self._pr_status(
                 f"⏳ Waiting: {pr_info.html_url} [auto-merge after rebase]",
                 level="debug",
             )
@@ -4972,11 +4984,7 @@ class AsyncMergeManager:
                 merged = await self._merge_pr_with_retry(pr_info, owner, repo)
             if merged:
                 result.status = MergeStatus.MERGED
-                if self.progress_tracker:
-                    self.progress_tracker.merge_success()
-                log_and_print(
-                    self.log,
-                    self._console,
+                self._pr_status(
                     f"✅ Merged: {pr_info.html_url}",
                     level="debug",
                 )
@@ -4987,9 +4995,7 @@ class AsyncMergeManager:
             "rebase cleared the conflict but the PR could not be merged "
             "(auto-merge unavailable)"
         )
-        if self.progress_tracker:
-            self.progress_tracker.merge_failure()
-        self._console.print(f"❌ Failed: {pr_info.html_url}", markup=False)
+        self._pr_status(f"❌ Failed: {pr_info.html_url}", level="error")
         return result
 
     async def _report_merge_failure(
@@ -5026,11 +5032,9 @@ class AsyncMergeManager:
                 detection = None
             if detection is not None and detection[0]:
                 stuck_check = detection[1]
-                # markup=False: a check name may contain characters
-                # Rich would otherwise treat as markup.
-                self._console.print(
+                self._pr_status(
                     f"⚠️ Stuck check: {pr_info.html_url} [{stuck_check}]",
-                    markup=False,
+                    level="warning",
                 )
                 # Arm auto-merge when the PR is otherwise mergeable
                 # (not dirty) so it lands automatically once the stuck
@@ -5049,14 +5053,12 @@ class AsyncMergeManager:
             # error too, so the end-of-run summary surfaces the real
             # cause rather than a generic "all retry attempts" line.
             result.error = failure_reason or "Failed to merge after all retry attempts"
-        if self.progress_tracker:
-            self.progress_tracker.merge_failure()
-        # Keep the live line terse: the full (often long) reason is
+        # Keep the live output terse: the full (often long) reason is
         # shown in the end-of-run summary via ``result.error``, so
         # repeating it inline only duplicates it.  The ``⚠️ Stuck
         # check`` line above already carries the cause for stuck PRs.
         if not stuck_reported:
-            self._console.print(f"❌ Failed: {pr_info.html_url}", markup=False)
+            self._pr_status(f"❌ Failed: {pr_info.html_url}", level="error")
         return result
 
     def _get_failure_summary(self, pr_info: PullRequestInfo) -> str:
@@ -5771,7 +5773,13 @@ class AsyncMergeManager:
                         try:
                             block_reason = (
                                 await self._github_client.analyze_block_reason(
-                                    owner, repo, pr_number, head_sha
+                                    owner,
+                                    repo,
+                                    pr_number,
+                                    head_sha,
+                                    base_branch=(pr_data.get("base") or {}).get(
+                                        "ref"
+                                    ),
                                 )
                             )
                             self.log.debug(

--- a/src/dependamerge/merge_manager.py
+++ b/src/dependamerge/merge_manager.py
@@ -1345,7 +1345,30 @@ class AsyncMergeManager:
             # local-vs-REST decision tree, the local-git workflow,
             # and the post-rebase polling loop all live in one
             # place where they can be tested in isolation.
-            if pr_info.mergeable_state == "behind" and self.fix_out_of_date:
+            #
+            # ``mergeable_state`` is a single value, so ``blocked``
+            # (failing required check) masks ``behind`` (stale head).
+            # A required check that *failed* on a branch that is
+            # *behind base* was judged against pre-rebase content —
+            # e.g. an org-required workflow audit that the base branch
+            # has since fixed — and only a rebase re-runs it against
+            # the current base.  Mirror the engine ladder's
+            # "stale failing verdict" rung here: when a blocked PR's
+            # block reason is check-related and the compare API shows
+            # the head demonstrably behind, refresh the branch before
+            # treating the failure as terminal.
+            needs_rebase = pr_info.mergeable_state == "behind"
+            if (
+                not needs_rebase
+                and self.fix_out_of_date
+                and not self.preview_mode
+                and pr_info.mergeable_state == "blocked"
+                and self._github_client is not None
+            ):
+                needs_rebase = await self._blocked_pr_needs_rebase(
+                    pr_info, repo_owner, repo_name
+                )
+            if needs_rebase and self.fix_out_of_date:
                 rebase_ctx = rebase.RebaseContext(
                     github_client=self._github_client,
                     token=self.token,
@@ -2202,6 +2225,120 @@ class AsyncMergeManager:
             or "waiting for status" in reason_lower
             or "queued" in reason_lower
         )
+
+    @staticmethod
+    def _block_reason_indicates_check_blockage(
+        block_reason: str | None,
+    ) -> bool:
+        """Return True if a block reason concerns status checks at all.
+
+        Broader sibling of
+        :meth:`_block_reason_indicates_pending_checks`: matches any
+        ``analyze_block_reason()`` phrasing about checks — failing,
+        missing, or pending — while rejecting reasons a rebase cannot
+        influence (missing approvals, requested changes, unresolved
+        Copilot feedback, opaque ruleset blocks).
+
+        Step 5 uses this to decide whether a ``blocked`` PR is worth
+        probing for staleness: refreshing the branch re-runs checks
+        against the current base, so only check-related blockage can
+        possibly be cured by a rebase.
+
+        Args:
+            block_reason: The string returned by
+                ``analyze_block_reason()``, or ``None`` if the
+                analysis failed or returned nothing.
+
+        Returns:
+            True when the reason mentions failing, missing, or
+            pending checks; False otherwise (including ``None``).
+        """
+        if block_reason is None:
+            return False
+        reason_lower = block_reason.lower()
+        return (
+            "failing check" in reason_lower
+            or "missing required status" in reason_lower
+            or "missing required check" in reason_lower
+            or "pending required check" in reason_lower
+            or ("required" in reason_lower and "pending" in reason_lower)
+            or "waiting for status" in reason_lower
+            or "queued" in reason_lower
+        )
+
+    async def _blocked_pr_needs_rebase(
+        self,
+        pr_info: PullRequestInfo,
+        repo_owner: str,
+        repo_name: str,
+    ) -> bool:
+        """Decide whether a ``blocked`` PR is really stale-and-fixable.
+
+        Implements the staleness probe behind Step 5's
+        blocked-masks-behind handling: a ``blocked`` PR is treated
+        like ``behind`` when **both** hold:
+
+        1. Its block reason is check-related (failing, missing, or
+           pending checks) — the only class of blockage a branch
+           refresh can cure, because the refresh re-runs checks
+           against the current base.
+        2. The compare API confirms the head is at least one commit
+           behind the base branch.  ``None`` (comparison failed)
+           counts as "not behind": a rebase is a write action and a
+           CI-time expense, so it must rest on positive evidence.
+
+        The two probes run in this order so the cheaper classification
+        gates the extra compare call.
+
+        Args:
+            pr_info: The pull request under evaluation.
+            repo_owner: Base repository owner.
+            repo_name: Base repository name.
+
+        Returns:
+            True when the PR should take the Step 5 rebase path.
+        """
+        if self._github_client is None:
+            return False
+        pr_key = f"{repo_owner}/{repo_name}#{pr_info.number}"
+        block_reason: str | None = None
+        try:
+            block_reason = await self._github_client.analyze_block_reason(
+                repo_owner,
+                repo_name,
+                pr_info.number,
+                pr_info.head_sha,
+            )
+        except Exception as exc:
+            self.log.debug(
+                "analyze_block_reason failed for %s during Step 5 "
+                "staleness probe: %s",
+                pr_key,
+                exc,
+            )
+            return False
+        if not self._block_reason_indicates_check_blockage(block_reason):
+            return False
+
+        behind_by = await self._github_client.get_behind_by(
+            repo_owner,
+            repo_name,
+            pr_info.base_branch or "main",
+            pr_info.head_sha,
+        )
+        if behind_by is None or behind_by <= 0:
+            return False
+
+        pr_info.behind_by = behind_by
+        log_and_print(
+            self.log,
+            self._console,
+            f"\U0001f504 Stale head: {pr_info.html_url} "
+            f"[blocked ({block_reason}); {behind_by} commit(s) behind "
+            f"base — rebasing to re-run checks]",
+            level="debug",
+        )
+        return True
 
     def _is_pr_mergeable(self, pr_info: PullRequestInfo) -> bool:
         """Check whether a PR is worth attempting to merge.

--- a/src/dependamerge/merge_manager.py
+++ b/src/dependamerge/merge_manager.py
@@ -43,6 +43,7 @@ from .models import ComparisonResult, PullRequestInfo
 from .netrc import NetrcParseError, resolve_gerrit_credentials
 from .output_utils import log_and_print
 from .progress_tracker import MergeProgressTracker
+from .slot_lease import holding_slot, parked
 
 # ---------------------------------------------------------------------------
 # Centralised timing constants for all async merge operations.
@@ -691,8 +692,17 @@ class AsyncMergeManager:
     async def _merge_single_pr_with_semaphore(
         self, pr_info: PullRequestInfo
     ) -> MergeResult:
-        """Merge a single PR with concurrency control."""
-        async with self._merge_semaphore:
+        """Merge a single PR with concurrency control.
+
+        The slot is leased, not pinned: any wait loop inside
+        ``_merge_single_pr`` that wraps itself in ``parked()`` (the
+        auto-merge wait, post-rebase polls, recreate waits, …)
+        releases the slot for the duration of the wait and re-acquires
+        it before resuming active work, so PRs waiting on external
+        events (dependabot rebases, CI) never starve runnable PRs.
+        See ``slot_lease.py`` and ``docs/MERGE_ENGINE_DESIGN.md``.
+        """
+        async with holding_slot(self._merge_semaphore):
             result = await self._merge_single_pr(pr_info)
             # Single terminal-accounting point: map the result status
             # onto the tracker counters (see _record_terminal_outcome).
@@ -3232,47 +3242,50 @@ class AsyncMergeManager:
         # 4. Poll for the status to appear (up to ~5 minutes)
         # pre-commit.ci can take up to five minutes to run and report back,
         # so we need a generous timeout to avoid prematurely marking PRs as
-        # unmergeable when the check simply hasn't finished yet.
+        # unmergeable when the check simply hasn't finished yet.  The
+        # whole poll is a wait on an external service, so the worker's
+        # concurrency slot is released for its duration (``parked()``).
         max_polls = self._merge_poll_max_attempts
-        for attempt in range(max_polls):
-            await asyncio.sleep(self._merge_recheck_interval)
-            try:
-                status_data = await self._github_client.get(
-                    f"/repos/{repo_owner}/{repo_name}/commits/{pr_info.head_sha}/status"
-                )
-                if isinstance(status_data, dict):
-                    for s in status_data.get("statuses", []):
-                        if not isinstance(s, dict):
-                            continue
-                        if s.get("context") != precommit_context:
-                            continue
-                        state = s.get("state")
-                        if state == "success":
-                            self._pr_status(
-                                f"✅ pre-commit.ci passed: {pr_info.html_url}",
-                                level="info",
-                            )
-                            return True
-                        elif state in ("failure", "error"):
-                            self._pr_status(
-                                f"❌ pre-commit.ci failed: {pr_info.html_url}",
-                                level="warning",
-                            )
-                            return False
-                        # state == "pending" — keep polling
-            except Exception as e:
-                self.log.debug(
-                    "Failed to poll pre-commit.ci status for %s: %s",
-                    f"{pr_info.repository_full_name}#{pr_info.number}",
-                    e,
-                )
+        async with parked():
+            for attempt in range(max_polls):
+                await asyncio.sleep(self._merge_recheck_interval)
+                try:
+                    status_data = await self._github_client.get(
+                        f"/repos/{repo_owner}/{repo_name}/commits/{pr_info.head_sha}/status"
+                    )
+                    if isinstance(status_data, dict):
+                        for s in status_data.get("statuses", []):
+                            if not isinstance(s, dict):
+                                continue
+                            if s.get("context") != precommit_context:
+                                continue
+                            state = s.get("state")
+                            if state == "success":
+                                self._pr_status(
+                                    f"✅ pre-commit.ci passed: {pr_info.html_url}",
+                                    level="info",
+                                )
+                                return True
+                            elif state in ("failure", "error"):
+                                self._pr_status(
+                                    f"❌ pre-commit.ci failed: {pr_info.html_url}",
+                                    level="warning",
+                                )
+                                return False
+                            # state == "pending" — keep polling
+                except Exception as e:
+                    self.log.debug(
+                        "Failed to poll pre-commit.ci status for %s: %s",
+                        f"{pr_info.repository_full_name}#{pr_info.number}",
+                        e,
+                    )
 
-            if attempt == max_polls - 1:
-                self.log.debug(
-                    f"Still waiting for pre-commit.ci on "
-                    f"{pr_info.repository_full_name}#{pr_info.number} "
-                    f"({(attempt + 1) * self._merge_recheck_interval:.0f}s elapsed)"
-                )
+                if attempt == max_polls - 1:
+                    self.log.debug(
+                        f"Still waiting for pre-commit.ci on "
+                        f"{pr_info.repository_full_name}#{pr_info.number} "
+                        f"({(attempt + 1) * self._merge_recheck_interval:.0f}s elapsed)"
+                    )
 
         self.log.warning(
             f"Timed out waiting for pre-commit.ci on "
@@ -3646,91 +3659,97 @@ class AsyncMergeManager:
 
         # 6. Poll for the old PR to close and a replacement to appear.
         #    Dependabot typically responds within 30-90 seconds.
-        #    We poll using the centralised merge timeout.
+        #    We poll using the centralised merge timeout.  The whole
+        #    poll (including the nested recreated-PR checks wait) is a
+        #    wait on dependabot + CI, so the worker's concurrency slot
+        #    is released for its duration (``parked()``).
         max_polls = self._merge_poll_max_attempts
         old_pr_closed = False
 
-        for attempt in range(max_polls):
-            await asyncio.sleep(self._merge_recheck_interval)
+        async with parked():
+            for attempt in range(max_polls):
+                await asyncio.sleep(self._merge_recheck_interval)
 
-            # 6a. Check if the old PR has been closed
-            if not old_pr_closed:
-                try:
-                    old_pr_data = await self._github_client.get(
-                        f"/repos/{repo_owner}/{repo_name}/pulls/{pr_info.number}"
-                    )
-                    if isinstance(old_pr_data, dict):
-                        if old_pr_data.get("state") == "closed":
-                            old_pr_closed = True
-                            self._pr_status(
-                                f"✅ Old PR closed by dependabot: "
-                                f"{pr_info.html_url} "
-                                f"({(attempt + 1) * self._merge_recheck_interval:.0f}s elapsed)",
-                                level="info",
-                            )
-                except Exception as e:
-                    self.log.debug(
-                        "Error polling old PR state for %s#%s: %s",
-                        pr_info.repository_full_name,
-                        pr_info.number,
-                        e,
-                    )
-
-            # 6b. Once the old PR is closed, look for the replacement
-            if old_pr_closed:
-                try:
-                    # Search for open PRs from dependabot on the same head branch
-                    prs = await self._github_client.get(
-                        f"/repos/{repo_owner}/{repo_name}/pulls"
-                        f"?state=open&head={repo_owner}:{pr_info.head_branch}&per_page=5"
-                    )
-                    if isinstance(prs, list):
-                        for pr_data in prs:
-                            if not isinstance(pr_data, dict):
-                                continue
-                            pr_author = pr_data.get("user", {}).get("login", "")
-                            if not is_dependabot(pr_author):
-                                continue
-
-                            new_number = pr_data.get("number")
-                            if new_number is None or new_number == pr_info.number:
-                                continue
-
-                            # Verify the replacement targets the same base branch
-                            new_base = pr_data.get("base", {}).get("ref", "")
-                            if new_base != (pr_info.base_branch or "main"):
-                                self.log.debug(
-                                    "Skipping candidate PR #%s: targets %s, "
-                                    "expected %s",
-                                    new_number,
-                                    new_base,
-                                    pr_info.base_branch or "main",
+                # 6a. Check if the old PR has been closed
+                if not old_pr_closed:
+                    try:
+                        old_pr_data = await self._github_client.get(
+                            f"/repos/{repo_owner}/{repo_name}/pulls/{pr_info.number}"
+                        )
+                        if isinstance(old_pr_data, dict):
+                            if old_pr_data.get("state") == "closed":
+                                old_pr_closed = True
+                                self._pr_status(
+                                    f"✅ Old PR closed by dependabot: "
+                                    f"{pr_info.html_url} "
+                                    f"({(attempt + 1) * self._merge_recheck_interval:.0f}s elapsed)",
+                                    level="info",
                                 )
-                                continue
+                    except Exception as e:
+                        self.log.debug(
+                            "Error polling old PR state for %s#%s: %s",
+                            pr_info.repository_full_name,
+                            pr_info.number,
+                            e,
+                        )
 
-                            # Found a replacement — now wait for checks to pass
-                            new_pr_info = await self._wait_for_recreated_pr_checks(
-                                repo_owner, repo_name, new_number, pr_data
-                            )
-                            # Always return after the first wait attempt to avoid
-                            # performing multiple long waits for the same PR.
-                            return new_pr_info
-                except Exception as e:
+                # 6b. Once the old PR is closed, look for the replacement
+                if old_pr_closed:
+                    try:
+                        # Search for open PRs from dependabot on the same head branch
+                        prs = await self._github_client.get(
+                            f"/repos/{repo_owner}/{repo_name}/pulls"
+                            f"?state=open&head={repo_owner}:{pr_info.head_branch}&per_page=5"
+                        )
+                        if isinstance(prs, list):
+                            for pr_data in prs:
+                                if not isinstance(pr_data, dict):
+                                    continue
+                                pr_author = pr_data.get("user", {}).get("login", "")
+                                if not is_dependabot(pr_author):
+                                    continue
+
+                                new_number = pr_data.get("number")
+                                if new_number is None or new_number == pr_info.number:
+                                    continue
+
+                                # Verify the replacement targets the same base branch
+                                new_base = pr_data.get("base", {}).get("ref", "")
+                                if new_base != (pr_info.base_branch or "main"):
+                                    self.log.debug(
+                                        "Skipping candidate PR #%s: targets %s, "
+                                        "expected %s",
+                                        new_number,
+                                        new_base,
+                                        pr_info.base_branch or "main",
+                                    )
+                                    continue
+
+                                # Found a replacement — now wait for checks to pass
+                                new_pr_info = (
+                                    await self._wait_for_recreated_pr_checks(
+                                        repo_owner, repo_name, new_number, pr_data
+                                    )
+                                )
+                                # Always return after the first wait attempt to avoid
+                                # performing multiple long waits for the same PR.
+                                return new_pr_info
+                    except Exception as e:
+                        self.log.debug(
+                            "Error searching for replacement PR for %s#%s: %s",
+                            pr_info.repository_full_name,
+                            pr_info.number,
+                            e,
+                        )
+
+                if attempt % 3 == 2:
                     self.log.debug(
-                        "Error searching for replacement PR for %s#%s: %s",
+                        "Still waiting for dependabot recreate on %s#%s (%.0fs elapsed, old_pr_closed=%s)",
                         pr_info.repository_full_name,
                         pr_info.number,
-                        e,
+                        (attempt + 1) * self._merge_recheck_interval,
+                        old_pr_closed,
                     )
-
-            if attempt % 3 == 2:
-                self.log.debug(
-                    "Still waiting for dependabot recreate on %s#%s (%.0fs elapsed, old_pr_closed=%s)",
-                    pr_info.repository_full_name,
-                    pr_info.number,
-                    (attempt + 1) * self._merge_recheck_interval,
-                    old_pr_closed,
-                )
 
         self.log.warning(
             "Timed out waiting for dependabot to recreate %s#%s",
@@ -4577,89 +4596,103 @@ class AsyncMergeManager:
         merged_during_wait = False
         first_poll = True
         try:
-            while loop.time() < deadline:
-                if stop_on_clean and pr_info.mergeable_state == "clean":
-                    break
-                # Sleep no longer than the time remaining so we don't
-                # overshoot the deadline.  Clamp to non-negative: the
-                # ``while`` check and this ``time()`` call are not
-                # atomic, so a near-deadline crossing could otherwise
-                # pass ``asyncio.sleep`` a tiny negative value.  The
-                # first poll uses a much shorter delay (see
-                # ``MERGE_WAIT_FIRST_POLL_SECONDS``) so a PR that
-                # resolved the moment the wait started is detected
-                # promptly instead of a full interval late.
-                interval = (
-                    min(MERGE_WAIT_FIRST_POLL_SECONDS, self._merge_recheck_interval)
-                    if first_poll
-                    else self._merge_recheck_interval
-                )
-                first_poll = False
-                remaining = max(0.0, deadline - loop.time())
-                await asyncio.sleep(min(interval, remaining))
-                try:
-                    refreshed_wait = await wait_client.get(
-                        f"/repos/{owner}/{repo}/pulls/{pr_info.number}"
-                    )
-                except Exception as wait_exc:
-                    self.log.debug(
-                        "Failed to refresh PR state during auto-merge "
-                        "wait for %s: %s",
-                        pr_key,
-                        wait_exc,
-                    )
-                    continue
-                if isinstance(refreshed_wait, dict):
-                    # Only overwrite when present, and preserve the
-                    # previous non-None value when GitHub returns null
-                    # (it does so while recomputing) so the
-                    # ``continue_states`` check below does not break the
-                    # loop early on a transient null.
-                    if "mergeable" in refreshed_wait:
-                        refreshed_mergeable = refreshed_wait.get("mergeable")
-                        if refreshed_mergeable is not None:
-                            pr_info.mergeable = refreshed_mergeable
-                    if "mergeable_state" in refreshed_wait:
-                        refreshed_state = refreshed_wait.get("mergeable_state")
-                        # Preserve the previous concrete state while
-                        # GitHub is still recomputing mergeability: it
-                        # returns ``null`` / ``""`` / ``"unknown"``
-                        # transiently, and overwriting with those would
-                        # push the state out of ``continue_states`` and
-                        # break the wait loop early (e.g. a ``blocked``
-                        # PR briefly going ``unknown`` would exit and
-                        # trigger a premature manual merge).
-                        if refreshed_state not in (None, "", "unknown"):
-                            pr_info.mergeable_state = refreshed_state
-                    # The head can change while we wait (rebase,
-                    # force-push); keep it current so any later
-                    # block-reason analysis queries the right commit.
-                    refreshed_head = (refreshed_wait.get("head") or {}).get("sha")
-                    if refreshed_head:
-                        pr_info.head_sha = refreshed_head
-                    if refreshed_wait.get("state") == "closed":
-                        closed_during_wait = True
-                        merged_during_wait = bool(refreshed_wait.get("merged", False))
-                        pr_info.state = "closed"
+            # The whole poll loop is a wait on an external event
+            # (auto-merge / CI / a rebase), so release this worker's
+            # concurrency slot for its duration — a parked PR must
+            # never starve runnable PRs (see ``slot_lease.py``).  The
+            # polling GETs are paced by the HTTP client's own limits.
+            async with parked():
+                while loop.time() < deadline:
+                    if stop_on_clean and pr_info.mergeable_state == "clean":
                         break
-                # A PR that becomes immediately mergeable while still
-                # ``unstable`` (only a non-required check is red) will
-                # never reach ``clean`` and never leave ``unstable``,
-                # so keeping it in ``continue_states`` would spin the
-                # wait to the deadline — the exact slow hang the
-                # Step 5.5 routing fix removes for PRs that *start*
-                # mergeable.  Break out as soon as GitHub reports
-                # ``unstable`` + ``mergeable is True`` so the caller can
-                # dispatch (auto-merge, already armed before this wait,
-                # will land it; failing that the caller merges directly).
-                if pr_info.mergeable_state == "unstable" and pr_info.mergeable is True:
-                    break
-                # Continue waiting only while the PR is in a state the
-                # caller still considers rescuable; any other value
-                # means it became mergeable, closed, or hit a terminal
-                # state, so exit and let the caller decide.
-                if pr_info.mergeable_state not in continue_states:
-                    break
+                    # Sleep no longer than the time remaining so we don't
+                    # overshoot the deadline.  Clamp to non-negative: the
+                    # ``while`` check and this ``time()`` call are not
+                    # atomic, so a near-deadline crossing could otherwise
+                    # pass ``asyncio.sleep`` a tiny negative value.  The
+                    # first poll uses a much shorter delay (see
+                    # ``MERGE_WAIT_FIRST_POLL_SECONDS``) so a PR that
+                    # resolved the moment the wait started is detected
+                    # promptly instead of a full interval late.
+                    interval = (
+                        min(
+                            MERGE_WAIT_FIRST_POLL_SECONDS,
+                            self._merge_recheck_interval,
+                        )
+                        if first_poll
+                        else self._merge_recheck_interval
+                    )
+                    first_poll = False
+                    remaining = max(0.0, deadline - loop.time())
+                    await asyncio.sleep(min(interval, remaining))
+                    try:
+                        refreshed_wait = await wait_client.get(
+                            f"/repos/{owner}/{repo}/pulls/{pr_info.number}"
+                        )
+                    except Exception as wait_exc:
+                        self.log.debug(
+                            "Failed to refresh PR state during auto-merge "
+                            "wait for %s: %s",
+                            pr_key,
+                            wait_exc,
+                        )
+                        continue
+                    if isinstance(refreshed_wait, dict):
+                        # Only overwrite when present, and preserve the
+                        # previous non-None value when GitHub returns null
+                        # (it does so while recomputing) so the
+                        # ``continue_states`` check below does not break the
+                        # loop early on a transient null.
+                        if "mergeable" in refreshed_wait:
+                            refreshed_mergeable = refreshed_wait.get("mergeable")
+                            if refreshed_mergeable is not None:
+                                pr_info.mergeable = refreshed_mergeable
+                        if "mergeable_state" in refreshed_wait:
+                            refreshed_state = refreshed_wait.get("mergeable_state")
+                            # Preserve the previous concrete state while
+                            # GitHub is still recomputing mergeability: it
+                            # returns ``null`` / ``""`` / ``"unknown"``
+                            # transiently, and overwriting with those would
+                            # push the state out of ``continue_states`` and
+                            # break the wait loop early (e.g. a ``blocked``
+                            # PR briefly going ``unknown`` would exit and
+                            # trigger a premature manual merge).
+                            if refreshed_state not in (None, "", "unknown"):
+                                pr_info.mergeable_state = refreshed_state
+                        # The head can change while we wait (rebase,
+                        # force-push); keep it current so any later
+                        # block-reason analysis queries the right commit.
+                        refreshed_head = (refreshed_wait.get("head") or {}).get("sha")
+                        if refreshed_head:
+                            pr_info.head_sha = refreshed_head
+                        if refreshed_wait.get("state") == "closed":
+                            closed_during_wait = True
+                            merged_during_wait = bool(
+                                refreshed_wait.get("merged", False)
+                            )
+                            pr_info.state = "closed"
+                            break
+                    # A PR that becomes immediately mergeable while still
+                    # ``unstable`` (only a non-required check is red) will
+                    # never reach ``clean`` and never leave ``unstable``,
+                    # so keeping it in ``continue_states`` would spin the
+                    # wait to the deadline — the exact slow hang the
+                    # Step 5.5 routing fix removes for PRs that *start*
+                    # mergeable.  Break out as soon as GitHub reports
+                    # ``unstable`` + ``mergeable is True`` so the caller can
+                    # dispatch (auto-merge, already armed before this wait,
+                    # will land it; failing that the caller merges directly).
+                    if (
+                        pr_info.mergeable_state == "unstable"
+                        and pr_info.mergeable is True
+                    ):
+                        break
+                    # Continue waiting only while the PR is in a state the
+                    # caller still considers rescuable; any other value
+                    # means it became mergeable, closed, or hit a terminal
+                    # state, so exit and let the caller decide.
+                    if pr_info.mergeable_state not in continue_states:
+                        break
         finally:
             async with self._waiting_lock:
                 self._waiting_prs.pop(pr_key, None)

--- a/src/dependamerge/merge_manager.py
+++ b/src/dependamerge/merge_manager.py
@@ -657,7 +657,12 @@ class AsyncMergeManager:
             tracker.merge_pending(pr_key)
         else:
             # Defensive: an unexpected terminal status still counts
-            # toward completion so the percentage reaches 100%.
+            # toward completion so the percentage reaches 100%.  Clear
+            # any transitory display state first so the PR cannot be
+            # left stuck in "rebasing"/"waiting" on the live display
+            # if a new terminal status is added without a counter
+            # mapping here.
+            tracker.track_pr_state(pr_key, None)
             tracker.pr_completed()
 
     def _track_pr_state(self, pr_info: PullRequestInfo, state: str | None) -> None:

--- a/src/dependamerge/progress_tracker.py
+++ b/src/dependamerge/progress_tracker.py
@@ -29,6 +29,9 @@ except ImportError:
         def update(self, *args: Any) -> None:
             pass
 
+        def refresh(self) -> None:
+            pass
+
     class Text:  # type: ignore[no-redef]  # pyright: ignore[reportRedefinition]
         def __init__(self, *args: Any, **kwargs: Any) -> None:
             pass
@@ -88,8 +91,12 @@ class ProgressTracker:
             return
 
         try:
+            # Pass a callable rather than a static renderable: Rich
+            # re-invokes it on every auto-refresh tick, so the elapsed
+            # clock keeps advancing even when no progress events fire
+            # (long silent API sequences used to freeze the display).
             self.live = Live(
-                self._generate_display_text(),
+                get_renderable=self._generate_display_text,
                 console=self.console,
                 refresh_per_second=2,
                 transient=False,
@@ -135,7 +142,7 @@ class ProgressTracker:
         if self.rich_available and self.paused:
             try:
                 self.live = Live(
-                    self._generate_display_text(),
+                    get_renderable=self._generate_display_text,
                     console=self.console,
                     refresh_per_second=2,
                     transient=False,
@@ -208,10 +215,15 @@ class ProgressTracker:
         self._refresh_display()
 
     def _refresh_display(self) -> None:
-        """Refresh the live display with current progress."""
+        """Repaint the live display with current progress.
+
+        The Live instance renders via ``get_renderable``, so a plain
+        ``refresh()`` repaints with current state immediately instead
+        of waiting for the next auto-refresh tick.
+        """
         if self.live and self.rich_available and not self.paused:
             try:
-                self.live.update(self._generate_display_text())
+                self.live.refresh()
             except Exception:
                 # If Rich display fails, fall back to simple print
                 self._fallback_display()

--- a/src/dependamerge/progress_tracker.py
+++ b/src/dependamerge/progress_tracker.py
@@ -358,7 +358,25 @@ class ProgressTracker:
 
 
 class MergeProgressTracker(ProgressTracker):
-    """Extended progress tracker with merge-specific metrics."""
+    """Extended progress tracker with merge-specific metrics.
+
+    In addition to the terminal counters (merged / failed / skipped /
+    blocked / pending / closed), PRs move through **transitory**
+    display states while the merge pipeline operates on them
+    (``rebasing`` → ``rebased`` → ``waiting`` → terminal).  Transitory
+    states are keyed by PR so a PR occupies at most one state at a
+    time; recording a terminal outcome removes the PR from whatever
+    transitory state it was in.
+    """
+
+    # Transitory display states in pipeline order.  Each entry is
+    # ``(state_key, display_label)``; only non-zero states render.
+    _STATE_ORDER: tuple[tuple[str, str], ...] = (
+        ("rebasing", "🔄 Rebasing"),
+        ("rebased", "⬆️ Rebased"),
+        ("recreating", "♻️ Recreating"),
+        ("waiting", "⏳ Waiting"),
+    )
 
     def __init__(
         self,
@@ -386,12 +404,20 @@ class MergeProgressTracker(ProgressTracker):
         self.prs_failed = 0
         self.prs_skipped = 0
         self.prs_closed = 0
+        # PRs left with auto-merge armed when the run ended (GitHub
+        # completes the merge server-side once checks pass).
+        self.prs_pending = 0
+        # PRs that are blocked and cannot be merged by this run.
+        self.prs_blocked = 0
         self.is_close_operation = is_close_operation
         self._custom_label = operation_label
         self._custom_icon = operation_icon
         # PR-level progress (used for repo-scoped operations)
         self.total_prs = 0
         self.completed_prs = 0
+        # Transitory per-PR display states: pr_key -> state key from
+        # ``_STATE_ORDER``.  Terminal outcomes remove the entry.
+        self._pr_states: dict[str, str] = {}
 
     def found_similar_pr(self, count: int = 1) -> None:
         """Update count of similar PRs found."""
@@ -407,21 +433,47 @@ class MergeProgressTracker(ProgressTracker):
         self.total_prs = total
         self._refresh_display()
 
-    def merge_success(self) -> None:
+    def track_pr_state(self, pr_key: str, state: str | None) -> None:
+        """Move a PR between transitory display states.
+
+        ``state`` is one of the keys in ``_STATE_ORDER`` (e.g.
+        ``"rebasing"``, ``"rebased"``, ``"waiting"``) or ``None`` to
+        clear the PR's entry when an operation finishes without
+        reaching a terminal outcome.  Terminal outcomes are recorded
+        via ``merge_success`` / ``merge_failure`` / ``merge_skipped``
+        / ``merge_blocked`` / ``merge_pending``, which also clear the
+        transitory entry when given the PR key.
+        """
+        if state is None:
+            self._pr_states.pop(pr_key, None)
+        else:
+            self._pr_states[pr_key] = state
+        self._refresh_display()
+
+    def _finish_pr(self, pr_key: str | None) -> None:
+        """Shared terminal-outcome bookkeeping.
+
+        Clears the PR's transitory state (when a key is supplied) and
+        advances PR-level completion progress.
+        """
+        if pr_key is not None:
+            self._pr_states.pop(pr_key, None)
+        if self.total_prs > 0:
+            self.completed_prs += 1
+
+    def merge_success(self, pr_key: str | None = None) -> None:
         """Record a successful merge."""
+        self._finish_pr(pr_key)
         self.prs_merged += 1
-        if self.total_prs > 0:
-            self.completed_prs += 1
         self._refresh_display()
 
-    def merge_failure(self) -> None:
+    def merge_failure(self, pr_key: str | None = None) -> None:
         """Record a failed merge."""
+        self._finish_pr(pr_key)
         self.prs_failed += 1
-        if self.total_prs > 0:
-            self.completed_prs += 1
         self._refresh_display()
 
-    def merge_skipped(self) -> None:
+    def merge_skipped(self, pr_key: str | None = None) -> None:
         """Record a PR skipped because it was merged externally.
 
         Distinct from ``merge_failure`` because the operator does
@@ -429,26 +481,41 @@ class MergeProgressTracker(ProgressTracker):
         by us.  Tracked separately so the final summary can show
         a non-zero ⏭️ Skipped count alongside Merged / Failed.
         """
+        self._finish_pr(pr_key)
         self.prs_skipped += 1
-        if self.total_prs > 0:
-            self.completed_prs += 1
         self._refresh_display()
 
-    def increment_closed(self) -> None:
+    def merge_blocked(self, pr_key: str | None = None) -> None:
+        """Record a PR that is blocked and cannot merge in this run."""
+        self._finish_pr(pr_key)
+        self.prs_blocked += 1
+        self._refresh_display()
+
+    def merge_pending(self, pr_key: str | None = None) -> None:
+        """Record a PR left with auto-merge armed at run end.
+
+        GitHub merges the PR server-side once its required checks
+        pass; from this run's perspective the PR is terminal but
+        neither merged nor failed.
+        """
+        self._finish_pr(pr_key)
+        self.prs_pending += 1
+        self._refresh_display()
+
+    def increment_closed(self, pr_key: str | None = None) -> None:
         """Record a successful close."""
+        self._finish_pr(pr_key)
         self.prs_closed += 1
-        if self.total_prs > 0:
-            self.completed_prs += 1
         self._refresh_display()
 
     def pr_completed(self) -> None:
         """Record a PR as processed without changing status counters.
 
-        Use this for BLOCKED/SKIPPED outcomes that bypass
-        ``merge_success()`` and ``merge_failure()``.  Those
-        methods already increment ``completed_prs``; this one
-        exists solely to keep the progress percentage accurate
-        for terminal states that neither method covers.
+        Use this for terminal outcomes that bypass the dedicated
+        counter methods.  Those methods already increment
+        ``completed_prs``; this one exists solely to keep the
+        progress percentage accurate for terminal states that no
+        counter method covers.
         """
         if self.total_prs > 0:
             self.completed_prs += 1
@@ -505,18 +572,39 @@ class MergeProgressTracker(ProgressTracker):
         if self.current_operation:
             text.append(f"\n   {self.current_operation}", style="dim")
 
-        # Merge stats
+        # Merge stats — transitory pipeline states first (in flow
+        # order), then terminal outcomes.
         stats_parts: list[str] = []
         if self.similar_prs_found > 0:
             stats_parts.append(f"🔁 Similar: {self.similar_prs_found}")
+        state_counts: dict[str, int] = {}
+        for pr_state in self._pr_states.values():
+            state_counts[pr_state] = state_counts.get(pr_state, 0) + 1
+        for state_key, label in self._STATE_ORDER:
+            count = state_counts.get(state_key, 0)
+            if count > 0:
+                stats_parts.append(f"{label}: {count}")
+        # Defensive: render unknown states too (sorted for stable
+        # output) so a new caller-supplied state is never silently
+        # dropped from the display.
+        known_states = {key for key, _ in self._STATE_ORDER}
+        for state_key in sorted(state_counts):
+            if state_key not in known_states:
+                stats_parts.append(
+                    f"{state_key.capitalize()}: {state_counts[state_key]}"
+                )
         if self.prs_merged > 0:
             stats_parts.append(f"✅ Merged: {self.prs_merged}")
+        if self.prs_pending > 0:
+            stats_parts.append(f"🤖 Pending: {self.prs_pending}")
         if self.prs_closed > 0:
             stats_parts.append(f"🚪 Closed: {self.prs_closed}")
         if self.prs_failed > 0:
             stats_parts.append(f"❌ Failed: {self.prs_failed}")
         if self.prs_skipped > 0:
             stats_parts.append(f"⏭️ Skipped: {self.prs_skipped}")
+        if self.prs_blocked > 0:
+            stats_parts.append(f"🛑 Blocked: {self.prs_blocked}")
 
         if stats_parts:
             text.append(f"\n   {' | '.join(stats_parts)}", style="dim")
@@ -553,6 +641,8 @@ class MergeProgressTracker(ProgressTracker):
                 "prs_merged": self.prs_merged,
                 "prs_failed": self.prs_failed,
                 "prs_skipped": self.prs_skipped,
+                "prs_blocked": self.prs_blocked,
+                "prs_pending": self.prs_pending,
                 "prs_closed": self.prs_closed,
                 "total_prs": self.total_prs,
                 "completed_prs": self.completed_prs,
@@ -576,12 +666,15 @@ class DummyProgressTracker(ProgressTracker):
         self.prs_merged = 0
         self.prs_failed = 0
         self.prs_skipped = 0
+        self.prs_blocked = 0
+        self.prs_pending = 0
         self.prs_closed = 0
         self.is_close_operation = False
         self._custom_label: str | None = None
         self._custom_icon: str | None = None
         self.total_prs = 0
         self.completed_prs = 0
+        self._pr_states: dict[str, str] = {}
 
     def start(self) -> None:
         pass
@@ -622,13 +715,25 @@ class DummyProgressTracker(ProgressTracker):
     def found_similar_pr(self, count: int = 1) -> None:
         pass
 
-    def merge_success(self) -> None:
+    def track_pr_state(self, pr_key: str, state: str | None) -> None:
         pass
 
-    def merge_failure(self) -> None:
+    def merge_success(self, pr_key: str | None = None) -> None:
         pass
 
-    def merge_skipped(self) -> None:
+    def merge_failure(self, pr_key: str | None = None) -> None:
+        pass
+
+    def merge_skipped(self, pr_key: str | None = None) -> None:
+        pass
+
+    def merge_blocked(self, pr_key: str | None = None) -> None:
+        pass
+
+    def merge_pending(self, pr_key: str | None = None) -> None:
+        pass
+
+    def increment_closed(self, pr_key: str | None = None) -> None:
         pass
 
     def _refresh_display(self) -> None:

--- a/src/dependamerge/rebase.py
+++ b/src/dependamerge/rebase.py
@@ -66,7 +66,6 @@ from .git_ops import (
     secure_rmtree,
 )
 from .models import PullRequestInfo
-from .output_utils import log_and_print
 
 if TYPE_CHECKING:
     from .github_async import GitHubAsync
@@ -104,6 +103,12 @@ class RebaseContext:
     # Async callable equivalent to ``manager._enable_auto_merge_for_pr``.
     # Passed in to avoid a circular import.
     enable_auto_merge: Callable[[PullRequestInfo, str, str], Awaitable[bool]]
+    # Optional callback (``manager._track_pr_state``) that moves the PR
+    # between transitory states on the Rich progress tracker
+    # ("rebasing", "rebased", "waiting", or ``None`` to clear).
+    # Default ``None`` keeps existing test constructions working and
+    # makes the tracker strictly optional for isolated use.
+    track_pr_state: Callable[[PullRequestInfo, str | None], None] | None = None
 
 
 @dataclass
@@ -580,12 +585,8 @@ async def perform_step5_rebase(
         # section.
         return Step5Outcome()
 
-    log_and_print(
-        ctx.log,
-        ctx.console,
-        f"🔄 Rebasing: {pr_info.html_url} [behind base branch]",
-        level="debug",
-    )
+    ctx.log.debug("Rebasing %s [behind base branch]", pr_info.html_url)
+    _set_tracker_state(ctx, pr_info, "rebasing")
 
     use_local, local_reason = await should_use_local_rebase(
         github_client=ctx.github_client,
@@ -620,6 +621,20 @@ async def perform_step5_rebase(
 # ---------------------------------------------------------------------------
 
 
+def _set_tracker_state(
+    ctx: RebaseContext,
+    pr_info: PullRequestInfo,
+    state: str | None,
+) -> None:
+    """Move the PR between transitory progress-tracker states.
+
+    No-op when the context was constructed without a
+    ``track_pr_state`` callback (isolated tests, preview mode).
+    """
+    if ctx.track_pr_state is not None:
+        ctx.track_pr_state(pr_info, state)
+
+
 async def _run_local_path(
     *,
     ctx: RebaseContext,
@@ -648,11 +663,10 @@ async def _run_local_path(
       manual merge attempt would 405 transiently. Letting Step
       5.5 wait gives GitHub time to settle before Step 6 acts.
     """
-    log_and_print(
-        ctx.log,
-        ctx.console,
-        f"🛡️ Local rebase: {pr_info.html_url} [{local_reason}]",
-        level="debug",
+    ctx.log.debug(
+        "Local rebase: %s [%s]",
+        pr_info.html_url,
+        local_reason,
     )
     try:
         local_rebase_ok = await local_rebase_pr(
@@ -695,18 +709,12 @@ async def _run_local_path(
         ctx.rebased_prs.add(f"{owner}/{repo}#{pr_info.number}")
 
     if local_rebase_ok:
-        log_and_print(
-            ctx.log,
-            ctx.console,
-            f"✅ Rebased (local): {pr_info.html_url}",
-            level="debug",
-        )
+        ctx.log.debug("Rebased (local): %s", pr_info.html_url)
+        _set_tracker_state(ctx, pr_info, "rebased")
     else:
-        log_and_print(
-            ctx.log,
-            ctx.console,
-            f"🛡️ Local rebase failed; deferring to auto-merge: {pr_info.html_url}",
-            level="debug",
+        ctx.log.debug(
+            "Local rebase failed; deferring to auto-merge: %s",
+            pr_info.html_url,
         )
 
 
@@ -749,9 +757,15 @@ async def _run_rest_path(
                 pr_info.number,
             )
 
-        # Wait for GitHub to process the update and run checks
-        ctx.console.print(f"⏳ Waiting: {pr_info.html_url}")
-        await asyncio.sleep(ctx.merge_recheck_interval)
+        # Wait briefly for GitHub to start processing the update.
+        # The full recheck interval (default 10s) is unnecessary here:
+        # ``_poll_post_rebase`` polls at that cadence anyway and
+        # tolerates the transient ``null``/``behind`` states GitHub
+        # reports while recomputing, so a short head start just gets
+        # the first data point sooner.
+        ctx.log.debug("Waiting for rebase to process: %s", pr_info.html_url)
+        _set_tracker_state(ctx, pr_info, "waiting")
+        await asyncio.sleep(min(2.0, ctx.merge_recheck_interval))
 
         updated_mergeable, updated_mergeable_state = await _poll_post_rebase(
             ctx=ctx,
@@ -787,11 +801,12 @@ async def _run_rest_path(
         # in ``blocked`` or ``behind`` state.
         ctx.rebased_prs.add(f"{owner}/{repo}#{pr_info.number}")
 
+        _set_tracker_state(ctx, pr_info, "rebased")
         _log_post_rebase_status(ctx=ctx, pr_info=pr_info)
         return Step5Outcome()
 
     except Exception as exc:
-        ctx.console.print(f"❌ Failed: {pr_info.html_url} [rebase error: {exc}]")
+        ctx.log.warning("Rebase failed for %s: %s", pr_info.html_url, exc)
         return Step5Outcome(failed=True, error_message=f"Failed to rebase PR: {exc}")
 
 
@@ -913,22 +928,16 @@ def _log_blocked_timeout(
     pr_info: PullRequestInfo,
     auto_merge_ok: bool,
 ) -> None:
-    """Emit the user-facing line when the post-rebase poll times out blocked."""
+    """Log when the post-rebase poll times out blocked (log only)."""
     if auto_merge_ok:
-        log_and_print(
-            ctx.log,
-            ctx.console,
-            f"⏳ Auto-merge will complete: {pr_info.html_url} "
-            "[timeout waiting for checks]",
-            level="warning",
+        ctx.log.warning(
+            "Auto-merge will complete: %s [timeout waiting for checks]",
+            pr_info.html_url,
         )
     else:
-        log_and_print(
-            ctx.log,
-            ctx.console,
-            f"⚠️ Proceeding without checks: {pr_info.html_url} "
-            "[timeout waiting for checks]",
-            level="warning",
+        ctx.log.warning(
+            "Proceeding without checks: %s [timeout waiting for checks]",
+            pr_info.html_url,
         )
 
 
@@ -937,33 +946,15 @@ def _log_post_rebase_status(
     ctx: RebaseContext,
     pr_info: PullRequestInfo,
 ) -> None:
-    """Emit the post-rebase status line based on the final mergeable_state."""
+    """Log the post-rebase status based on the final mergeable_state."""
     state = pr_info.mergeable_state
     if state == "clean":
-        log_and_print(
-            ctx.log,
-            ctx.console,
-            f"✅ Rebased: {pr_info.html_url}",
-            level="debug",
-        )
+        ctx.log.debug("Rebased: %s", pr_info.html_url)
     elif state == "behind":
-        log_and_print(
-            ctx.log,
-            ctx.console,
-            f"⚠️ Rebased: {pr_info.html_url} [still behind after rebase]",
-            level="debug",
-        )
+        ctx.log.debug("Rebased: %s [still behind after rebase]", pr_info.html_url)
     elif state == "blocked":
-        log_and_print(
-            ctx.log,
-            ctx.console,
-            f"⬆️ Rebased: {pr_info.html_url} [waiting for status checks]",
-            level="debug",
+        ctx.log.debug(
+            "Rebased: %s [waiting for status checks]", pr_info.html_url
         )
     else:
-        log_and_print(
-            ctx.log,
-            ctx.console,
-            f"ℹ️ Rebased: {pr_info.html_url}",
-            level="debug",
-        )
+        ctx.log.debug("Rebased: %s [state=%s]", pr_info.html_url, state)

--- a/src/dependamerge/rebase.py
+++ b/src/dependamerge/rebase.py
@@ -66,6 +66,7 @@ from .git_ops import (
     secure_rmtree,
 )
 from .models import PullRequestInfo
+from .slot_lease import parked
 
 if TYPE_CHECKING:
     from .github_async import GitHubAsync
@@ -762,18 +763,22 @@ async def _run_rest_path(
         # ``_poll_post_rebase`` polls at that cadence anyway and
         # tolerates the transient ``null``/``behind`` states GitHub
         # reports while recomputing, so a short head start just gets
-        # the first data point sooner.
+        # the first data point sooner.  The settle sleep and the poll
+        # are both waits on GitHub-side processing, so the worker's
+        # concurrency slot is released for their duration
+        # (``parked()`` — see ``slot_lease.py``).
         ctx.log.debug("Waiting for rebase to process: %s", pr_info.html_url)
         _set_tracker_state(ctx, pr_info, "waiting")
-        await asyncio.sleep(min(2.0, ctx.merge_recheck_interval))
+        async with parked():
+            await asyncio.sleep(min(2.0, ctx.merge_recheck_interval))
 
-        updated_mergeable, updated_mergeable_state = await _poll_post_rebase(
-            ctx=ctx,
-            pr_info=pr_info,
-            owner=owner,
-            repo=repo,
-            auto_merge_ok=auto_merge_ok,
-        )
+            updated_mergeable, updated_mergeable_state = await _poll_post_rebase(
+                ctx=ctx,
+                pr_info=pr_info,
+                owner=owner,
+                repo=repo,
+                auto_merge_ok=auto_merge_ok,
+            )
 
         # Update our PR info with the latest state.  Preserve the
         # previous non-None values when the refresh returns

--- a/src/dependamerge/slot_lease.py
+++ b/src/dependamerge/slot_lease.py
@@ -1,0 +1,138 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 The Linux Foundation
+
+"""Park-aware concurrency slots for the production merge path.
+
+This ports the merge engine's core scheduling semantic (see
+``docs/MERGE_ENGINE_DESIGN.md`` and ``engine/scheduler.py``) to the
+legacy orchestration without decomposing ``_merge_single_pr`` into
+engine phases: **a concurrency slot is held only while a PR is doing
+active work; a PR waiting on an external event (a dependabot rebase,
+CI checks, auto-merge) holds no slot.**
+
+The legacy behaviour — every waiting loop running inside the worker
+task that holds one of the N global semaphore slots — meant a handful
+of slow external operations could pin the entire run's capacity: 41
+repos needing a ~5-minute rebase at 10 slots drain in 20-25 minutes of
+idle waiting.  With parking, all 41 rebases are issued in one
+scheduling pass and runnable PRs never queue behind parked ones.
+
+Usage::
+
+    async with holding_slot(semaphore):       # replaces bare acquire
+        ...active work...
+        async with parked():                  # inside any wait loop
+            while not done:
+                await poll()                  # slot released here
+        ...active work again (slot re-held)...
+
+``parked()`` finds the current task's lease through a
+:class:`contextvars.ContextVar`, so deeply nested wait loops (e.g. the
+rebase module's post-rebase poll) release the slot without threading a
+lease parameter through every call site.  Each ``asyncio`` task gets
+its own context, so concurrent workers never see each other's lease.
+
+While parked, the polling GETs run without a slot — API protection is
+not the semaphore's job: the shared ``GitHubAsync`` client has its own
+concurrency cap, RPS limiter, and adaptive throttle.
+
+Nesting ``parked()`` inside ``parked()`` is a no-op for the inner
+block (the slot is already released); ``parked()`` outside any
+``holding_slot()`` is also a no-op, so helpers using it remain safe to
+call from tests or non-slotted paths.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import contextvars
+from collections.abc import AsyncIterator
+
+__all__ = ["SlotLease", "current_lease", "holding_slot", "parked"]
+
+
+class SlotLease:
+    """A releasable, re-acquirable hold on an ``asyncio.Semaphore``.
+
+    Tracks whether the permit is currently held so ``release`` /
+    ``acquire`` are idempotent: releasing an already-released lease or
+    re-acquiring a held one is a no-op, never a semaphore imbalance.
+    """
+
+    __slots__ = ("_semaphore", "_held")
+
+    def __init__(self, semaphore: asyncio.Semaphore) -> None:
+        self._semaphore = semaphore
+        self._held = False
+
+    @property
+    def held(self) -> bool:
+        return self._held
+
+    async def acquire(self) -> None:
+        """Acquire the underlying permit (no-op when already held)."""
+        if not self._held:
+            await self._semaphore.acquire()
+            self._held = True
+
+    def release(self) -> None:
+        """Release the underlying permit (no-op when not held)."""
+        if self._held:
+            self._semaphore.release()
+            self._held = False
+
+
+_current_lease: contextvars.ContextVar[SlotLease | None] = contextvars.ContextVar(
+    "dependamerge_slot_lease", default=None
+)
+
+
+def current_lease() -> SlotLease | None:
+    """The current task's slot lease, or ``None`` outside one."""
+    return _current_lease.get()
+
+
+@contextlib.asynccontextmanager
+async def holding_slot(semaphore: asyncio.Semaphore) -> AsyncIterator[SlotLease]:
+    """Hold one slot of ``semaphore`` for the duration of the block.
+
+    Drop-in replacement for ``async with semaphore:`` that additionally
+    publishes a :class:`SlotLease` to the task context so nested
+    :func:`parked` blocks can release the slot while waiting.
+    """
+    lease = SlotLease(semaphore)
+    await lease.acquire()
+    token = _current_lease.set(lease)
+    try:
+        yield lease
+    finally:
+        _current_lease.reset(token)
+        # Balanced regardless of what the block did: exactly one
+        # release when the lease is still held, none when a parked
+        # block was cancelled mid-reacquire.
+        lease.release()
+
+
+@contextlib.asynccontextmanager
+async def parked() -> AsyncIterator[None]:
+    """Release the current task's slot for the duration of a wait.
+
+    On exit the slot is re-acquired (competing fairly with queued
+    work) before active processing resumes.  A no-op when the task
+    holds no lease or the lease is already released (nested parks).
+    """
+    lease = _current_lease.get()
+    if lease is None or not lease.held:
+        yield
+        return
+    lease.release()
+    try:
+        yield
+    finally:
+        # Re-acquire even when the wait body raised: the caller's
+        # exception handling (and eventually ``holding_slot``'s
+        # ``finally``) expects the lease to be in its pre-park state.
+        # If *this* acquire is cancelled, the lease stays released and
+        # ``holding_slot`` correctly skips its final release.
+        await lease.acquire()

--- a/tests/engine/__init__.py
+++ b/tests/engine/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 The Linux Foundation

--- a/tests/engine/test_engine_ladder.py
+++ b/tests/engine/test_engine_ladder.py
@@ -1,0 +1,309 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 The Linux Foundation
+
+"""Tests for the recovery ladder decision table."""
+
+from __future__ import annotations
+
+from dependamerge.engine.ladder import (
+    ATTEMPT_PRECOMMIT,
+    ATTEMPT_REBASE,
+    ATTEMPT_RECREATE,
+    ATTEMPT_WAIT,
+    ActionKind,
+    LadderInput,
+    decide,
+)
+
+
+def _facts(**overrides) -> LadderInput:
+    base: dict = {
+        "mergeable_state": "clean",
+        "mergeable": True,
+        "is_dependabot": True,
+    }
+    base.update(overrides)
+    return LadderInput(**base)
+
+
+class TestMergeableStates:
+    def test_clean_merges(self):
+        action = decide(_facts(mergeable_state="clean"))
+        assert action.kind is ActionKind.MERGE
+
+    def test_unknown_state_attempts_merge(self):
+        action = decide(_facts(mergeable_state="unknown", mergeable=None))
+        assert action.kind is ActionKind.MERGE
+
+    def test_empty_state_attempts_merge(self):
+        action = decide(_facts(mergeable_state="", mergeable=None))
+        assert action.kind is ActionKind.MERGE
+
+    def test_unstable_mergeable_attempts_merge(self):
+        # ``unstable`` = only a non-required check is red; the merge
+        # button is live and the merge call is the arbiter.
+        action = decide(_facts(mergeable_state="unstable", mergeable=True))
+        assert action.kind is ActionKind.MERGE
+
+    def test_unstable_not_mergeable_waits_once(self):
+        # Mergeability still computing (None) or reading False: wait
+        # for it to settle instead of firing a premature merge call.
+        for mergeable in (None, False):
+            action = decide(_facts(mergeable_state="unstable", mergeable=mergeable))
+            assert action.kind is ActionKind.WAIT_CHECKS
+
+    def test_unstable_not_mergeable_after_wait_fails(self):
+        action = decide(
+            _facts(
+                mergeable_state="unstable",
+                mergeable=False,
+                attempted={ATTEMPT_WAIT},
+            )
+        )
+        assert action.kind is ActionKind.FAIL
+
+
+class TestDirty:
+    def test_dependabot_conflict_rebases(self):
+        action = decide(_facts(mergeable_state="dirty"))
+        assert action.kind is ActionKind.REBASE_DEPENDABOT
+
+    def test_human_conflict_fails(self):
+        action = decide(_facts(mergeable_state="dirty", is_dependabot=False))
+        assert action.kind is ActionKind.FAIL
+        assert action.reason == "merge conflicts"
+
+    def test_dependabot_conflict_after_rebase_attempt_fails(self):
+        action = decide(_facts(mergeable_state="dirty", attempted={ATTEMPT_REBASE}))
+        assert action.kind is ActionKind.FAIL
+
+
+class TestBehind:
+    def test_dependabot_behind_uses_macro(self):
+        action = decide(_facts(mergeable_state="behind"))
+        assert action.kind is ActionKind.REBASE_DEPENDABOT
+
+    def test_non_dependabot_behind_updates_branch(self):
+        action = decide(_facts(mergeable_state="behind", is_dependabot=False))
+        assert action.kind is ActionKind.REBASE_BRANCH
+
+    def test_behind_without_fix_waits(self):
+        action = decide(_facts(mergeable_state="behind", fix_out_of_date=False))
+        assert action.kind is ActionKind.WAIT_CHECKS
+
+    def test_behind_after_rebase_attempt_waits(self):
+        action = decide(_facts(mergeable_state="behind", attempted={ATTEMPT_REBASE}))
+        assert action.kind is ActionKind.WAIT_CHECKS
+
+    def test_behind_after_rebase_and_wait_fails(self):
+        action = decide(
+            _facts(
+                mergeable_state="behind",
+                attempted={ATTEMPT_REBASE, ATTEMPT_WAIT},
+            )
+        )
+        assert action.kind is ActionKind.FAIL
+
+
+class TestBlockedStaleFailingCheck:
+    """Rung 3: the rung the legacy orchestration lacks.
+
+    A required check that completed with a failure on a branch that is
+    behind base was judged against stale content; a rebase re-runs it
+    against current base.  This is exactly the org-required workflow
+    audit scenario: a batch of automation PRs branched before the
+    audit fix merged all fail the audit until rebased.
+    """
+
+    def test_dependabot_failing_check_behind_rebases(self):
+        action = decide(
+            _facts(
+                mergeable_state="blocked",
+                mergeable=False,
+                has_failing_required_check=True,
+                behind_by=6,
+            )
+        )
+        assert action.kind is ActionKind.REBASE_DEPENDABOT
+        assert "stale" in action.reason
+
+    def test_non_dependabot_failing_check_behind_updates_branch(self):
+        action = decide(
+            _facts(
+                mergeable_state="blocked",
+                mergeable=False,
+                is_dependabot=False,
+                has_failing_required_check=True,
+                behind_by=1,
+            )
+        )
+        assert action.kind is ActionKind.REBASE_BRANCH
+
+    def test_failing_check_up_to_date_fails(self):
+        # Branch is current: the failure is genuine; a rebase cannot
+        # change the verdict, so no rebase is attempted.
+        action = decide(
+            _facts(
+                mergeable_state="blocked",
+                mergeable=False,
+                has_failing_required_check=True,
+                behind_by=0,
+                block_reason="Blocked by failing check: Audit",
+            )
+        )
+        assert action.kind is ActionKind.FAIL
+        assert action.reason == "Blocked by failing check: Audit"
+
+    def test_failing_check_unknown_behind_fails(self):
+        # Unknown distance from base: fail closed rather than rebase
+        # a possibly-current branch.
+        action = decide(
+            _facts(
+                mergeable_state="blocked",
+                mergeable=False,
+                has_failing_required_check=True,
+                behind_by=None,
+            )
+        )
+        assert action.kind is ActionKind.FAIL
+
+    def test_failing_check_behind_after_rebase_fails(self):
+        # The rebase already happened and the check still fails: the
+        # failure is real on current base.
+        action = decide(
+            _facts(
+                mergeable_state="blocked",
+                mergeable=False,
+                has_failing_required_check=True,
+                behind_by=2,
+                attempted={ATTEMPT_REBASE},
+                block_reason="Blocked by failing check: Audit",
+            )
+        )
+        assert action.kind is ActionKind.FAIL
+
+
+class TestBlockedOtherRungs:
+    def test_pending_checks_wait(self):
+        action = decide(
+            _facts(
+                mergeable_state="blocked",
+                mergeable=False,
+                has_pending_required_check=True,
+            )
+        )
+        assert action.kind is ActionKind.WAIT_CHECKS
+
+    def test_pending_checks_after_wait_fails(self):
+        action = decide(
+            _facts(
+                mergeable_state="blocked",
+                mergeable=False,
+                has_pending_required_check=True,
+                attempted={ATTEMPT_WAIT},
+                block_reason="Blocked by pending required check: build",
+            )
+        )
+        assert action.kind is ActionKind.FAIL
+
+    def test_stuck_check_dependabot_recreates(self):
+        action = decide(
+            _facts(
+                mergeable_state="blocked",
+                mergeable=False,
+                stuck_required_check="DCO",
+            )
+        )
+        assert action.kind is ActionKind.RECREATE
+        assert "DCO" in action.reason
+
+    def test_stuck_check_non_dependabot_falls_through(self):
+        # No recreate macro for human PRs; with nothing else pending
+        # the item fails with the block reason.
+        action = decide(
+            _facts(
+                mergeable_state="blocked",
+                mergeable=False,
+                is_dependabot=False,
+                stuck_required_check="DCO",
+                block_reason="Blocked by pending required check: DCO",
+            )
+        )
+        assert action.kind is ActionKind.FAIL
+
+    def test_stuck_check_after_recreate_falls_through(self):
+        action = decide(
+            _facts(
+                mergeable_state="blocked",
+                mergeable=False,
+                stuck_required_check="DCO",
+                attempted={ATTEMPT_RECREATE},
+            )
+        )
+        assert action.kind is ActionKind.FAIL
+
+    def test_stale_precommit_retriggers(self):
+        action = decide(
+            _facts(
+                mergeable_state="blocked",
+                mergeable=False,
+                stale_precommit_check=True,
+            )
+        )
+        assert action.kind is ActionKind.RETRIGGER_PRECOMMIT
+
+    def test_stale_precommit_after_retrigger_fails(self):
+        action = decide(
+            _facts(
+                mergeable_state="blocked",
+                mergeable=False,
+                stale_precommit_check=True,
+                attempted={ATTEMPT_PRECOMMIT},
+            )
+        )
+        assert action.kind is ActionKind.FAIL
+
+    def test_blocked_no_recovery_fails_with_reason(self):
+        action = decide(
+            _facts(
+                mergeable_state="blocked",
+                mergeable=False,
+                block_reason="Blocked by missing required reviews",
+            )
+        )
+        assert action.kind is ActionKind.FAIL
+        assert action.reason == "Blocked by missing required reviews"
+
+    def test_blocked_no_reason_fails_with_default(self):
+        action = decide(_facts(mergeable_state="blocked", mergeable=False))
+        assert action.kind is ActionKind.FAIL
+        assert "cannot resolve" in action.reason
+
+
+class TestRungPriority:
+    def test_stale_failing_check_outranks_stuck_and_precommit(self):
+        # A behind branch with a failing check is rebased even when a
+        # stuck check / stale pre-commit.ci is also present: the
+        # rebase re-triggers everything at once.
+        action = decide(
+            _facts(
+                mergeable_state="blocked",
+                mergeable=False,
+                has_failing_required_check=True,
+                behind_by=3,
+                stuck_required_check="DCO",
+                stale_precommit_check=True,
+            )
+        )
+        assert action.kind is ActionKind.REBASE_DEPENDABOT
+
+    def test_stuck_check_outranks_pending_wait(self):
+        action = decide(
+            _facts(
+                mergeable_state="blocked",
+                mergeable=False,
+                stuck_required_check="DCO",
+                has_pending_required_check=True,
+            )
+        )
+        assert action.kind is ActionKind.RECREATE

--- a/tests/engine/test_engine_reconciler.py
+++ b/tests/engine/test_engine_reconciler.py
@@ -1,0 +1,227 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 The Linux Foundation
+
+"""Tests for the reconciler: parking, waking, expiry, resilience."""
+
+from __future__ import annotations
+
+import asyncio
+
+from dependamerge.engine.model import Park, Snapshot, WorkItem
+from dependamerge.engine.reconciler import Reconciler
+
+
+def make_item(key: str = "o/r#1") -> WorkItem:
+    return WorkItem(index=0, lane="o/r", key=key, payload=None, phase="p")
+
+
+def make_park(wake, reason: str = "test") -> Park:
+    return Park(reason=reason, wake=wake, on_wake="wake", on_timeout="timeout")
+
+
+class TestWake:
+    async def test_wakes_when_predicate_fires(self):
+        flips = {"clean": False}
+
+        async def snapshots(item: WorkItem) -> Snapshot | None:
+            return Snapshot(mergeable_state="clean" if flips["clean"] else "blocked")
+
+        reconciler = Reconciler(snapshots, interval=0.02)
+        task = asyncio.create_task(reconciler.run())
+        try:
+            item = make_item()
+            park = make_park(
+                lambda it: (
+                    it.snapshot is not None and it.snapshot.mergeable_state == "clean"
+                )
+            )
+            loop = asyncio.get_running_loop()
+
+            async def flip_soon():
+                await asyncio.sleep(0.05)
+                flips["clean"] = True
+
+            flip = asyncio.create_task(flip_soon())
+            woke = await reconciler.park(item, park, loop.time() + 5.0)
+            await flip
+            assert woke is True
+            assert item.snapshot is not None
+            assert item.snapshot.mergeable_state == "clean"
+            assert reconciler.parked_view() == {}
+        finally:
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+
+    async def test_times_out_at_deadline(self):
+        async def snapshots(item: WorkItem) -> Snapshot | None:
+            return Snapshot(mergeable_state="blocked")
+
+        reconciler = Reconciler(snapshots, interval=0.02)
+        task = asyncio.create_task(reconciler.run())
+        try:
+            loop = asyncio.get_running_loop()
+            woke = await reconciler.park(
+                make_item(), make_park(lambda it: False), loop.time() + 0.08
+            )
+            assert woke is False
+        finally:
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+
+    async def test_expired_deadline_resolves_without_waiting(self):
+        async def snapshots(item: WorkItem) -> Snapshot | None:
+            return None
+
+        reconciler = Reconciler(snapshots, interval=60.0)
+        loop = asyncio.get_running_loop()
+        # No reconciler task running at all: an already-expired
+        # deadline must resolve synchronously.
+        woke = await reconciler.park(
+            make_item(), make_park(lambda it: True), loop.time() - 1.0
+        )
+        assert woke is False
+
+
+class TestResilience:
+    async def test_failed_snapshot_keeps_waiting_and_previous_snapshot(self):
+        calls = {"n": 0}
+
+        async def snapshots(item: WorkItem) -> Snapshot | None:
+            calls["n"] += 1
+            if calls["n"] == 1:
+                return Snapshot(mergeable_state="blocked")
+            if calls["n"] == 2:
+                raise RuntimeError("transient API failure")
+            return Snapshot(mergeable_state="clean")
+
+        reconciler = Reconciler(snapshots, interval=0.02)
+        task = asyncio.create_task(reconciler.run())
+        try:
+            item = make_item()
+            loop = asyncio.get_running_loop()
+            woke = await reconciler.park(
+                item,
+                make_park(
+                    lambda it: (
+                        it.snapshot is not None
+                        and it.snapshot.mergeable_state == "clean"
+                    )
+                ),
+                loop.time() + 5.0,
+            )
+            assert woke is True
+            assert calls["n"] >= 3
+        finally:
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+
+    async def test_predicate_exception_does_not_kill_loop(self):
+        async def snapshots(item: WorkItem) -> Snapshot | None:
+            return Snapshot(mergeable_state="blocked")
+
+        boom_item = make_item("o/r#1")
+        ok_item = make_item("o/r#2")
+
+        def bad_predicate(it: WorkItem) -> bool:
+            raise RuntimeError("predicate bug")
+
+        reconciler = Reconciler(snapshots, interval=0.02)
+        task = asyncio.create_task(reconciler.run())
+        try:
+            loop = asyncio.get_running_loop()
+            results = await asyncio.gather(
+                reconciler.park(boom_item, make_park(bad_predicate), loop.time() + 0.1),
+                reconciler.park(ok_item, make_park(lambda it: True), loop.time() + 5.0),
+            )
+            # The buggy predicate times out; the healthy one wakes.
+            assert results == [False, True]
+        finally:
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+
+    async def test_flush_times_out_all_parked(self):
+        async def snapshots(item: WorkItem) -> Snapshot | None:
+            return None
+
+        reconciler = Reconciler(snapshots, interval=60.0)
+        loop = asyncio.get_running_loop()
+        parked = [
+            asyncio.create_task(
+                reconciler.park(
+                    make_item(f"o/r#{i}"),
+                    make_park(lambda it: False),
+                    loop.time() + 60.0,
+                )
+            )
+            for i in range(3)
+        ]
+        await asyncio.sleep(0.02)
+        assert len(reconciler.parked_view()) == 3
+        reconciler.flush()
+        assert await asyncio.gather(*parked) == [False, False, False]
+        assert reconciler.parked_view() == {}
+
+    async def test_parked_view_reports_reason_and_deadline(self):
+        async def snapshots(item: WorkItem) -> Snapshot | None:
+            return None
+
+        reconciler = Reconciler(snapshots, interval=60.0)
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + 60.0
+        parked = asyncio.create_task(
+            reconciler.park(
+                make_item("o/r#7"),
+                make_park(lambda it: False, reason="waiting for rebase"),
+                deadline,
+            )
+        )
+        await asyncio.sleep(0.02)
+        view = reconciler.parked_view()
+        assert view["o/r#7"] == ("waiting for rebase", deadline)
+        reconciler.flush()
+        await parked
+
+    async def test_duplicate_park_times_out_previous_waiter(self):
+        # The engine enforces key uniqueness, so this is a defensive
+        # path: a second park with the same key must not orphan the
+        # first waiter (which would suspend its task forever).
+        async def snapshots(item: WorkItem) -> Snapshot | None:
+            return None
+
+        reconciler = Reconciler(snapshots, interval=60.0)
+        loop = asyncio.get_running_loop()
+        first = asyncio.create_task(
+            reconciler.park(
+                make_item("o/r#1"),
+                make_park(lambda it: False, reason="first"),
+                loop.time() + 60.0,
+            )
+        )
+        await asyncio.sleep(0.02)
+        second = asyncio.create_task(
+            reconciler.park(
+                make_item("o/r#1"),
+                make_park(lambda it: False, reason="second"),
+                loop.time() + 60.0,
+            )
+        )
+        # The first waiter resolves as a timeout instead of hanging.
+        assert await asyncio.wait_for(first, timeout=1.0) is False
+        await asyncio.sleep(0.02)
+        # The second park is the one now tracked.
+        assert reconciler.parked_view()["o/r#1"][0] == "second"
+        reconciler.flush()
+        assert await second is False
+        assert reconciler.parked_view() == {}

--- a/tests/engine/test_engine_scheduler.py
+++ b/tests/engine/test_engine_scheduler.py
@@ -1,0 +1,484 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 The Linux Foundation
+
+"""Tests for the engine scheduler: lanes, slots, parking, budgets."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+
+from dependamerge.engine.model import (
+    Advance,
+    Finish,
+    ItemState,
+    Park,
+    Snapshot,
+    Transition,
+    WorkItem,
+)
+from dependamerge.engine.scheduler import (
+    MAX_PHASE_EXECUTIONS,
+    Engine,
+    flat_lanes,
+)
+
+FAST = {
+    "concurrency": 4,
+    "default_park_timeout": 0.3,
+    "reconcile_interval": 0.02,
+}
+
+
+def make_items(specs: list[tuple[str, str]]) -> list[WorkItem]:
+    """Build items from (lane, key) pairs, phase preset to 'start'."""
+    return [
+        WorkItem(index=i, lane=lane, key=key, payload=None, phase="start")
+        for i, (lane, key) in enumerate(specs)
+    ]
+
+
+class ScriptedRunner:
+    """PhaseRunner driven by a dict of phase → behaviour callables.
+
+    Records every (key, phase) execution and tracks live concurrency.
+    """
+
+    def __init__(self, script: dict[str, Any], *, hold: float = 0.0) -> None:
+        self.script = script
+        self.hold = hold
+        self.calls: list[tuple[str, str]] = []
+        self.active = 0
+        self.max_active = 0
+        self.active_by_lane: dict[str, int] = {}
+        self.max_active_by_lane: dict[str, int] = {}
+
+    async def run(self, item: WorkItem, phase: str) -> Transition:
+        self.calls.append((item.key, phase))
+        self.active += 1
+        self.max_active = max(self.max_active, self.active)
+        lane_active = self.active_by_lane.get(item.lane, 0) + 1
+        self.active_by_lane[item.lane] = lane_active
+        self.max_active_by_lane[item.lane] = max(
+            self.max_active_by_lane.get(item.lane, 0), lane_active
+        )
+        try:
+            if self.hold:
+                await asyncio.sleep(self.hold)
+            behaviour = self.script[phase]
+            result = behaviour(item) if callable(behaviour) else behaviour
+            if isinstance(result, Exception):
+                raise result
+            transition: Transition = result
+            return transition
+        finally:
+            self.active -= 1
+            self.active_by_lane[item.lane] -= 1
+
+    def on_error(self, item: WorkItem, exc: Exception) -> Any:
+        return f"error:{exc}"
+
+
+async def no_snapshots(item: WorkItem) -> Snapshot | None:
+    return None
+
+
+class TestBasicExecution:
+    async def test_single_item_finishes(self):
+        runner = ScriptedRunner({"start": Finish("ok")})
+        engine = Engine(runner, no_snapshots, **FAST)
+        items = make_items([("r1", "r1#1")])
+        done = await engine.run(items)
+        assert done[0].outcome == "ok"
+        assert done[0].state is ItemState.DONE
+
+    async def test_advance_chains_phases(self):
+        runner = ScriptedRunner({"start": Advance("second"), "second": Finish("done")})
+        engine = Engine(runner, no_snapshots, **FAST)
+        items = make_items([("r1", "r1#1")])
+        done = await engine.run(items)
+        assert done[0].outcome == "done"
+        assert runner.calls == [("r1#1", "start"), ("r1#1", "second")]
+
+    async def test_results_in_input_order(self):
+        # Items in different lanes finish out of order (varying hold
+        # times) but come back positionally.
+        async def _run(item: WorkItem, phase: str) -> Transition:
+            await asyncio.sleep(0.05 if item.index == 0 else 0.0)
+            return Finish(f"out-{item.index}")
+
+        class Runner:
+            run = staticmethod(_run)
+
+            def on_error(self, item, exc):
+                return "err"
+
+        engine = Engine(Runner(), no_snapshots, **FAST)
+        items = make_items([("r1", "r1#1"), ("r2", "r2#1"), ("r3", "r3#1")])
+        done = await engine.run(items)
+        assert [i.outcome for i in done] == ["out-0", "out-1", "out-2"]
+
+    async def test_empty_batch(self):
+        runner = ScriptedRunner({})
+        engine = Engine(runner, no_snapshots, **FAST)
+        assert await engine.run([]) == []
+
+    async def test_duplicate_keys_rejected(self):
+        # Parked tracking and progress views index items by key, so
+        # duplicates would silently shadow each other.
+        runner = ScriptedRunner({"start": Finish("ok")})
+        engine = Engine(runner, no_snapshots, **FAST)
+        items = make_items([("r1", "r1#1"), ("r1", "r1#1")])
+        with pytest.raises(ValueError, match="duplicate work item key"):
+            await engine.run(items)
+
+
+class TestLaneSerialisation:
+    async def test_one_in_flight_per_lane_fifo(self):
+        runner = ScriptedRunner({"start": Finish("ok")}, hold=0.02)
+        engine = Engine(runner, no_snapshots, **FAST)
+        items = make_items(
+            [("r1", "r1#1"), ("r1", "r1#2"), ("r1", "r1#3"), ("r2", "r2#1")]
+        )
+        await engine.run(items)
+        assert runner.max_active_by_lane["r1"] == 1
+        r1_calls = [key for key, _ in runner.calls if key.startswith("r1#")]
+        assert r1_calls == ["r1#1", "r1#2", "r1#3"]
+
+    async def test_distinct_lanes_overlap(self):
+        runner = ScriptedRunner({"start": Finish("ok")}, hold=0.05)
+        engine = Engine(runner, no_snapshots, **FAST)
+        items = make_items([("r1", "r1#1"), ("r2", "r2#1"), ("r3", "r3#1")])
+        await engine.run(items)
+        assert runner.max_active >= 2
+
+    async def test_global_concurrency_cap(self):
+        runner = ScriptedRunner({"start": Finish("ok")}, hold=0.05)
+        engine = Engine(
+            runner,
+            no_snapshots,
+            concurrency=2,
+            default_park_timeout=0.3,
+            reconcile_interval=0.02,
+        )
+        items = make_items([(f"r{i}", f"r{i}#1") for i in range(6)])
+        await engine.run(items)
+        assert runner.max_active <= 2
+
+    async def test_item_waiting_for_slot_reports_queued(self):
+        # concurrency=1: while the first item holds the slot, an item
+        # blocked on slot acquisition must read QUEUED, not ACTIVE.
+        observed: list[ItemState] = []
+
+        items = make_items([("r1", "r1#1"), ("r2", "r2#1")])
+
+        async def _run(item: WorkItem, phase: str) -> Transition:
+            if item.key == "r1#1":
+                await asyncio.sleep(0.05)
+                observed.append(items[1].state)
+            return Finish("ok")
+
+        class Runner:
+            run = staticmethod(_run)
+
+            def on_error(self, item, exc):
+                return "err"
+
+        engine = Engine(
+            Runner(),
+            no_snapshots,
+            concurrency=1,
+            default_park_timeout=0.3,
+            reconcile_interval=0.02,
+        )
+        done = await engine.run(items)
+        assert observed == [ItemState.QUEUED]
+        assert [i.outcome for i in done] == ["ok", "ok"]
+
+    async def test_lane_continues_after_item_exception(self):
+        def boom(item: WorkItem) -> Transition:
+            raise RuntimeError("phase crashed")
+
+        runner = ScriptedRunner(
+            {"start": lambda item: boom(item) if item.index == 0 else Finish("ok")}
+        )
+        engine = Engine(runner, no_snapshots, **FAST)
+        items = make_items([("r1", "r1#1"), ("r1", "r1#2")])
+        done = await engine.run(items)
+        assert done[0].outcome == "error:phase crashed"
+        assert done[0].state is ItemState.DONE
+        assert done[1].outcome == "ok"
+
+    async def test_flat_lanes_helper_gives_unique_lanes(self):
+        items = make_items([("r1", "r1#1"), ("r1", "r1#2")])
+        flat_lanes(items)
+        assert items[0].lane != items[1].lane
+
+
+class TestParking:
+    async def test_park_wakes_on_predicate(self):
+        # Phase "start" parks until the snapshot says clean; the
+        # snapshot source flips state after two ticks.
+        ticks = {"n": 0}
+
+        async def snapshots(item: WorkItem) -> Snapshot | None:
+            ticks["n"] += 1
+            state = "clean" if ticks["n"] >= 2 else "blocked"
+            return Snapshot(mergeable_state=state)
+
+        runner = ScriptedRunner(
+            {
+                "start": Park(
+                    reason="waiting for checks",
+                    wake=lambda item: (
+                        item.snapshot is not None
+                        and item.snapshot.mergeable_state == "clean"
+                    ),
+                    on_wake="merge",
+                    on_timeout="timed-out",
+                ),
+                "merge": Finish("merged"),
+                "timed-out": Finish("pending"),
+            }
+        )
+        engine = Engine(runner, snapshots, **FAST)
+        items = make_items([("r1", "r1#1")])
+        done = await engine.run(items)
+        assert done[0].outcome == "merged"
+        assert ("r1#1", "merge") in runner.calls
+
+    async def test_park_times_out_to_on_timeout_phase(self):
+        runner = ScriptedRunner(
+            {
+                "start": Park(
+                    reason="never wakes",
+                    wake=lambda item: False,
+                    on_wake="merge",
+                    on_timeout="timed-out",
+                    timeout=0.05,
+                ),
+                "merge": Finish("merged"),
+                "timed-out": Finish("pending"),
+            }
+        )
+        engine = Engine(runner, no_snapshots, **FAST)
+        items = make_items([("r1", "r1#1")])
+        done = await engine.run(items)
+        assert done[0].outcome == "pending"
+        assert ("r1#1", "merge") not in runner.calls
+
+    async def test_parked_items_do_not_hold_slots(self):
+        # concurrency=1: item A parks (indefinitely within the test
+        # window); item B in another lane must still run to completion
+        # while A is parked.  This is the core capacity fix.
+        order: list[str] = []
+
+        def start(item: WorkItem) -> Transition:
+            if item.key == "r1#1":
+                return Park(
+                    reason="slow rebase",
+                    wake=lambda it: False,
+                    on_wake="merge",
+                    on_timeout="timed-out",
+                    timeout=0.15,
+                )
+            order.append("b-ran")
+            return Finish("b-done")
+
+        runner = ScriptedRunner(
+            {
+                "start": start,
+                "timed-out": lambda item: Finish("a-pending"),
+            }
+        )
+        engine = Engine(
+            runner,
+            no_snapshots,
+            concurrency=1,
+            default_park_timeout=0.3,
+            reconcile_interval=0.02,
+        )
+        items = make_items([("r1", "r1#1"), ("r2", "r2#1")])
+        done = await engine.run(items)
+        assert done[1].outcome == "b-done"
+        assert done[0].outcome == "a-pending"
+        assert order == ["b-ran"]
+
+    async def test_parked_item_blocks_same_lane_successor(self):
+        # Per-repo serialisation survives parking: the next item in
+        # the same lane must not start while its predecessor is parked.
+        started: list[str] = []
+
+        def start(item: WorkItem) -> Transition:
+            started.append(item.key)
+            if item.key == "r1#1":
+                return Park(
+                    reason="rebase",
+                    wake=lambda it: False,
+                    on_wake="merge",
+                    on_timeout="timed-out",
+                    timeout=0.1,
+                )
+            return Finish("second")
+
+        runner = ScriptedRunner(
+            {"start": start, "timed-out": lambda item: Finish("first")}
+        )
+        engine = Engine(runner, no_snapshots, **FAST)
+        items = make_items([("r1", "r1#1"), ("r1", "r1#2")])
+        await engine.run(items)
+        # r1#2 starts only after r1#1 finished (park + timeout phase).
+        assert started == ["r1#1", "r1#2"]
+        first_done = runner.calls.index(("r1#1", "timed-out"))
+        second_start = runner.calls.index(("r1#2", "start"))
+        assert second_start > first_done
+
+    async def test_parked_view_exposes_reason(self):
+        seen: dict[str, tuple[str, float]] = {}
+
+        engine_ref: list[Engine] = []
+
+        def start(item: WorkItem) -> Transition:
+            return Park(
+                reason="waiting for dependabot rebase",
+                wake=lambda it: bool(seen.update(engine_ref[0].parked_view())) or False,
+                on_wake="merge",
+                on_timeout="timed-out",
+                timeout=0.1,
+            )
+
+        runner = ScriptedRunner(
+            {"start": start, "timed-out": lambda item: Finish("pending")}
+        )
+        engine = Engine(runner, no_snapshots, **FAST)
+        engine_ref.append(engine)
+        await engine.run(make_items([("r1", "r1#1")]))
+        assert seen["r1#1"][0] == "waiting for dependabot rebase"
+
+
+class TestBudgets:
+    async def test_no_wait_mode_skips_parks_entirely(self):
+        # max_wait=0: the parking phase's side effects happen, then
+        # on_timeout runs immediately — nothing sleeps.
+        side_effects: list[str] = []
+
+        def start(item: WorkItem) -> Transition:
+            side_effects.append("rebase-requested")
+            return Park(
+                reason="rebase",
+                wake=lambda it: True,  # would wake instantly if waited
+                on_wake="merge",
+                on_timeout="fire-and-forget",
+            )
+
+        runner = ScriptedRunner(
+            {
+                "start": start,
+                "fire-and-forget": lambda item: Finish("auto-merge armed"),
+                "merge": lambda item: Finish("merged"),
+            }
+        )
+        engine = Engine(
+            runner,
+            no_snapshots,
+            concurrency=2,
+            default_park_timeout=60.0,
+            reconcile_interval=0.02,
+            max_wait=0,
+        )
+        done = await engine.run(make_items([("r1", "r1#1")]))
+        assert side_effects == ["rebase-requested"]
+        assert done[0].outcome == "auto-merge armed"
+
+    async def test_run_deadline_clamps_park_timeouts(self):
+        # A park asking for 60s is clamped to the 0.1s run deadline.
+        runner = ScriptedRunner(
+            {
+                "start": Park(
+                    reason="long wait",
+                    wake=lambda item: False,
+                    on_wake="merge",
+                    on_timeout="timed-out",
+                    timeout=60.0,
+                ),
+                "timed-out": lambda item: Finish("deadline"),
+            }
+        )
+        engine = Engine(
+            runner,
+            no_snapshots,
+            concurrency=2,
+            default_park_timeout=60.0,
+            reconcile_interval=0.02,
+            max_wait=0.1,
+        )
+        loop = asyncio.get_running_loop()
+        t0 = loop.time()
+        done = await engine.run(make_items([("r1", "r1#1")]))
+        assert done[0].outcome == "deadline"
+        assert loop.time() - t0 < 5.0
+
+    async def test_park_after_run_deadline_resolves_immediately(self):
+        # Second park starts after the run deadline already passed: it
+        # must not wait at all.
+        runner = ScriptedRunner(
+            {
+                "start": Park(
+                    reason="first",
+                    wake=lambda item: False,
+                    on_wake="merge",
+                    on_timeout="park-again",
+                    timeout=60.0,
+                ),
+                "park-again": Park(
+                    reason="second",
+                    wake=lambda item: False,
+                    on_wake="merge",
+                    on_timeout="timed-out",
+                    timeout=60.0,
+                ),
+                "timed-out": lambda item: Finish("done"),
+            }
+        )
+        engine = Engine(
+            runner,
+            no_snapshots,
+            concurrency=2,
+            default_park_timeout=60.0,
+            reconcile_interval=0.02,
+            max_wait=0.05,
+        )
+        done = await engine.run(make_items([("r1", "r1#1")]))
+        assert done[0].outcome == "done"
+
+    async def test_phase_budget_converts_cycles_to_failures(self):
+        runner = ScriptedRunner({"start": Advance("start")})
+        engine = Engine(runner, no_snapshots, **FAST)
+        done = await engine.run(make_items([("r1", "r1#1")]))
+        assert "phase budget exhausted" in str(done[0].outcome)
+        assert len(runner.calls) == MAX_PHASE_EXECUTIONS
+
+
+class TestObservers:
+    async def test_on_item_done_fires_per_item(self):
+        completed: list[str] = []
+        runner = ScriptedRunner({"start": Finish("ok")})
+        engine = Engine(
+            runner,
+            no_snapshots,
+            on_item_done=lambda item: completed.append(item.key),
+            **FAST,
+        )
+        await engine.run(make_items([("r1", "r1#1"), ("r2", "r2#1")]))
+        assert sorted(completed) == ["r1#1", "r2#1"]
+
+    async def test_observer_exception_does_not_kill_lane(self):
+        def observer(item: WorkItem) -> None:
+            raise RuntimeError("observer bug")
+
+        runner = ScriptedRunner({"start": Finish("ok")})
+        engine = Engine(runner, no_snapshots, on_item_done=observer, **FAST)
+        done = await engine.run(make_items([("r1", "r1#1"), ("r1", "r1#2")]))
+        assert [i.outcome for i in done] == ["ok", "ok"]

--- a/tests/test_auto_merge.py
+++ b/tests/test_auto_merge.py
@@ -574,11 +574,11 @@ class TestRecheckIntervalClamping:
 
 
 class TestAutoMergePendingCompletesProgress:
-    """AUTO_MERGE_PENDING status must bump PR-level progress to completed."""
+    """AUTO_MERGE_PENDING status must be recorded as a pending outcome."""
 
     @pytest.mark.asyncio
-    async def test_auto_merge_pending_calls_pr_completed(self) -> None:
-        """pr_completed() is called so PR progress reaches 100%."""
+    async def test_auto_merge_pending_calls_merge_pending(self) -> None:
+        """merge_pending() is called so the PR lands in the 🤖 Pending counter."""
         tracker = MagicMock()
         mgr, client = make_merge_manager(
             preview_mode=False,
@@ -645,7 +645,11 @@ class TestAutoMergePendingCompletesProgress:
             result = await mgr._merge_single_pr_with_semaphore(pr)
 
         assert result.status == MergeStatus.AUTO_MERGE_PENDING
-        tracker.pr_completed.assert_called_once()
+        # Terminal accounting routes AUTO_MERGE_PENDING to the
+        # dedicated pending counter (which also advances PR-level
+        # completion), not the generic pr_completed() fallback.
+        tracker.merge_pending.assert_called_once_with("owner/repo#42")
+        tracker.pr_completed.assert_not_called()
         tracker.merge_success.assert_not_called()
         tracker.merge_failure.assert_not_called()
 

--- a/tests/test_blocked_masks_behind.py
+++ b/tests/test_blocked_masks_behind.py
@@ -1,0 +1,380 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 The Linux Foundation
+
+"""Tests for the blocked-masks-behind handling in Step 5.
+
+GitHub's ``mergeable_state`` is a single value, so ``blocked`` (a
+failing required check) masks ``behind`` (a stale head).  When a
+required check failed against a head that predates fixes on the base
+branch, only a rebase re-runs the check against current base.  These
+tests cover:
+
+- ``_block_reason_indicates_check_blockage`` classification
+- ``_blocked_pr_needs_rebase`` staleness probe (reason gate, compare
+  gate, error handling, probe ordering)
+- Step 5 routing: a blocked-but-stale PR takes the rebase path in
+  ``_merge_single_pr``
+- ``GitHubAsync.get_behind_by`` compare-API parsing
+"""
+
+from contextlib import ExitStack
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from dependamerge.github2gerrit_detector import GitHub2GerritDetectionResult
+from dependamerge.merge_manager import AsyncMergeManager, MergeStatus
+from dependamerge.models import PullRequestInfo
+from dependamerge.rebase import Step5Outcome
+from tests.conftest import make_merge_manager
+
+_BLOCKED_PR = PullRequestInfo(
+    number=92,
+    node_id="PR_kwDOTestNode92",
+    title="Chore: Bump release-drafter from 7.4.0 to 7.5.1",
+    body="Dependabot PR",
+    author="dependabot[bot]",
+    head_sha="feedfacecafe",
+    base_branch="main",
+    head_branch="dependabot/github_actions/release-drafter-7.5.1",
+    state="open",
+    mergeable=True,
+    mergeable_state="blocked",
+    behind_by=None,
+    files_changed=[],
+    repository_full_name="owner/repo",
+    html_url="https://github.com/owner/repo/pull/92",
+    reviews=[],
+    review_comments=[],
+)
+
+
+# ---------------------------------------------------------------------------
+# _block_reason_indicates_check_blockage
+# ---------------------------------------------------------------------------
+
+
+class TestBlockReasonIndicatesCheckBlockage:
+    """Classification of check-related vs unrelated block reasons."""
+
+    @pytest.mark.parametrize(
+        "reason",
+        [
+            "Blocked by failing check: Zizmor Scan 🌈",
+            "Blocked by 3 failing checks",
+            "Blocked by missing required status: pre-commit.ci - pr",
+            "Blocked by 2 missing required statuses: a, b",
+            "Blocked by pending required check: DCO",
+            "Blocked by 2 pending required checks: a, b",
+        ],
+    )
+    def test_check_related_reasons_match(self, reason: str) -> None:
+        assert AsyncMergeManager._block_reason_indicates_check_blockage(reason)
+
+    @pytest.mark.parametrize(
+        "reason",
+        [
+            None,
+            "Blocked by branch protection (requires approval)",
+            "Human reviewer requested changes",
+            "Blocked by 2 unresolved Copilot reviews",
+            "Blocked by 4 unresolved Copilot comments",
+            "Blocked by repository ruleset (no specific failing condition detected)",
+        ],
+    )
+    def test_unrelated_reasons_do_not_match(self, reason: str | None) -> None:
+        assert not AsyncMergeManager._block_reason_indicates_check_blockage(reason)
+
+
+# ---------------------------------------------------------------------------
+# _blocked_pr_needs_rebase
+# ---------------------------------------------------------------------------
+
+
+class TestBlockedPrNeedsRebase:
+    """Staleness probe for blocked PRs."""
+
+    @pytest.mark.asyncio
+    async def test_failing_check_and_behind_triggers_rebase(self) -> None:
+        """Failing check + demonstrably behind → rebase path."""
+        mgr, client = make_merge_manager(fix_out_of_date=True)
+        client.analyze_block_reason = AsyncMock(
+            return_value="Blocked by failing check: Zizmor Scan 🌈"
+        )
+        client.get_behind_by = AsyncMock(return_value=2)
+        pr = _BLOCKED_PR.model_copy()
+
+        assert await mgr._blocked_pr_needs_rebase(pr, "owner", "repo")
+        # The probe records the evidence on the PR for later steps.
+        assert pr.behind_by == 2
+
+    @pytest.mark.asyncio
+    async def test_up_to_date_head_does_not_rebase(self) -> None:
+        """Failing check but head not behind → no rebase."""
+        mgr, client = make_merge_manager(fix_out_of_date=True)
+        client.analyze_block_reason = AsyncMock(
+            return_value="Blocked by failing check: Zizmor Scan 🌈"
+        )
+        client.get_behind_by = AsyncMock(return_value=0)
+
+        assert not await mgr._blocked_pr_needs_rebase(
+            _BLOCKED_PR.model_copy(), "owner", "repo"
+        )
+
+    @pytest.mark.asyncio
+    async def test_unknown_staleness_does_not_rebase(self) -> None:
+        """Compare failure (None) counts as not behind, not as behind."""
+        mgr, client = make_merge_manager(fix_out_of_date=True)
+        client.analyze_block_reason = AsyncMock(
+            return_value="Blocked by failing check: Zizmor Scan 🌈"
+        )
+        client.get_behind_by = AsyncMock(return_value=None)
+
+        assert not await mgr._blocked_pr_needs_rebase(
+            _BLOCKED_PR.model_copy(), "owner", "repo"
+        )
+
+    @pytest.mark.asyncio
+    async def test_non_check_blockage_skips_compare_probe(self) -> None:
+        """Approval blockage → False without spending the compare call."""
+        mgr, client = make_merge_manager(fix_out_of_date=True)
+        client.analyze_block_reason = AsyncMock(
+            return_value="Blocked by branch protection (requires approval)"
+        )
+        client.get_behind_by = AsyncMock(return_value=5)
+
+        assert not await mgr._blocked_pr_needs_rebase(
+            _BLOCKED_PR.model_copy(), "owner", "repo"
+        )
+        client.get_behind_by.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_analyze_failure_does_not_rebase(self) -> None:
+        """analyze_block_reason raising → treat as not rebasable."""
+        mgr, client = make_merge_manager(fix_out_of_date=True)
+        client.analyze_block_reason = AsyncMock(side_effect=RuntimeError("boom"))
+        client.get_behind_by = AsyncMock(return_value=5)
+
+        assert not await mgr._blocked_pr_needs_rebase(
+            _BLOCKED_PR.model_copy(), "owner", "repo"
+        )
+        client.get_behind_by.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# Step 5 routing in _merge_single_pr
+# ---------------------------------------------------------------------------
+
+
+def _step5_patches(mgr: AsyncMergeManager) -> list:
+    """Common patches to drive _merge_single_pr up to Step 5."""
+    no_g2g = GitHub2GerritDetectionResult()
+    return [
+        patch.object(
+            mgr,
+            "_detect_github2gerrit",
+            new_callable=AsyncMock,
+            return_value=no_g2g,
+        ),
+        patch.object(
+            mgr,
+            "_get_merge_method_for_repo",
+            new_callable=AsyncMock,
+            return_value="merge",
+        ),
+        patch.object(
+            mgr,
+            "_trigger_stale_precommit_ci",
+            new_callable=AsyncMock,
+            return_value=False,
+        ),
+        patch.object(
+            mgr,
+            "_check_merge_requirements",
+            new_callable=AsyncMock,
+            return_value=(True, ""),
+        ),
+        patch.object(
+            mgr,
+            "_approve_pr",
+            new_callable=AsyncMock,
+            return_value=True,
+        ),
+    ]
+
+
+class TestStep5BlockedMasksBehind:
+    """Blocked-but-stale PRs take the Step 5 rebase path."""
+
+    @pytest.mark.asyncio
+    async def test_blocked_stale_pr_enters_rebase_path(self) -> None:
+        """blocked + failing check + behind → perform_step5_rebase runs."""
+        mgr, client = make_merge_manager(
+            preview_mode=False, fix_out_of_date=True, merge_timeout=0.1
+        )
+        client.get = AsyncMock(return_value={})
+        client.analyze_block_reason = AsyncMock(
+            return_value="Blocked by failing check: Zizmor Scan 🌈"
+        )
+        client.get_behind_by = AsyncMock(return_value=3)
+
+        pr = _BLOCKED_PR.model_copy()
+        # Returning failed=True makes _merge_single_pr bail right
+        # after the rebase call, keeping the test scoped to routing.
+        outcome = Step5Outcome(failed=True, error_message="rebase failed")
+        with ExitStack() as stack:
+            for p in _step5_patches(mgr):
+                stack.enter_context(p)
+            mock_rebase = stack.enter_context(
+                patch(
+                    "dependamerge.merge_manager.rebase.perform_step5_rebase",
+                    new_callable=AsyncMock,
+                    return_value=outcome,
+                )
+            )
+            result = await mgr._merge_single_pr(pr)
+
+        mock_rebase.assert_awaited_once()
+        assert result.status == MergeStatus.FAILED
+        assert result.error == "rebase failed"
+
+    @pytest.mark.asyncio
+    async def test_blocked_pr_without_fix_skips_probe(self) -> None:
+        """--no-fix disables the staleness probe entirely."""
+        mgr, client = make_merge_manager(
+            preview_mode=False, fix_out_of_date=False, merge_timeout=0.1
+        )
+        client.get = AsyncMock(return_value={})
+        client.analyze_block_reason = AsyncMock(
+            return_value="Blocked by failing check: Zizmor Scan 🌈"
+        )
+        client.get_behind_by = AsyncMock(return_value=3)
+
+        pr = _BLOCKED_PR.model_copy()
+        with ExitStack() as stack:
+            for p in _step5_patches(mgr):
+                stack.enter_context(p)
+            mock_rebase = stack.enter_context(
+                patch(
+                    "dependamerge.merge_manager.rebase.perform_step5_rebase",
+                    new_callable=AsyncMock,
+                    return_value=Step5Outcome(),
+                )
+            )
+            stack.enter_context(
+                patch.object(
+                    mgr,
+                    "_merge_pr_with_retry",
+                    new_callable=AsyncMock,
+                    return_value=True,
+                )
+            )
+            await mgr._merge_single_pr(pr)
+
+        mock_rebase.assert_not_awaited()
+        client.get_behind_by.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_blocked_pr_not_behind_skips_rebase(self) -> None:
+        """blocked + failing check but up-to-date → no rebase path."""
+        mgr, client = make_merge_manager(
+            preview_mode=False, fix_out_of_date=True, merge_timeout=0.1
+        )
+        client.get = AsyncMock(return_value={})
+        client.analyze_block_reason = AsyncMock(
+            return_value="Blocked by failing check: Zizmor Scan 🌈"
+        )
+        client.get_behind_by = AsyncMock(return_value=0)
+
+        pr = _BLOCKED_PR.model_copy()
+        with ExitStack() as stack:
+            for p in _step5_patches(mgr):
+                stack.enter_context(p)
+            mock_rebase = stack.enter_context(
+                patch(
+                    "dependamerge.merge_manager.rebase.perform_step5_rebase",
+                    new_callable=AsyncMock,
+                    return_value=Step5Outcome(),
+                )
+            )
+            stack.enter_context(
+                patch.object(
+                    mgr,
+                    "_merge_pr_with_retry",
+                    new_callable=AsyncMock,
+                    return_value=True,
+                )
+            )
+            await mgr._merge_single_pr(pr)
+
+        mock_rebase.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# GitHubAsync.get_behind_by
+# ---------------------------------------------------------------------------
+
+
+class TestGetBehindBy:
+    """Compare-API parsing in GitHubAsync.get_behind_by."""
+
+    def _client(self):  # type: ignore[no-untyped-def]
+        from dependamerge.github_async import GitHubAsync
+
+        return GitHubAsync(token="test-token")
+
+    @pytest.mark.asyncio
+    async def test_returns_behind_by_from_compare(self) -> None:
+        client = self._client()
+        with patch.object(
+            client,
+            "get",
+            new_callable=AsyncMock,
+            return_value={"behind_by": 4, "ahead_by": 1},
+        ) as mock_get:
+            behind = await client.get_behind_by("owner", "repo", "main", "feedface")
+        assert behind == 4
+        mock_get.assert_awaited_once_with("/repos/owner/repo/compare/main...feedface")
+
+    @pytest.mark.asyncio
+    async def test_encodes_base_ref_with_slash(self) -> None:
+        client = self._client()
+        with patch.object(
+            client,
+            "get",
+            new_callable=AsyncMock,
+            return_value={"behind_by": 2, "ahead_by": 0},
+        ) as mock_get:
+            behind = await client.get_behind_by(
+                "owner", "repo", "release/1.2", "feedface"
+            )
+        assert behind == 2
+        mock_get.assert_awaited_once_with(
+            "/repos/owner/repo/compare/release%2F1.2...feedface"
+        )
+
+    @pytest.mark.asyncio
+    async def test_returns_none_on_api_error(self) -> None:
+        client = self._client()
+        with patch.object(
+            client,
+            "get",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("boom"),
+        ):
+            assert (
+                await client.get_behind_by("owner", "repo", "main", "feedface") is None
+            )
+
+    @pytest.mark.asyncio
+    async def test_returns_none_on_unexpected_payload(self) -> None:
+        client = self._client()
+        with patch.object(
+            client,
+            "get",
+            new_callable=AsyncMock,
+            return_value={"behind_by": "not-an-int"},
+        ):
+            assert (
+                await client.get_behind_by("owner", "repo", "main", "feedface") is None
+            )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -348,14 +348,15 @@ class TestCLI:
             assert "No similar PRs found" in result.stdout
             # Check for merge message (may include Rich color codes)
             assert "22" in result.stdout
-            # Check for merge success message (may include Rich color codes)
-            assert "✅ Merged:" in result.stdout
-            assert "1" in result.stdout and "PRs" in result.stdout
+            # Per-PR ✅ Merged lines are no longer printed during real
+            # merges (the live tracker conveys progress); assert the
+            # final summary reports the merge instead.
+            assert "Final Results:" in result.stdout
+            assert "1 merged" in result.stdout
 
             # Test passes if we reach this point - the merge was successful
         # The mocking prevented actual HTTP calls and the CLI completed successfully
-        # Check that the PR URL appears in the success message
-        assert "https://github.com/owner/repo/pull/22" in result.stdout
+        assert "0 failed" in result.stdout
 
     @patch("dependamerge.cli.GitHubClient")
     def test_merge_command_non_automation_pr_no_override(self, mock_client_class):

--- a/tests/test_dependabot_recreate.py
+++ b/tests/test_dependabot_recreate.py
@@ -190,9 +190,11 @@ class TestCheckPrCommitSignatures:
 class TestRequiresCommitSignatures:
     """Tests for the requires_commit_signatures method.
 
-    The decision logic lives in ``_requires_commit_signatures_uncached``;
-    the public method adds a per-``owner/repo@branch`` session cache
-    (covered by ``test_result_is_cached_per_branch`` below).
+    The decision logic lives in ``_requires_commit_signatures_uncached``
+    (which returns a ``(verdict, reliable)`` tuple); the public method
+    adds a per-``owner/repo@branch`` session cache that only stores
+    reliable verdicts (covered by ``test_result_is_cached_per_branch``
+    and ``test_unreliable_verdict_not_cached`` below).
     """
 
     @pytest.mark.asyncio
@@ -201,10 +203,11 @@ class TestRequiresCommitSignatures:
         api.get = AsyncMock(return_value={"enabled": True})
         api.log = AsyncMock()
         api.log.debug = lambda *a, **kw: None
-        result = await GitHubAsync._requires_commit_signatures_uncached(
+        result, reliable = await GitHubAsync._requires_commit_signatures_uncached(
             api, "owner", "repo", "main"
         )
         assert result is True
+        assert reliable is True
 
     @pytest.mark.asyncio
     async def test_classic_protection_disabled(self):
@@ -219,10 +222,11 @@ class TestRequiresCommitSignatures:
         )
         api.log = AsyncMock()
         api.log.debug = lambda *a, **kw: None
-        result = await GitHubAsync._requires_commit_signatures_uncached(
+        result, reliable = await GitHubAsync._requires_commit_signatures_uncached(
             api, "owner", "repo", "main"
         )
         assert result is False
+        assert reliable is True
 
     @pytest.mark.asyncio
     async def test_classic_protection_404_falls_through_to_rulesets(self):
@@ -248,10 +252,11 @@ class TestRequiresCommitSignatures:
         api.log = AsyncMock()
         api.log.debug = lambda *a, **kw: None
         api._ruleset_applies_to_branch = GitHubAsync._ruleset_applies_to_branch
-        result = await GitHubAsync._requires_commit_signatures_uncached(
+        result, reliable = await GitHubAsync._requires_commit_signatures_uncached(
             api, "owner", "repo", "main"
         )
         assert result is True
+        assert reliable is True
 
     @pytest.mark.asyncio
     async def test_ruleset_inactive_is_ignored(self):
@@ -277,10 +282,11 @@ class TestRequiresCommitSignatures:
         api.log = AsyncMock()
         api.log.debug = lambda *a, **kw: None
         api._ruleset_applies_to_branch = GitHubAsync._ruleset_applies_to_branch
-        result = await GitHubAsync._requires_commit_signatures_uncached(
+        result, reliable = await GitHubAsync._requires_commit_signatures_uncached(
             api, "owner", "repo", "main"
         )
         assert result is False
+        assert reliable is True
 
     @pytest.mark.asyncio
     async def test_both_apis_error_returns_false(self):
@@ -288,10 +294,13 @@ class TestRequiresCommitSignatures:
         api.get = AsyncMock(side_effect=Exception("Server error"))
         api.log = AsyncMock()
         api.log.debug = lambda *a, **kw: None
-        result = await GitHubAsync._requires_commit_signatures_uncached(
+        result, reliable = await GitHubAsync._requires_commit_signatures_uncached(
             api, "owner", "repo", "main"
         )
         assert result is False
+        # Error-derived False verdicts are flagged unreliable so the
+        # public method will not cache them.
+        assert reliable is False
 
     @pytest.mark.asyncio
     async def test_branch_with_slash_is_url_encoded(self):
@@ -300,10 +309,11 @@ class TestRequiresCommitSignatures:
         api.get = AsyncMock(return_value={"enabled": True})
         api.log = AsyncMock()
         api.log.debug = lambda *a, **kw: None
-        result = await GitHubAsync._requires_commit_signatures_uncached(
+        result, reliable = await GitHubAsync._requires_commit_signatures_uncached(
             api, "owner", "repo", "release/v1"
         )
         assert result is True
+        assert reliable is True
         # The REST call must URL-encode the slash in the branch name
         called_path = api.get.call_args_list[0][0][0]
         assert "release%2Fv1" in called_path
@@ -326,6 +336,34 @@ class TestRequiresCommitSignatures:
             # A different branch is a different cache entry.
             await api.requires_commit_signatures("owner", "repo", "dev")
             assert api.get.await_count > calls_after_first
+
+    @pytest.mark.asyncio
+    async def test_unreliable_verdict_not_cached(self):
+        """A False verdict derived from transient errors is retried."""
+        async with GitHubAsync(token="t") as api:
+            # First lookup: every request fails (transient outage) →
+            # False, but unreliable and therefore uncached.  Second
+            # lookup: classic protection answers definitively → True,
+            # cached.
+            api.get = AsyncMock(  # type: ignore[method-assign]
+                side_effect=[
+                    Exception("500 Server Error"),  # classic protection
+                    Exception("500 Server Error"),  # repo metadata
+                    Exception("500 Server Error"),  # rulesets list
+                    {"enabled": True},  # retry: classic protection
+                ]
+            )
+
+            first = await api.requires_commit_signatures("owner", "repo", "main")
+            second = await api.requires_commit_signatures("owner", "repo", "main")
+            calls_after_second = api.get.await_count
+            third = await api.requires_commit_signatures("owner", "repo", "main")
+
+            assert first is False
+            assert second is True
+            assert third is True
+            # The reliable True verdict was cached; no more traffic.
+            assert api.get.await_count == calls_after_second
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_dependabot_recreate.py
+++ b/tests/test_dependabot_recreate.py
@@ -188,7 +188,12 @@ class TestCheckPrCommitSignatures:
 # GitHubAsync.requires_commit_signatures
 # ---------------------------------------------------------------------------
 class TestRequiresCommitSignatures:
-    """Tests for the requires_commit_signatures method."""
+    """Tests for the requires_commit_signatures method.
+
+    The decision logic lives in ``_requires_commit_signatures_uncached``;
+    the public method adds a per-``owner/repo@branch`` session cache
+    (covered by ``test_result_is_cached_per_branch`` below).
+    """
 
     @pytest.mark.asyncio
     async def test_classic_protection_enabled(self):
@@ -196,7 +201,7 @@ class TestRequiresCommitSignatures:
         api.get = AsyncMock(return_value={"enabled": True})
         api.log = AsyncMock()
         api.log.debug = lambda *a, **kw: None
-        result = await GitHubAsync.requires_commit_signatures(
+        result = await GitHubAsync._requires_commit_signatures_uncached(
             api, "owner", "repo", "main"
         )
         assert result is True
@@ -214,7 +219,7 @@ class TestRequiresCommitSignatures:
         )
         api.log = AsyncMock()
         api.log.debug = lambda *a, **kw: None
-        result = await GitHubAsync.requires_commit_signatures(
+        result = await GitHubAsync._requires_commit_signatures_uncached(
             api, "owner", "repo", "main"
         )
         assert result is False
@@ -243,7 +248,7 @@ class TestRequiresCommitSignatures:
         api.log = AsyncMock()
         api.log.debug = lambda *a, **kw: None
         api._ruleset_applies_to_branch = GitHubAsync._ruleset_applies_to_branch
-        result = await GitHubAsync.requires_commit_signatures(
+        result = await GitHubAsync._requires_commit_signatures_uncached(
             api, "owner", "repo", "main"
         )
         assert result is True
@@ -272,7 +277,7 @@ class TestRequiresCommitSignatures:
         api.log = AsyncMock()
         api.log.debug = lambda *a, **kw: None
         api._ruleset_applies_to_branch = GitHubAsync._ruleset_applies_to_branch
-        result = await GitHubAsync.requires_commit_signatures(
+        result = await GitHubAsync._requires_commit_signatures_uncached(
             api, "owner", "repo", "main"
         )
         assert result is False
@@ -283,7 +288,7 @@ class TestRequiresCommitSignatures:
         api.get = AsyncMock(side_effect=Exception("Server error"))
         api.log = AsyncMock()
         api.log.debug = lambda *a, **kw: None
-        result = await GitHubAsync.requires_commit_signatures(
+        result = await GitHubAsync._requires_commit_signatures_uncached(
             api, "owner", "repo", "main"
         )
         assert result is False
@@ -295,7 +300,7 @@ class TestRequiresCommitSignatures:
         api.get = AsyncMock(return_value={"enabled": True})
         api.log = AsyncMock()
         api.log.debug = lambda *a, **kw: None
-        result = await GitHubAsync.requires_commit_signatures(
+        result = await GitHubAsync._requires_commit_signatures_uncached(
             api, "owner", "repo", "release/v1"
         )
         assert result is True
@@ -303,6 +308,24 @@ class TestRequiresCommitSignatures:
         called_path = api.get.call_args_list[0][0][0]
         assert "release%2Fv1" in called_path
         assert "release/v1" not in called_path
+
+    @pytest.mark.asyncio
+    async def test_result_is_cached_per_branch(self):
+        """The public method caches the verdict per owner/repo@branch."""
+        async with GitHubAsync(token="t") as api:
+            api.get = AsyncMock(return_value={"enabled": True})  # type: ignore[method-assign]
+            first = await api.requires_commit_signatures("owner", "repo", "main")
+            calls_after_first = api.get.await_count
+            second = await api.requires_commit_signatures("owner", "repo", "main")
+
+            assert first is True
+            assert second is True
+            # No additional API traffic for the repeat lookup.
+            assert api.get.await_count == calls_after_first
+
+            # A different branch is a different cache entry.
+            await api.requires_commit_signatures("owner", "repo", "dev")
+            assert api.get.await_count > calls_after_first
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_merge_conflict_handling.py
+++ b/tests/test_merge_conflict_handling.py
@@ -135,7 +135,7 @@ class TestHandleMergeConflict:
             patch.object(
                 mgr, "_wait_for_auto_merge", new_callable=AsyncMock
             ) as mock_wait,
-            patch("dependamerge.merge_manager.log_and_print") as mock_log,
+            patch.object(mgr, "log") as mock_log,
             patch.object(mgr, "_console") as mock_console,
         ):
             result = await mgr._handle_merge_conflict(
@@ -146,14 +146,19 @@ class TestHandleMergeConflict:
         assert result.error == "merge conflicts"
         mock_rebase.assert_not_called()
         mock_wait.assert_not_called()
-        # The specific 🔀 cause line is emitted.
+        # The specific 🔀 cause line is logged (not printed — real
+        # merges keep the console clean; the reason reaches the user
+        # via ``result.error`` in the end-of-run summary).
         assert any(
-            "🔀 Merge conflict" in str(call.args[2]) for call in mock_log.call_args_list
+            "🔀 Merge conflict" in str(call.args[0])
+            for call in mock_log.info.call_args_list
+            if call.args
         )
-        # ...and it is NOT duplicated with a redundant ❌ Failed line.
+        # ...and nothing is printed to the console for this PR.
         printed = " ".join(
             str(c.args[0]) for c in mock_console.print.call_args_list if c.args
         )
+        assert "🔀 Merge conflict" not in printed
         assert "❌ Failed" not in printed
 
     @pytest.mark.asyncio

--- a/tests/test_merge_state_tracking.py
+++ b/tests/test_merge_state_tracking.py
@@ -1,0 +1,240 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 The Linux Foundation
+
+"""Tests for merge progress tracker state transitions and counters.
+
+The live merge display moved from per-PR console lines to counter-based
+reporting: PRs travel through transitory states (rebasing → rebased →
+waiting) rendered live on the stats line, then land in exactly one
+terminal counter (merged / pending / closed / failed / skipped /
+blocked).  ``AsyncMergeManager._record_terminal_outcome`` is the single
+accounting point mapping ``MergeStatus`` onto those counters.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from dependamerge.merge_manager import MergeStatus
+from dependamerge.models import PullRequestInfo
+from dependamerge.progress_tracker import (
+    DummyProgressTracker,
+    MergeProgressTracker,
+)
+from tests.conftest import make_merge_manager
+
+
+def _make_pr(**overrides: Any) -> PullRequestInfo:
+    defaults: dict[str, Any] = {
+        "number": 7,
+        "title": "CI: Bump foo from 1 to 2",
+        "body": "Dependabot PR",
+        "author": "dependabot[bot]",
+        "head_sha": "abc123",
+        "base_branch": "main",
+        "head_branch": "dependabot/foo",
+        "state": "open",
+        "mergeable": True,
+        "mergeable_state": "clean",
+        "behind_by": 0,
+        "files_changed": [],
+        "repository_full_name": "org/repo",
+        "html_url": "https://github.com/org/repo/pull/7",
+    }
+    defaults.update(overrides)
+    return PullRequestInfo(**defaults)
+
+
+class TestTransitoryStates:
+    """PRs move between transitory display states, one state at a time."""
+
+    def test_track_pr_state_moves_between_states(self) -> None:
+        tracker = MergeProgressTracker("org")
+        tracker.track_pr_state("org/repo#1", "rebasing")
+        assert tracker._pr_states == {"org/repo#1": "rebasing"}
+
+        # Transition: the PR occupies exactly one state at a time.
+        tracker.track_pr_state("org/repo#1", "rebased")
+        assert tracker._pr_states == {"org/repo#1": "rebased"}
+
+        tracker.track_pr_state("org/repo#1", "waiting")
+        assert tracker._pr_states == {"org/repo#1": "waiting"}
+
+    def test_track_pr_state_none_clears(self) -> None:
+        tracker = MergeProgressTracker("org")
+        tracker.track_pr_state("org/repo#1", "waiting")
+        tracker.track_pr_state("org/repo#1", None)
+        assert tracker._pr_states == {}
+
+    def test_clear_unknown_key_is_noop(self) -> None:
+        tracker = MergeProgressTracker("org")
+        tracker.track_pr_state("org/repo#1", None)
+        assert tracker._pr_states == {}
+
+    def test_terminal_outcome_clears_transitory_state(self) -> None:
+        tracker = MergeProgressTracker("org")
+        tracker.set_total_prs(2)
+        tracker.track_pr_state("org/repo#1", "rebasing")
+        tracker.track_pr_state("org/repo#2", "waiting")
+
+        tracker.merge_success("org/repo#1")
+        tracker.merge_failure("org/repo#2")
+
+        assert tracker._pr_states == {}
+        assert tracker.prs_merged == 1
+        assert tracker.prs_failed == 1
+        assert tracker.completed_prs == 2
+
+    def test_terminal_outcome_without_key_keeps_states(self) -> None:
+        """Legacy no-arg calls still count but cannot clear a state."""
+        tracker = MergeProgressTracker("org")
+        tracker.track_pr_state("org/repo#1", "rebasing")
+        tracker.merge_success()
+        assert tracker.prs_merged == 1
+        assert tracker._pr_states == {"org/repo#1": "rebasing"}
+
+
+class TestTerminalCounters:
+    """New pending/blocked counters and completion accounting."""
+
+    def test_merge_pending_counts_and_completes(self) -> None:
+        tracker = MergeProgressTracker("org")
+        tracker.set_total_prs(1)
+        tracker.merge_pending("org/repo#1")
+        assert tracker.prs_pending == 1
+        assert tracker.completed_prs == 1
+
+    def test_merge_blocked_counts_and_completes(self) -> None:
+        tracker = MergeProgressTracker("org")
+        tracker.set_total_prs(1)
+        tracker.merge_blocked("org/repo#1")
+        assert tracker.prs_blocked == 1
+        assert tracker.completed_prs == 1
+
+    def test_summary_includes_new_counters(self) -> None:
+        tracker = MergeProgressTracker("org")
+        tracker.merge_pending()
+        tracker.merge_blocked()
+        summary = tracker.get_summary()
+        assert summary["prs_pending"] == 1
+        assert summary["prs_blocked"] == 1
+
+    def test_dummy_tracker_mirrors_surface(self) -> None:
+        """DummyProgressTracker accepts the whole new surface."""
+        dummy = DummyProgressTracker()
+        dummy.track_pr_state("org/repo#1", "rebasing")
+        dummy.merge_success("org/repo#1")
+        dummy.merge_failure("org/repo#1")
+        dummy.merge_skipped("org/repo#1")
+        dummy.merge_blocked("org/repo#1")
+        dummy.merge_pending("org/repo#1")
+        dummy.increment_closed("org/repo#1")
+
+
+class TestDisplayRendering:
+    """Stats line renders transitory states then terminal counters."""
+
+    def test_states_render_in_pipeline_order(self) -> None:
+        tracker = MergeProgressTracker("org")
+        tracker.rich_available = True
+        tracker.set_total_prs(6)
+        tracker.track_pr_state("org/repo#1", "waiting")
+        tracker.track_pr_state("org/repo#2", "rebasing")
+        tracker.track_pr_state("org/repo#3", "rebased")
+        tracker.merge_success("org/repo#4")
+        tracker.merge_pending("org/repo#5")
+        tracker.merge_failure("org/repo#6")
+
+        plain = tracker._generate_display_text().plain
+        assert "🔄 Rebasing: 1" in plain
+        assert "⬆️ Rebased: 1" in plain
+        assert "⏳ Waiting: 1" in plain
+        assert "✅ Merged: 1" in plain
+        assert "🤖 Pending: 1" in plain
+        assert "❌ Failed: 1" in plain
+        # Pipeline order: transitory states precede terminal counters.
+        assert plain.index("Rebasing") < plain.index("Rebased")
+        assert plain.index("Rebased") < plain.index("Waiting")
+        assert plain.index("Waiting") < plain.index("Merged")
+
+    def test_zero_counters_do_not_render(self) -> None:
+        tracker = MergeProgressTracker("org")
+        tracker.rich_available = True
+        tracker.set_total_prs(1)
+        tracker.merge_success("org/repo#1")
+        plain = tracker._generate_display_text().plain
+        assert "Pending" not in plain
+        assert "Blocked" not in plain
+        assert "Rebasing" not in plain
+
+    def test_unknown_state_rendered_defensively(self) -> None:
+        tracker = MergeProgressTracker("org")
+        tracker.rich_available = True
+        tracker.track_pr_state("org/repo#1", "polishing")
+        plain = tracker._generate_display_text().plain
+        assert "Polishing: 1" in plain
+
+
+class TestRecordTerminalOutcome:
+    """_record_terminal_outcome maps MergeStatus onto tracker methods."""
+
+    @pytest.mark.parametrize(
+        ("status", "method"),
+        [
+            (MergeStatus.MERGED, "merge_success"),
+            (MergeStatus.FAILED, "merge_failure"),
+            (MergeStatus.SKIPPED, "merge_skipped"),
+            (MergeStatus.BLOCKED, "merge_blocked"),
+            (MergeStatus.AUTO_MERGE_PENDING, "merge_pending"),
+        ],
+    )
+    def test_status_maps_to_counter(self, status: MergeStatus, method: str) -> None:
+        tracker = MagicMock()
+        mgr, _client = make_merge_manager(progress_tracker=tracker)
+        pr = _make_pr()
+
+        mgr._record_terminal_outcome(pr, status)
+
+        getattr(tracker, method).assert_called_once_with("org/repo#7")
+        # Exactly one terminal method fires per outcome.
+        all_methods = {
+            "merge_success",
+            "merge_failure",
+            "merge_skipped",
+            "merge_blocked",
+            "merge_pending",
+            "pr_completed",
+        }
+        for other in all_methods - {method}:
+            getattr(tracker, other).assert_not_called()
+
+    def test_unexpected_status_falls_back_to_pr_completed(self) -> None:
+        tracker = MagicMock()
+        mgr, _client = make_merge_manager(progress_tracker=tracker)
+        pr = _make_pr()
+
+        mgr._record_terminal_outcome(pr, MergeStatus.PENDING)
+
+        tracker.pr_completed.assert_called_once()
+        tracker.merge_success.assert_not_called()
+        tracker.merge_failure.assert_not_called()
+
+    def test_no_tracker_is_noop(self) -> None:
+        mgr, _client = make_merge_manager(progress_tracker=None)
+        # Must not raise.
+        mgr._record_terminal_outcome(_make_pr(), MergeStatus.MERGED)
+
+    def test_track_pr_state_delegates_with_pr_key(self) -> None:
+        tracker = MagicMock()
+        mgr, _client = make_merge_manager(progress_tracker=tracker)
+        pr = _make_pr()
+
+        mgr._track_pr_state(pr, "rebasing")
+        tracker.track_pr_state.assert_called_once_with("org/repo#7", "rebasing")
+
+        tracker.track_pr_state.reset_mock()
+        mgr._track_pr_state(pr, None)
+        tracker.track_pr_state.assert_called_once_with("org/repo#7", None)

--- a/tests/test_org_and_user_caches.py
+++ b/tests/test_org_and_user_caches.py
@@ -347,3 +347,198 @@ class TestAuthenticatedUserLoginCache:
 
             assert call_count["user"] == 1
             assert gh._authenticated_user_login == "persistent-user"
+
+
+# ---------------------------------------------------------------------------
+# GitHubAsync.get_authenticated_user_login
+# ---------------------------------------------------------------------------
+
+
+class TestGetAuthenticatedUserLogin:
+    """The public login accessor caches per session and degrades on error."""
+
+    @pytest.mark.asyncio
+    async def test_fetches_once_then_caches(self):
+        async with GitHubAsync(token="fake-token") as gh:
+            gh.get = AsyncMock(return_value={"login": "cached-user"})  # type: ignore[method-assign]
+
+            first = await gh.get_authenticated_user_login()
+            second = await gh.get_authenticated_user_login()
+
+            assert first == "cached-user"
+            assert second == "cached-user"
+            gh.get.assert_awaited_once_with("/user")
+
+    @pytest.mark.asyncio
+    async def test_returns_none_on_error_without_caching(self):
+        async with GitHubAsync(token="fake-token") as gh:
+            gh.get = AsyncMock(  # type: ignore[method-assign]
+                side_effect=[Exception("boom"), {"login": "recovered"}]
+            )
+
+            assert await gh.get_authenticated_user_login() is None
+            # A later call retries and succeeds (failures are not cached).
+            assert await gh.get_authenticated_user_login() == "recovered"
+
+
+# ---------------------------------------------------------------------------
+# GitHubAsync repo/branch-scoped session caches
+# ---------------------------------------------------------------------------
+
+
+class TestRepoBranchSessionCaches:
+    """Session caches added for the merge-phase performance work.
+
+    Branch protection, required status checks, and the repo default
+    branch are repo/branch-level configuration that does not change
+    mid-run, yet the merge pipeline used to re-fetch them per PR (or
+    several times per blocked PR via ``analyze_block_reason``).
+    """
+
+    @pytest.mark.asyncio
+    async def test_branch_protection_cached_per_branch(self):
+        async with GitHubAsync(token="fake-token") as gh:
+            gh.get = AsyncMock(  # type: ignore[method-assign]
+                return_value={"required_pull_request_reviews": {}}
+            )
+
+            first = await gh.get_branch_protection("org", "repo", "main")
+            second = await gh.get_branch_protection("org", "repo", "main")
+
+            assert first == second == {"required_pull_request_reviews": {}}
+            gh.get.assert_awaited_once()
+
+            # A different branch is fetched separately.
+            await gh.get_branch_protection("org", "repo", "dev")
+            assert gh.get.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_branch_protection_404_negative_cached(self):
+        async with GitHubAsync(token="fake-token") as gh:
+            gh.get = AsyncMock(side_effect=Exception("404 Not Found"))  # type: ignore[method-assign]
+
+            assert await gh.get_branch_protection("org", "repo", "main") == {}
+            assert await gh.get_branch_protection("org", "repo", "main") == {}
+            # The 404 ("no protection") verdict is cached too.
+            gh.get.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_branch_protection_transient_error_not_cached(self):
+        async with GitHubAsync(token="fake-token") as gh:
+            gh.get = AsyncMock(  # type: ignore[method-assign]
+                side_effect=[Exception("500 Server Error"), {"ok": True}]
+            )
+
+            with pytest.raises(Exception, match="500"):
+                await gh.get_branch_protection("org", "repo", "main")
+            # The failure was not cached; the retry succeeds.
+            assert await gh.get_branch_protection("org", "repo", "main") == {"ok": True}
+
+    @pytest.mark.asyncio
+    async def test_required_status_checks_cached_per_branch(self):
+        async with GitHubAsync(token="fake-token") as gh:
+
+            async def mock_get(url: str):
+                if url == "/repos/org/repo":
+                    return {"default_branch": "main"}
+                if url.endswith("/rulesets?per_page=100"):
+                    return [{"id": 7}]
+                if url.endswith("/rulesets/7"):
+                    return {
+                        "id": 7,
+                        "conditions": {},
+                        "rules": [
+                            {
+                                "type": "required_status_checks",
+                                "parameters": {
+                                    "required_status_checks": [{"context": "ci/build"}]
+                                },
+                            }
+                        ],
+                    }
+                return {}
+
+            gh.get = AsyncMock(side_effect=mock_get)  # type: ignore[method-assign]
+
+            first = await gh.get_required_status_checks("org", "repo", "main")
+            calls_after_first = gh.get.await_count
+            second = await gh.get_required_status_checks("org", "repo", "main")
+
+            assert first == [{"context": "ci/build"}]
+            assert second == [{"context": "ci/build"}]
+            # The repeat is served entirely from cache.
+            assert gh.get.await_count == calls_after_first
+
+    @pytest.mark.asyncio
+    async def test_required_status_checks_cache_returns_copy(self):
+        """Callers must not be able to mutate the cached list."""
+        async with GitHubAsync(token="fake-token") as gh:
+            gh.get = AsyncMock(return_value=[])  # type: ignore[method-assign]
+
+            first = await gh.get_required_status_checks("org", "repo", "main")
+            first.append({"context": "injected"})
+            second = await gh.get_required_status_checks("org", "repo", "main")
+
+            assert second == []
+
+    @pytest.mark.asyncio
+    async def test_default_branch_cached(self):
+        async with GitHubAsync(token="fake-token") as gh:
+            gh.get = AsyncMock(return_value={"default_branch": "master"})  # type: ignore[method-assign]
+
+            assert await gh._resolve_default_branch("org", "repo") == "master"
+            assert await gh._resolve_default_branch("org", "repo") == "master"
+            gh.get.assert_awaited_once_with("/repos/org/repo")
+
+    @pytest.mark.asyncio
+    async def test_default_branch_failure_not_cached(self):
+        async with GitHubAsync(token="fake-token") as gh:
+            gh.get = AsyncMock(  # type: ignore[method-assign]
+                side_effect=[Exception("boom"), {"default_branch": "main"}]
+            )
+
+            assert await gh._resolve_default_branch("org", "repo") is None
+            assert await gh._resolve_default_branch("org", "repo") == "main"
+
+
+# ---------------------------------------------------------------------------
+# analyze_block_reason base_branch fast path
+# ---------------------------------------------------------------------------
+
+
+class TestAnalyzeBlockReasonBaseBranchFastPath:
+    """A caller-supplied base_branch skips the PR-detail fetch."""
+
+    @pytest.mark.asyncio
+    async def test_supplied_base_branch_skips_pr_fetch(self):
+        async with GitHubAsync(token="fake-token") as gh:
+            fetched_urls: list[str] = []
+
+            async def mock_get(url: str):
+                fetched_urls.append(url)
+                if url.endswith("/check-runs"):
+                    return {"check_runs": []}
+                if url.endswith("/status"):
+                    return {"statuses": []}
+                if url.endswith("/reviews"):
+                    return [{"state": "APPROVED", "user": {"login": "u"}}]
+                if url.endswith("/comments"):
+                    return []
+                return {}
+
+            gh.get = AsyncMock(side_effect=mock_get)  # type: ignore[method-assign]
+            gh.get_required_status_checks = AsyncMock(return_value=[])  # type: ignore[method-assign]
+            gh._detect_branch_protection_kind = AsyncMock(  # type: ignore[method-assign]
+                return_value="ruleset"
+            )
+
+            await gh.analyze_block_reason(
+                "org", "repo", 5, "abc123", base_branch="main"
+            )
+
+            # The PR-detail endpoint was never fetched — the supplied
+            # base branch made that round-trip unnecessary.
+            assert "/repos/org/repo/pulls/5" not in fetched_urls
+            gh.get_required_status_checks.assert_awaited_once_with(
+                "org", "repo", "main"
+            )

--- a/tests/test_org_and_user_caches.py
+++ b/tests/test_org_and_user_caches.py
@@ -482,6 +482,75 @@ class TestRepoBranchSessionCaches:
             assert second == []
 
     @pytest.mark.asyncio
+    async def test_required_status_checks_error_result_not_cached(self):
+        """An error-degraded (empty) result must not be pinned.
+
+        The fetch treats API errors as "no required checks"; caching
+        that verdict would let a transient outage misclassify blocked
+        PRs for the rest of the session.  The next call retries.
+        """
+        async with GitHubAsync(token="fake-token") as gh:
+            healthy = False
+
+            async def mock_get(url: str):
+                if not healthy:
+                    raise Exception("500 Server Error")
+                if url == "/repos/org/repo":
+                    return {"default_branch": "main"}
+                if url.endswith("/rulesets?per_page=100"):
+                    return [{"id": 7}]
+                if url.endswith("/rulesets/7"):
+                    return {
+                        "id": 7,
+                        "conditions": {},
+                        "rules": [
+                            {
+                                "type": "required_status_checks",
+                                "parameters": {
+                                    "required_status_checks": [{"context": "ci/build"}]
+                                },
+                            }
+                        ],
+                    }
+                return {}
+
+            gh.get = AsyncMock(side_effect=mock_get)  # type: ignore[method-assign]
+
+            # Outage: degraded empty verdict, not cached.
+            assert await gh.get_required_status_checks("org", "repo", "main") == []
+
+            # API recovers: the retry sees the real required checks.
+            healthy = True
+            result = await gh.get_required_status_checks("org", "repo", "main")
+            assert result == [{"context": "ci/build"}]
+
+            # And the reliable result IS cached.
+            calls_before = gh.get.await_count
+            again = await gh.get_required_status_checks("org", "repo", "main")
+            assert again == [{"context": "ci/build"}]
+            assert gh.get.await_count == calls_before
+
+    @pytest.mark.asyncio
+    async def test_required_status_checks_404_protection_cached(self):
+        """A 404 on the fallback endpoint is definitive and cached."""
+        async with GitHubAsync(token="fake-token") as gh:
+
+            async def mock_get(url: str):
+                if url == "/repos/org/repo":
+                    return {"default_branch": "main"}
+                if url.endswith("/rulesets?per_page=100"):
+                    return []
+                raise Exception("404 Not Found")
+
+            gh.get = AsyncMock(side_effect=mock_get)  # type: ignore[method-assign]
+
+            assert await gh.get_required_status_checks("org", "repo", "main") == []
+            calls_after_first = gh.get.await_count
+            assert await gh.get_required_status_checks("org", "repo", "main") == []
+            # "No protection" (404) is a real verdict — served from cache.
+            assert gh.get.await_count == calls_after_first
+
+    @pytest.mark.asyncio
     async def test_default_branch_cached(self):
         async with GitHubAsync(token="fake-token") as gh:
             gh.get = AsyncMock(return_value={"default_branch": "master"})  # type: ignore[method-assign]

--- a/tests/test_progress_ticker.py
+++ b/tests/test_progress_ticker.py
@@ -1,0 +1,102 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 The Linux Foundation
+
+"""Tests for the live progress display's self-updating clock.
+
+Regression tests for the frozen elapsed counter: the tracker used to
+hand Rich ``Live`` a static text snapshot, so the clock only advanced
+when a progress event fired.  During long silent API sequences the
+display froze for 10+ seconds and the tool appeared to hang.  The
+tracker now passes ``get_renderable`` so every auto-refresh tick
+re-renders with a current elapsed time.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from typing import Any
+
+from dependamerge import progress_tracker as pt
+from dependamerge.progress_tracker import MergeProgressTracker, ProgressTracker
+
+
+class _RecordingLive:
+    """Stand-in for rich.live.Live that records construction and calls."""
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        self.args = args
+        self.kwargs = kwargs
+        self.refresh_calls = 0
+        self.update_calls = 0
+        self.started = False
+
+    def start(self) -> None:
+        self.started = True
+
+    def stop(self) -> None:
+        self.started = False
+
+    def refresh(self) -> None:
+        self.refresh_calls += 1
+
+    def update(self, *args: Any) -> None:
+        self.update_calls += 1
+
+
+class TestLiveRenderableIsCallable:
+    def test_start_passes_get_renderable(self, monkeypatch) -> None:
+        monkeypatch.setattr(pt, "Live", _RecordingLive)
+        tracker = MergeProgressTracker("owner")
+        tracker.rich_available = True
+        tracker.start()
+        live = tracker.live
+        assert isinstance(live, _RecordingLive)
+        assert live.started
+        # Rich re-invokes the callable on every auto-refresh tick, so
+        # the elapsed clock advances without progress events.
+        assert live.kwargs["get_renderable"] == tracker._generate_display_text
+        tracker.stop()
+
+    def test_resume_passes_get_renderable(self, monkeypatch) -> None:
+        monkeypatch.setattr(pt, "Live", _RecordingLive)
+        tracker = MergeProgressTracker("owner")
+        tracker.rich_available = True
+        tracker.start()
+        tracker.suspend()
+        tracker.resume()
+        live = tracker.live
+        assert isinstance(live, _RecordingLive)
+        assert live.kwargs["get_renderable"] == tracker._generate_display_text
+        tracker.stop()
+
+    def test_progress_events_repaint_via_refresh(self, monkeypatch) -> None:
+        # Event-driven repaints go through refresh() (re-render via the
+        # callable), never update(<static text>), which would reinstate
+        # a frozen snapshot.
+        monkeypatch.setattr(pt, "Live", _RecordingLive)
+        tracker = MergeProgressTracker("owner")
+        tracker.rich_available = True
+        tracker.start()
+        live = tracker.live
+        tracker.set_total_prs(3)
+        tracker.merge_success()
+        tracker.merge_failure()
+        assert live.refresh_calls >= 3
+        assert live.update_calls == 0
+        tracker.stop()
+
+
+class TestElapsedRecomputesPerRender:
+    def test_merge_tracker_elapsed_reflects_current_time(self) -> None:
+        tracker = MergeProgressTracker("owner")
+        tracker.rich_available = True
+        tracker.start_time = datetime.now() - timedelta(seconds=90)
+        text = tracker._generate_display_text()
+        assert "Elapsed: 1m" in text.plain
+
+    def test_base_tracker_elapsed_reflects_current_time(self) -> None:
+        tracker = ProgressTracker("owner")
+        tracker.rich_available = True
+        tracker.start_time = datetime.now() - timedelta(seconds=90)
+        text = tracker._generate_display_text()
+        assert "Elapsed: 1m" in text.plain

--- a/tests/test_slot_lease.py
+++ b/tests/test_slot_lease.py
@@ -1,0 +1,286 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 The Linux Foundation
+
+"""Tests for park-aware concurrency slots (Phase 2 engine wiring).
+
+Covers the ``slot_lease`` primitives in isolation and the production
+guarantee they exist for: a PR waiting on an external event releases
+its concurrency slot so runnable PRs are never starved by parked ones
+(see ``docs/MERGE_ENGINE_DESIGN.md``).
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from dependamerge.slot_lease import (
+    SlotLease,
+    current_lease,
+    holding_slot,
+    parked,
+)
+
+# ---------------------------------------------------------------------------
+# SlotLease primitive
+# ---------------------------------------------------------------------------
+
+
+class TestSlotLease:
+    async def test_acquire_and_release(self):
+        sem = asyncio.Semaphore(1)
+        lease = SlotLease(sem)
+        assert lease.held is False
+
+        await lease.acquire()
+        assert lease.held is True
+        assert sem.locked()
+
+        lease.release()
+        assert lease.held is False
+        assert not sem.locked()
+
+    async def test_release_is_idempotent(self):
+        """Double-release must not over-credit the semaphore."""
+        sem = asyncio.Semaphore(1)
+        lease = SlotLease(sem)
+        await lease.acquire()
+        lease.release()
+        lease.release()  # no-op, not a second release
+
+        await sem.acquire()  # take the single permit back
+        assert sem.locked()  # exactly one permit existed
+
+    async def test_acquire_is_idempotent(self):
+        sem = asyncio.Semaphore(2)
+        lease = SlotLease(sem)
+        await lease.acquire()
+        await lease.acquire()  # no-op, does not consume a second permit
+
+        # The second permit is still available.
+        await asyncio.wait_for(sem.acquire(), timeout=0.5)
+
+
+# ---------------------------------------------------------------------------
+# holding_slot / parked context managers
+# ---------------------------------------------------------------------------
+
+
+class TestHoldingSlot:
+    async def test_holds_and_releases(self):
+        sem = asyncio.Semaphore(1)
+        async with holding_slot(sem) as lease:
+            assert lease.held is True
+            assert sem.locked()
+            assert current_lease() is lease
+        assert not sem.locked()
+        assert current_lease() is None
+
+    async def test_release_on_exception(self):
+        sem = asyncio.Semaphore(1)
+        with pytest.raises(RuntimeError):
+            async with holding_slot(sem):
+                raise RuntimeError("boom")
+        assert not sem.locked()
+
+    async def test_lease_is_task_local(self):
+        """Concurrent tasks never see each other's lease."""
+        sem = asyncio.Semaphore(2)
+        seen: dict[str, object] = {}
+        barrier_a = asyncio.Event()
+        barrier_b = asyncio.Event()
+
+        async def worker(name: str, wait: asyncio.Event, fire: asyncio.Event):
+            async with holding_slot(sem):
+                seen[name] = current_lease()
+                fire.set()
+                await asyncio.wait_for(wait.wait(), timeout=2.0)
+
+        task_a = asyncio.create_task(worker("a", barrier_a, barrier_b))
+        await asyncio.wait_for(barrier_b.wait(), timeout=2.0)
+        task_b = asyncio.create_task(worker("b", barrier_b, barrier_a))
+        await asyncio.gather(task_a, task_b)
+
+        assert seen["a"] is not None
+        assert seen["b"] is not None
+        assert seen["a"] is not seen["b"]
+
+
+class TestParked:
+    async def test_releases_slot_during_wait(self):
+        sem = asyncio.Semaphore(1)
+        async with holding_slot(sem) as lease:
+            assert sem.locked()
+            async with parked():
+                assert lease.held is False
+                assert not sem.locked()
+            # Re-acquired on exit.
+            assert lease.held is True
+            assert sem.locked()
+
+    async def test_noop_without_lease(self):
+        """parked() outside holding_slot() must be harmless."""
+        assert current_lease() is None
+        async with parked():
+            pass  # no error, no lease involved
+
+    async def test_nested_park_is_noop(self):
+        """An inner parked() inside an already-parked block is a no-op."""
+        sem = asyncio.Semaphore(1)
+        async with holding_slot(sem) as lease:
+            async with parked():
+                assert lease.held is False
+                async with parked():
+                    assert lease.held is False
+                # The inner exit must NOT prematurely re-acquire.
+                assert lease.held is False
+            assert lease.held is True
+
+    async def test_reacquire_on_wait_exception(self):
+        """The slot is re-acquired even when the wait body raises."""
+        sem = asyncio.Semaphore(1)
+        async with holding_slot(sem) as lease:
+            with pytest.raises(ValueError):
+                async with parked():
+                    raise ValueError("wait failed")
+            assert lease.held is True
+        assert not sem.locked()
+
+    async def test_parked_item_does_not_starve_runnable_work(self):
+        """The core Phase 2 guarantee.
+
+        With one slot: worker A parks on a slow external wait; worker
+        B must acquire the slot and finish while A is still parked.
+        Legacy behaviour (wait inside ``async with semaphore:``) would
+        deadline B behind A's full wait.
+        """
+        sem = asyncio.Semaphore(1)
+        a_parked = asyncio.Event()
+        b_done = asyncio.Event()
+        order: list[str] = []
+
+        async def worker_a():
+            async with holding_slot(sem):
+                order.append("a-active")
+                async with parked():
+                    a_parked.set()
+                    # Simulate a long external wait; B must complete
+                    # well before this deadline.
+                    await asyncio.wait_for(b_done.wait(), timeout=5.0)
+                order.append("a-resumed")
+
+        async def worker_b():
+            await asyncio.wait_for(a_parked.wait(), timeout=2.0)
+            async with holding_slot(sem):
+                order.append("b-active")
+            b_done.set()
+
+        await asyncio.gather(worker_a(), worker_b())
+        assert order == ["a-active", "b-active", "a-resumed"]
+
+    async def test_parked_reacquire_competes_fairly(self):
+        """A parked worker re-queues for the slot when it wakes."""
+        sem = asyncio.Semaphore(1)
+        a_parked = asyncio.Event()
+        b_started = asyncio.Event()
+        release_b = asyncio.Event()
+        order: list[str] = []
+
+        async def worker_a():
+            async with holding_slot(sem):
+                async with parked():
+                    a_parked.set()
+                    await asyncio.wait_for(b_started.wait(), timeout=2.0)
+                    # B holds the slot now; A's re-acquire must block
+                    # until B finishes.
+                order.append("a-resumed")
+
+        async def worker_b():
+            await asyncio.wait_for(a_parked.wait(), timeout=2.0)
+            async with holding_slot(sem):
+                b_started.set()
+                await asyncio.wait_for(release_b.wait(), timeout=2.0)
+                order.append("b-done")
+
+        async def releaser():
+            await asyncio.wait_for(b_started.wait(), timeout=2.0)
+            # Give A's re-acquire a chance to (wrongly) jump the queue.
+            await asyncio.sleep(0.05)
+            release_b.set()
+
+        await asyncio.gather(worker_a(), worker_b(), releaser())
+        assert order == ["b-done", "a-resumed"]
+
+
+# ---------------------------------------------------------------------------
+# Production wiring: waits inside the merge path release the slot
+# ---------------------------------------------------------------------------
+
+
+class TestMergeManagerParksWaits:
+    """The auto-merge wait releases the worker's concurrency slot."""
+
+    async def test_wait_for_auto_merge_parks_the_slot(self, mocker):
+        from dependamerge.merge_manager import AsyncMergeManager
+        from dependamerge.models import PullRequestInfo
+
+        mgr = AsyncMergeManager(
+            token="t",
+            concurrency=1,
+            merge_timeout=30.0,
+        )
+        # Tighten the poll cadence so the test runs fast.
+        mgr._merge_recheck_interval = 0.01
+
+        pr = PullRequestInfo(
+            number=1,
+            node_id="n1",
+            title="t",
+            body=None,
+            author="dependabot[bot]",
+            head_sha="abc",
+            base_branch="main",
+            head_branch="dep/x",
+            state="open",
+            mergeable=True,
+            mergeable_state="blocked",
+            behind_by=None,
+            files_changed=[],
+            repository_full_name="org/repo",
+            html_url="https://github.com/org/repo/pull/1",
+        )
+
+        slot_state_during_wait: list[bool] = []
+
+        async def fake_get(url: str):
+            # Observe the semaphore while the wait loop polls: the
+            # slot must be free (parked) at this point.
+            slot_state_during_wait.append(mgr._merge_semaphore.locked())
+            return {
+                "state": "closed",
+                "merged": True,
+                "mergeable": True,
+                "mergeable_state": "clean",
+                "head": {"sha": "abc"},
+            }
+
+        client = mocker.AsyncMock()
+        client.get = mocker.AsyncMock(side_effect=fake_get)
+        mgr._github_client = client
+
+        async with holding_slot(mgr._merge_semaphore):
+            assert mgr._merge_semaphore.locked()
+            closed, merged = await mgr._wait_for_auto_merge(
+                pr,
+                "org",
+                "repo",
+                continue_states=("blocked",),
+            )
+            # Slot re-acquired after the wait.
+            assert mgr._merge_semaphore.locked()
+
+        assert closed is True
+        assert merged is True
+        assert slot_state_during_wait  # the poll ran at least once
+        assert not any(slot_state_during_wait)  # slot was free every poll

--- a/tests/test_stuck_check_detection.py
+++ b/tests/test_stuck_check_detection.py
@@ -527,7 +527,7 @@ class TestReportMergeFailure:
 
     @pytest.mark.asyncio
     async def test_stuck_check_reports_and_arms_auto_merge(self) -> None:
-        """A stuck check yields the ⚠️ line and arms auto-merge (non-dirty)."""
+        """A stuck check sets the error reason and arms auto-merge (non-dirty)."""
         mgr, _client = _make_manager()
         pr = _make_pr_info(author="someuser", mergeable_state="blocked")
         result = MergeResult(pr_info=pr, status=MergeStatus.PENDING)
@@ -551,9 +551,11 @@ class TestReportMergeFailure:
         assert out.status == MergeStatus.FAILED
         assert out.error == "stuck check: DCO"
         mock_enable.assert_awaited_once()
+        # Real merge runs keep the console clean: per-PR status goes
+        # to the log only, and the stuck-check reason reaches the
+        # user via ``result.error`` in the end-of-run summary.
         printed = _printed(mock_console)
-        assert "⚠️ Stuck check" in printed
-        # The generic failure line is suppressed for stuck PRs.
+        assert "⚠️ Stuck check" not in printed
         assert "❌ Failed" not in printed
 
     @pytest.mark.asyncio
@@ -603,10 +605,11 @@ class TestReportMergeFailure:
         # The result error now surfaces the real reason so the
         # end-of-run summary is informative (was a generic message).
         assert out.error == "branch protection rules prevent merge"
-        # The inline line is now terse (URL only); the reason is
-        # reserved for the end-of-run summary to avoid duplication.
+        # Real merge runs no longer print per-PR failure lines; the
+        # reason is reported once in the end-of-run summary via
+        # ``result.error``.
         printed = _printed(mock_console)
-        assert "❌ Failed" in printed
+        assert "❌ Failed" not in printed
         assert "branch protection" not in printed
 
     @pytest.mark.asyncio


### PR DESCRIPTION
# Park-aware merge orchestration engine (phase 1)

## Summary

Adds a standalone merge orchestration engine package under
`src/dependamerge/engine/`. **Nothing in the production merge path uses
it yet** — the engine's scheduling semantics can be reviewed and tested
in isolation. A follow-up PR wires `merge_prs_parallel` /
`_merge_single_pr` through it via a pipeline adapter.

On top of the engine package, this PR now also carries production
changes: a fix routing stale-failing-check PRs through rebase (third
commit), a reworked live progress display plus merge-path API-call
reductions (fourth commit), a review-feedback hardening commit
(fifth), and the **Phase 2 engine wiring** — park-aware concurrency
slots in the production merge path (sixth commit).

Full architecture and migration plan: `docs/MERGE_ENGINE_DESIGN.md`.

## Motivation

Three structural problems in the current orchestration, all observed in
production bulk-merge runs:

1. **Waiting pins concurrency slots.** Every waiting loop
   (`_wait_for_auto_merge`, conflict-recovery poll, post-rebase poll,
   recreate poll, pre-commit.ci wait) runs inside a worker holding one
   of the N global slots. A real run with 41 repos needing a rebase at
   10 slots and ~5 min each drains in 20–25 minutes of idle waiting.
2. **Budgets are per-loop, not per-run.** `--max-wait` / `--no-wait`
   apply to `_wait_for_auto_merge` alone; the other polls each burn up
   to `--merge-timeout` independently (worst case ~5 stacked timeouts
   for one PR).
3. **Recovery routing is scattered and has a gap.** A failing required
   check on a branch that is *behind base* is a stale verdict — a
   rebase re-runs it against current base. The legacy code classifies
   it as terminal; in a recent bulk run this failed 88 of 92 PRs that a
   rebase would have fixed.

## What's in the package

- `model.py` — `WorkItem` / `Snapshot` / transitions (`Advance`,
  `Park`, `Finish`). Generic: no GitHub types, opaque payloads.
- `scheduler.py` — `Engine`: per-repo lanes (FIFO, ≤1 in-flight per
  repo), global slots held **only during active phases** (parked items
  are free), uniform `max_wait` clamp on every park, `max_wait 0`
  fire-and-forget mode, phase-budget cycle guard, single
  `on_item_done` finalization hook.
- `reconciler.py` — one batched poller for all parked items; wakes on
  predicate or deadline. Same API cost as the status-quo polling, zero
  concurrency cost while waiting.
- `ladder.py` — pure recovery decision table (no I/O): conflict →
  dependabot rebase; behind → rebase/update-branch; **failing required
  check + behind base → rebase (the new rung)**; stuck check →
  recreate / pre-commit.ci re-trigger; pending checks → wait; otherwise
  terminal with `analyze_block_reason`'s phrase. Every rung fires at
  most once per item per run (guaranteed forward progress);
  `behind_by=None` fails closed. `unstable` merges only while the
  merge button is live (`mergeable is True`); otherwise it waits once
  for mergeability to settle.

## Bonus: live-updating elapsed clock (second commit)

The progress tracker handed Rich `Live` a static text snapshot, so
the elapsed counter froze for 10+ seconds during long silent API
sequences and the tool appeared to hang. The tracker now passes
`get_renderable` so every auto-refresh tick (2/s) re-renders with a
current elapsed time, and event repaints use `live.refresh()`.
Regression-tested in `tests/test_progress_ticker.py`.

## Production fix: blocked masks behind (third commit)

The first production application of the engine's design: GitHub's
`mergeable_state` is a single value, so `blocked` (failing required
check) masks `behind` (stale head). A required check that failed on a
head predating fixes merged to base is a **stale verdict** — only a
branch refresh re-runs it against current base. The legacy Step 5
keyed the rebase solely off `mergeable_state == "behind"`, so these
PRs went straight to a merge attempt that failed with "Repository
rule violations found / Required workflows failed" (observed org-wide
after Zizmor remediation landed on main: every stuck automation PR
failed with zero rebase attempts).

This ports the ladder's "stale failing verdict" rung (Rung 3,
`engine/ladder.py`) to the production path:

- `GitHubAsync.get_behind_by()` — staleness via the compare API,
  independent of `mergeable_state`.
- `_block_reason_indicates_check_blockage()` — broader sibling of the
  pending-checks predicate: matches failing/missing/pending check
  phrasings, rejects blockage a rebase cannot cure (approvals,
  requested changes, Copilot feedback, opaque rulesets).
- `_blocked_pr_needs_rebase()` — probe ordered cheap-first (reason
  classification gates the compare call); a failed comparison counts
  as "not behind" since a rebase is a write action needing positive
  evidence.
- Step 5 routes qualifying blocked PRs through the existing
  `perform_step5_rebase` path (dependabot macro / update-branch).
  Disabled by `--no-fix`; skipped in preview mode.

## Live PR state tracking + merge-path perf (fourth commit)

### Output rework

Per-PR status lines (`✅ Merged: <url>`, `🔄 Rebasing: <url> [...]`,
…) no longer interleave with the Rich progress display during real
runs. Instead the tracker itself shows PRs moving through the
pipeline live:

```text
▶️ Merging PRs in lfreleng-actions (10/10 PRs, 100%)
   Merging PR 11 in lfreleng-actions/node-workflows
   🔄 Rebasing: 1 | ⬆️ Rebased: 2 | ✅ Merged: 8 | 🤖 Pending: 1 | ❌ Failed: 2
   ⏱️ Elapsed: 1m 46s
```

- Transitory states render in pipeline order ahead of the terminal
  counters: `🔄 Rebasing`, `⬆️ Rebased`, `♻️ Recreating`, `⏳ Waiting`.
  PRs move between counters as their state changes
  (Rebasing → Rebased → Merged/Failed, etc.).
- New terminal counters: `🤖 Pending` (auto-merge armed but CI still
  running when the tool exits) and `🛑 Blocked`, alongside Merged,
  Closed, Failed, and Skipped.
- The bracketed reason text that used to trail each in-progress line
  now prints after the tracker finishes: every non-merged outcome
  (Failed / Blocked / Skipped / auto-merge pending) gets an
  end-of-run section listing each PR's URL and reason.
- Preview mode (`🔍 Dependamerge Evaluation`) still prints one line
  per PR — unchanged by design.
- Terminal outcome accounting funnels through a single recording
  point (`_record_terminal_outcome`) so each PR is counted exactly
  once, including on exception paths.

### Merge-path API-call reductions

- **Session caches** in `GitHubAsync` for repo-stable lookups:
  default branch, branch protection, required status checks,
  signature requirement, and the authenticated user login. Keyed by
  `owner/repo[@branch]`; transient errors are never cached ("no
  protection" 404s are).
- **`analyze_block_reason` fast path**: all call sites pass the base
  branch they already hold, removing a redundant PR-details fetch per
  blocked-PR analysis.
- **No post-approval sleep when arming auto-merge**: the propagation
  delay only matters before an *immediate* merge dispatch; GitHub
  re-evaluates protection when checks complete, so the sleep was dead
  time on the critical path.
- **Faster first poll** in `_wait_for_auto_merge` (2s instead of the
  full 10s interval), catching PRs that merge the instant auto-merge
  is armed; steady-state cadence unchanged.
- Shortened the post-`update_branch` settle sleep in the rebase path.

## Phase 2: park-aware concurrency slots (sixth commit)

Ports the engine's central scheduling semantic to the production
merge path: **a concurrency slot is held only while a PR does active
work**. A PR waiting on an external event (dependabot rebase, CI
checks, auto-merge) releases its slot and re-acquires it when the
wait ends, so parked PRs never starve runnable ones. This fixes
structural problem 1 (waiting pins concurrency slots) without the
full pipeline-adapter decomposition — the legacy control flow and its
~600-test seam survive untouched.

- `slot_lease.py` — `holding_slot(semaphore)` replaces the bare
  semaphore acquire in `_merge_single_pr_with_semaphore` and
  publishes a re-acquirable `SlotLease` through a `ContextVar`;
  `parked()` releases the current task's slot while a wait runs and
  re-acquires it before active work resumes. Nested parks and parks
  outside a lease are no-ops; release/acquire are idempotent so the
  semaphore can never be over-credited.
- Wrapped waits: `_wait_for_auto_merge` (also serving both conflict
  recovery phases), the pre-commit.ci re-trigger poll, the dependabot
  recreate poll (with its nested recreated-PR checks wait), and the
  rebase module's post-update settle + poll.
- Invariants preserved: ≤1 in-flight PR per repository (parking
  releases the *global* slot, never the striped scheduler's per-repo
  serialisation), merge-dispatch locks are never held across a park,
  the waiting-PRs ticker is unchanged, and parked polling GETs are
  paced by the HTTP client's own concurrency/RPS limits.

Worked example from the design doc: 41 repos each needing a ~5-minute
rebase at 10 slots used to drain in 20–25 minutes of idle waiting;
with parking, all 41 rebases issue in one scheduling pass and total
wall time collapses to roughly one rebase+CI latency.

## Testing

- 61 engine unit tests in `tests/engine/` covering the ladder
  (table-driven, every rung/guard), the scheduler (ordering, lane
  FIFO, slot release while parked, deadline clamping, no-wait mode,
  exception conversion, cycle guard, observer), and the reconciler
  (wake/timeout/failed-refresh/predicate-exception/flush), plus 5
  progress-ticker tests.
- 23 tests in `tests/test_blocked_masks_behind.py` covering the
  block-reason classifier, the staleness probe (reason gate, compare
  gate, error handling, probe ordering), Step 5 routing, and
  `get_behind_by` payload parsing.
- 20 new tests in `tests/test_merge_state_tracking.py` covering state
  transitions, terminal counter movement, stats-line rendering order,
  and the single-accounting guarantee; new cache tests in
  `tests/test_org_and_user_caches.py`.
- 13 new tests in `tests/test_slot_lease.py` covering the lease
  primitives, task-local isolation, exception paths, the
  no-starvation guarantee, and that `_wait_for_auto_merge` polls with
  the slot released.
- Full suite: **1344 passed, 13 skipped**.

