### PR TITLE
Fix: retrigger stuck pre-commit.ci after wait

### DIFF
--- a/README.md
+++ b/README.md
@@ -649,9 +649,10 @@ dependamerge merge https://github.com/owner/repo/pull/123
 ➡️ To proceed with merging enter: abc123def456
 Enter the string above to continue (or press Enter to cancel):
 
-🔨 Merging 2 mergeable pull requests...
-✅ Success: https://github.com/org/repo1/pull/45
-✅ Success: https://github.com/org/repo3/pull/89
+🚀 Merging 2 pull requests...
+▶️ Merging PRs in org (2/2 PRs, 100%)
+   ✅ Merged: 2
+   ⏱️ Elapsed: 16s
 
 🚀 Final Results: 2 merged, 0 failed
 ```

--- a/src/dependamerge/cli.py
+++ b/src/dependamerge/cli.py
@@ -940,7 +940,6 @@ def _execute_confirmed_merge(
         if result.status.value == "merged"
     ]
     merged_count = len(mergeable_prs)
-    console.print(f"\n🔨 Merging {merged_count} mergeable pull requests...")
 
     _restart_merge_progress_tracker(ctx, merged_count)
     try:
@@ -1405,8 +1404,6 @@ def _execute_repo_confirmed_merge(
         for i, result in enumerate(preview_results)
         if result.status.value == "merged"
     ]
-    merged_count = len(mergeable_prs)
-    console.print(f"\n🔨 Merging {merged_count} mergeable pull requests...")
 
     if ctx.show_progress:
         ctx.progress_tracker = MergeProgressTracker(
@@ -1801,8 +1798,6 @@ def _execute_org_confirmed_merge(
         for i, result in enumerate(preview_results)
         if result.status.value == "merged"
     ]
-    merged_count = len(mergeable_prs)
-    console.print(f"\n🔨 Merging {merged_count} mergeable pull requests...")
 
     if ctx.show_progress:
         ctx.progress_tracker = MergeProgressTracker(

--- a/src/dependamerge/cli.py
+++ b/src/dependamerge/cli.py
@@ -891,9 +891,12 @@ def _handle_preview_confirmation(
     assert ctx.source_pr is not None
 
     console.print(f"\nMergeable {merged_count}/{total_to_merge} PRs")
+    # Per-PR preview lines are no longer printed during the run, so
+    # report the not-mergeable PRs (and why) here before prompting.
+    _print_failed_pr_details(merge_results)
 
     if merged_count == 0:
-        console.print("\n💡 No PRs are mergeable at this time.")
+        console.print("\n\U0001f4a1 No PRs are mergeable at this time.")
         return
 
     commit_messages = ctx.github_client.get_pull_request_commits(
@@ -1279,11 +1282,16 @@ def _handle_repo_merge(
         (pr, None) for pr in repo_prs
     ]
 
+    # Without --no-confirm this first pass is a preview (evaluation)
+    # run — label the tracker accordingly so its counters ("Mergeable")
+    # don't claim merges that never happened.
+    preview_run = ctx.dry_run or not ctx.no_confirm
     if ctx.show_progress:
         ctx.progress_tracker = MergeProgressTracker(
             f"{ctx.owner}/{ctx.repo_name}",
-            operation_label="Merging PRs",
-            operation_icon="▶️",
+            operation_label="Evaluating PRs" if preview_run else "Merging PRs",
+            operation_icon="\U0001f50d" if preview_run else "\u25b6\ufe0f",
+            preview=preview_run,
         )
         ctx.progress_tracker.set_total_prs(len(all_prs_to_merge))
         ctx.progress_tracker.start()
@@ -1299,7 +1307,7 @@ def _handle_repo_merge(
         merge_results = _run_parallel_merge(
             ctx,
             all_prs_to_merge,
-            preview=ctx.dry_run or not ctx.no_confirm,
+            preview=preview_run,
             # Allow parallel workers; the merge dispatch itself is
             # serialised per repo by ``AsyncMergeManager`` so PRs
             # parked in Step 5.5's wait loop no longer block other
@@ -1354,9 +1362,12 @@ def _handle_repo_preview_confirmation(
     source PR for SHA generation — it uses the repository name instead.
     """
     console.print(f"\nMergeable {merged_count}/{total_to_merge} PRs")
+    # Per-PR preview lines are no longer printed during the run, so
+    # report the not-mergeable PRs (and why) here before prompting.
+    _print_failed_pr_details(merge_results)
 
     if merged_count == 0:
-        console.print("\n💡 No PRs are mergeable at this time.")
+        console.print("\n\U0001f4a1 No PRs are mergeable at this time.")
         return
 
     # Generate a confirmation token from the repo context
@@ -1674,11 +1685,16 @@ def _handle_org_merge(
     final_distinct_repos = {pr.repository_full_name for pr in owner_prs}
     concurrency = min(10, len(final_distinct_repos)) or 1
 
+    # Without --no-confirm this first pass is a preview (evaluation)
+    # run — label the tracker accordingly so its counters ("Mergeable")
+    # don't claim merges that never happened.
+    preview_run = ctx.dry_run or not ctx.no_confirm
     if ctx.show_progress:
         ctx.progress_tracker = MergeProgressTracker(
             parsed_org.owner,
-            operation_label="Merging PRs",
-            operation_icon="▶️",
+            operation_label="Evaluating PRs" if preview_run else "Merging PRs",
+            operation_icon="\U0001f50d" if preview_run else "\u25b6\ufe0f",
+            preview=preview_run,
         )
         ctx.progress_tracker.set_total_prs(len(all_prs_to_merge))
         ctx.progress_tracker.start()
@@ -1687,7 +1703,7 @@ def _handle_org_merge(
         merge_results = _run_parallel_merge(
             ctx,
             all_prs_to_merge,
-            preview=ctx.dry_run or not ctx.no_confirm,
+            preview=preview_run,
             concurrency=concurrency,
             # Owner-wide batches mix many repositories and often contain
             # multiple PRs per repository; stripe to avoid stacking and
@@ -1740,9 +1756,12 @@ def _handle_org_preview_confirmation(
     confirmation token from the owner login instead of a repository.
     """
     console.print(f"\nMergeable {merged_count}/{total_to_merge} PRs")
+    # Per-PR preview lines are no longer printed during the run, so
+    # report the not-mergeable PRs (and why) here before prompting.
+    _print_failed_pr_details(merge_results)
 
     if merged_count == 0:
-        console.print("\n💡 No PRs are mergeable at this time.")
+        console.print("\n\U0001f4a1 No PRs are mergeable at this time.")
         return
 
     combined = f"org-merge:{parsed_org.owner}:{merged_count}"

--- a/src/dependamerge/cli.py
+++ b/src/dependamerge/cli.py
@@ -2702,6 +2702,310 @@ def _display_pr_info(
         progress_tracker.resume()
 
 
+@dataclass
+class _CloseContext:
+    """Shared state for the ``close`` command pipeline."""
+
+    token: str
+    github_client: GitHubClient
+    owner: str
+    repo_name: str
+    pr_number: int
+    source_pr: PullRequestInfo
+    progress_tracker: MergeProgressTracker | None
+
+
+def _run_close_parallel(
+    ctx: _CloseContext,
+    prs: list[PullRequestInfo],
+    preview_mode: bool,
+) -> list[CloseResult]:
+    """Close (or preview-close) ``prs`` in parallel."""
+
+    async def _close_parallel() -> list[CloseResult]:
+        close_manager = AsyncCloseManager(
+            token=ctx.token,
+            progress_tracker=ctx.progress_tracker,
+            preview_mode=preview_mode,
+        )
+        async with close_manager:
+            # Convert to list of tuples (PR, None) for consistency
+            pr_tuples: list[tuple[PullRequestInfo, ComparisonResult | None]] = [
+                (pr, None) for pr in prs
+            ]
+            return await close_manager.close_prs_parallel(pr_tuples)
+
+    return asyncio.run(_close_parallel())
+
+
+def _print_close_debug_matching(
+    ctx: _CloseContext,
+    comparator: PRComparator,
+    similarity_threshold: float,
+) -> None:
+    """Show detailed matching diagnostics for the source PR."""
+    source_pr = ctx.source_pr
+    console.print("\n🔍 Debug Matching Information")
+    console.print(
+        "   Source PR automation status: "
+        f"{ctx.github_client.is_automation_author(source_pr.author)}"
+    )
+    console.print(
+        "   Extracted package: "
+        f"'{comparator._extract_package_name(source_pr.title)}'"
+    )
+    console.print(f"   Similarity threshold: {similarity_threshold}")
+    if source_pr.body:
+        console.print(f"   Body preview: {source_pr.body[:100]}...")
+        console.print(
+            "   Is dependabot body: "
+            f"{comparator._is_dependabot_body(source_pr.body)}"
+        )
+    else:
+        console.print("   ⚠️ Source PR has no body")
+    console.print()
+
+
+def _validate_close_authorization(
+    ctx: _CloseContext,
+    override: str | None,
+) -> bool:
+    """Gate non-automation source PRs behind the override SHA.
+
+    Returns True when the close may proceed; False when the caller
+    should stop (the reason has already been printed).
+    """
+    if ctx.github_client.is_automation_author(ctx.source_pr.author):
+        return True
+
+    commit_messages = ctx.github_client.get_pull_request_commits(
+        ctx.owner, ctx.repo_name, ctx.pr_number
+    )
+    first_commit_line = commit_messages[0].split("\n")[0] if commit_messages else ""
+
+    # Generate expected SHA
+    expected_sha = _generate_override_sha(ctx.source_pr, first_commit_line)
+
+    if not override:
+        console.print("Source PR is not from a recognized automation tool.")
+        console.print(
+            f"To close this and similar PRs, run again with: --override {expected_sha}"
+        )
+        console.print(
+            f"This SHA is based on the author '{ctx.source_pr.author}' and commit message '{first_commit_line[:50]}...'",
+            style="dim",
+        )
+        return False
+
+    if override != expected_sha:
+        console.print(
+            f"Error: Invalid override SHA. Expected: {expected_sha}",
+            style="bold red",
+        )
+        console.print(
+            "This prevents accidental bulk operations on non-automation PRs.",
+            style="dim",
+        )
+        return False
+
+    console.print("Override SHA validated. Proceeding with non-automation PR close.")
+    return True
+
+
+def _find_similar_prs_for_close(
+    ctx: _CloseContext,
+    comparator: PRComparator,
+    debug_matching: bool,
+) -> list[tuple[PullRequestInfo, ComparisonResult]]:
+    """Search the owner for PRs similar to the source PR."""
+    if ctx.progress_tracker:
+        console.print()
+    else:
+        console.print(f"\nChecking owner: {ctx.owner}")
+
+    # Use GitHubService for async PR finding
+    from .github_service import GitHubService
+
+    if ctx.progress_tracker:
+        ctx.progress_tracker.update_operation("Listing repositories...")
+
+    async def _find_similar():
+        svc = GitHubService(
+            token=ctx.token,
+            progress_tracker=ctx.progress_tracker,
+            debug_matching=debug_matching,
+        )
+        try:
+            only_automation = ctx.github_client.is_automation_author(
+                ctx.source_pr.author
+            )
+            return await svc.find_similar_prs(
+                ctx.owner,
+                ctx.source_pr,
+                comparator,
+                only_automation=only_automation,
+            )
+        finally:
+            await svc.close()
+
+    return asyncio.run(_find_similar())
+
+
+def _print_close_analysis_summary(
+    ctx: _CloseContext,
+    all_similar_prs: list[tuple[PullRequestInfo, ComparisonResult]],
+) -> None:
+    """Report the search outcome and list the matching PRs."""
+    if ctx.progress_tracker:
+        ctx.progress_tracker.stop()
+        summary = ctx.progress_tracker.get_summary()
+        elapsed_time = summary.get("elapsed_time")
+        total_prs_analyzed = summary.get("total_prs_analyzed")
+        completed_repositories = summary.get("completed_repositories")
+        similar_prs_found = summary.get("similar_prs_found")
+        errors_count = summary.get("errors_count", 0)
+        console.print(f"\n✅ Analysis completed in {elapsed_time}")
+        console.print(
+            f"📊 Analyzed {total_prs_analyzed} PRs across {completed_repositories} repositories"
+        )
+        console.print(f"🔍 Found {similar_prs_found} similar PRs")
+        if errors_count > 0:
+            console.print(f"⚠️ {errors_count} errors encountered during analysis")
+        console.print()
+    else:
+        console.print(f"\n🔍 Found {len(all_similar_prs)} similar PRs")
+
+    if not all_similar_prs:
+        # Not a failure: the supplied PR is simply the only one to
+        # close.  Use a neutral glyph rather than ❌ so the output
+        # does not read like an error.
+        console.print("⏩ No similar PRs found for this owner")
+
+    for target_pr, comparison in all_similar_prs:
+        console.print(f"  • {target_pr.repository_full_name} #{target_pr.number}")
+        console.print(f"    {_format_condensed_similarity(comparison)}")
+
+
+def _run_close_dry_run(
+    ctx: _CloseContext,
+    all_prs_to_close: list[PullRequestInfo],
+) -> None:
+    """Evaluate in preview mode and report what *would* be closed."""
+    if ctx.progress_tracker:
+        ctx.progress_tracker.start()
+        console.print()
+    else:
+        console.print(
+            f"\n🧪 Dry run: evaluating {len(all_prs_to_close)} " "pull requests..."
+        )
+
+    close_results = _run_close_parallel(ctx, all_prs_to_close, True)
+
+    if ctx.progress_tracker:
+        ctx.progress_tracker.stop()
+        console.print()
+
+    closeable_count = sum(1 for r in close_results if r.status.value == "closed")
+    console.print(
+        f"\n🧪 Dry run: would close {closeable_count}/"
+        f"{len(all_prs_to_close)} PRs (no changes made)"
+    )
+
+
+def _run_interactive_close(
+    ctx: _CloseContext,
+    all_prs_to_close: list[PullRequestInfo],
+) -> None:
+    """Preview the close, then prompt for SHA-gated confirmation."""
+    if ctx.progress_tracker:
+        ctx.progress_tracker.start()
+        console.print()
+    else:
+        console.print(f"\n🚀 Evaluating {len(all_prs_to_close)} pull requests...")
+
+    close_results = _run_close_parallel(ctx, all_prs_to_close, True)
+
+    if ctx.progress_tracker:
+        ctx.progress_tracker.stop()
+        console.print()
+
+    # Count closeable PRs
+    closed_count = sum(1 for r in close_results if r.status.value == "closed")
+    total_to_close = len(all_prs_to_close)
+
+    console.print(f"\nCloseable {closed_count}/{total_to_close} PRs")
+
+    if closed_count == 0:
+        console.print("\n❌ No PRs are eligible for closing")
+        return
+
+    # Generate continuation SHA and prompt user
+    commit_messages = ctx.github_client.get_pull_request_commits(
+        ctx.owner, ctx.repo_name, ctx.pr_number
+    )
+    first_commit_line = commit_messages[0].split("\n")[0] if commit_messages else ""
+    continue_sha_hash = _generate_continue_sha(ctx.source_pr, first_commit_line)
+    console.print()
+    console.print(f"To proceed with closing enter: {continue_sha_hash}")
+
+    # Check if in test mode (don't prompt during tests)
+    if "pytest" in sys.modules or os.getenv("TESTING"):
+        console.print("⚠️ Test mode detected - skipping interactive prompt")
+        return
+
+    user_input = typer.prompt(
+        "\nEnter the string above to continue (or press Enter to cancel)"
+    ).strip()
+
+    if user_input != continue_sha_hash:
+        console.print("\n❌ Operation cancelled by user")
+        return
+
+    # Run actual close on closeable PRs only
+    console.print(f"\n🔨 Closing {closed_count} closeable pull requests...")
+    closeable_prs = [
+        all_prs_to_close[i]
+        for i, result in enumerate(close_results)
+        # These were preview "closed"
+        if result.status.value == "closed"
+    ]
+
+    if ctx.progress_tracker:
+        ctx.progress_tracker.start()
+
+    final_results = _run_close_parallel(ctx, closeable_prs, False)
+
+    if ctx.progress_tracker:
+        ctx.progress_tracker.stop()
+
+    # Count final results
+    final_closed = sum(1 for r in final_results if r.status.value == "closed")
+    final_failed = sum(1 for r in final_results if r.status.value == "failed")
+
+    console.print(f"\n🚀 Final Results: {final_closed} closed, {final_failed} failed")
+
+
+def _run_immediate_close(
+    ctx: _CloseContext,
+    all_prs_to_close: list[PullRequestInfo],
+) -> None:
+    """Close all candidate PRs without confirmation."""
+    if ctx.progress_tracker:
+        ctx.progress_tracker.start()
+    console.print(f"\n🚀 Closing {len(all_prs_to_close)} pull requests...")
+
+    close_results = _run_close_parallel(ctx, all_prs_to_close, False)
+
+    if ctx.progress_tracker:
+        ctx.progress_tracker.stop()
+
+    # Count results
+    closed_count = sum(1 for r in close_results if r.status.value == "closed")
+    failed_count = sum(1 for r in close_results if r.status.value == "failed")
+
+    console.print(f"\n🚀 Final Results: {closed_count} closed, {failed_count} failed")
+
+
 @app.command()
 def close(
     pr_url: str = typer.Argument(..., help="GitHub pull request URL"),
@@ -2784,129 +3088,27 @@ def close(
 
         comparator = PRComparator(similarity_threshold)
 
+        ctx = _CloseContext(
+            token=token,
+            github_client=github_client,
+            owner=owner,
+            repo_name=repo_name,
+            pr_number=pr_number,
+            source_pr=source_pr,
+            progress_tracker=progress_tracker,
+        )
+
         # Debug matching info for source PR
         if debug_matching:
-            console.print("\n🔍 Debug Matching Information")
-            console.print(
-                f"   Source PR automation status: {github_client.is_automation_author(source_pr.author)}"
-            )
-            console.print(
-                f"   Extracted package: '{comparator._extract_package_name(source_pr.title)}'"
-            )
-            console.print(f"   Similarity threshold: {similarity_threshold}")
-            if source_pr.body:
-                console.print(f"   Body preview: {source_pr.body[:100]}...")
-                console.print(
-                    f"   Is dependabot body: {comparator._is_dependabot_body(source_pr.body)}"
-                )
-            else:
-                console.print("   ⚠️ Source PR has no body")
-            console.print()
+            _print_close_debug_matching(ctx, comparator, similarity_threshold)
 
         # Check if source PR is from automation or has valid override
-        is_automation = github_client.is_automation_author(source_pr.author)
-        override_valid = False
-
-        if not is_automation:
-            commit_messages = github_client.get_pull_request_commits(
-                owner, repo_name, pr_number
-            )
-            first_commit_line = (
-                commit_messages[0].split("\n")[0] if commit_messages else ""
-            )
-
-            # Generate expected SHA
-            expected_sha = _generate_override_sha(source_pr, first_commit_line)
-
-            # Check if override matches
-            if override == expected_sha:
-                override_valid = True
-
-            if not override:
-                console.print("Source PR is not from a recognized automation tool.")
-                console.print(
-                    f"To close this and similar PRs, run again with: --override {expected_sha}"
-                )
-                console.print(
-                    f"This SHA is based on the author '{source_pr.author}' and commit message '{first_commit_line[:50]}...'",
-                    style="dim",
-                )
-                return
-
-            if not override_valid:
-                console.print(
-                    f"Error: Invalid override SHA. Expected: {expected_sha}",
-                    style="bold red",
-                )
-                console.print(
-                    "This prevents accidental bulk operations on non-automation PRs.",
-                    style="dim",
-                )
-                return
-
-            console.print(
-                "Override SHA validated. Proceeding with non-automation PR close."
-            )
+        if not _validate_close_authorization(ctx, override):
+            return
 
         # Find similar PRs across the owner (organization or user)
-        if progress_tracker:
-            console.print()
-        else:
-            console.print(f"\nChecking owner: {owner}")
-
-        # Use GitHubService for async PR finding
-        from .github_service import GitHubService
-
-        if progress_tracker:
-            progress_tracker.update_operation("Listing repositories...")
-
-        async def _find_similar():
-            svc = GitHubService(
-                token=token,
-                progress_tracker=progress_tracker,
-                debug_matching=debug_matching,
-            )
-            try:
-                only_automation = github_client.is_automation_author(source_pr.author)
-                return await svc.find_similar_prs(
-                    owner,
-                    source_pr,
-                    comparator,
-                    only_automation=only_automation,
-                )
-            finally:
-                await svc.close()
-
-        all_similar_prs = asyncio.run(_find_similar())
-
-        if progress_tracker:
-            progress_tracker.stop()
-            summary = progress_tracker.get_summary()
-            elapsed_time = summary.get("elapsed_time")
-            total_prs_analyzed = summary.get("total_prs_analyzed")
-            completed_repositories = summary.get("completed_repositories")
-            similar_prs_found = summary.get("similar_prs_found")
-            errors_count = summary.get("errors_count", 0)
-            console.print(f"\n✅ Analysis completed in {elapsed_time}")
-            console.print(
-                f"📊 Analyzed {total_prs_analyzed} PRs across {completed_repositories} repositories"
-            )
-            console.print(f"🔍 Found {similar_prs_found} similar PRs")
-            if errors_count > 0:
-                console.print(f"⚠️ {errors_count} errors encountered during analysis")
-            console.print()
-        else:
-            console.print(f"\n🔍 Found {len(all_similar_prs)} similar PRs")
-
-        if not all_similar_prs:
-            # Not a failure: the supplied PR is simply the only one to
-            # close.  Use a neutral glyph rather than ❌ so the output
-            # does not read like an error.
-            console.print("⏩ No similar PRs found for this owner")
-
-        for target_pr, comparison in all_similar_prs:
-            console.print(f"  • {target_pr.repository_full_name} #{target_pr.number}")
-            console.print(f"    {_format_condensed_similarity(comparison)}")
+        all_similar_prs = _find_similar_prs_for_close(ctx, comparator, debug_matching)
+        _print_close_analysis_summary(ctx, all_similar_prs)
 
         if not no_confirm:
             # IMPORTANT: Each PR must produce exactly ONE line of output in this section
@@ -2915,156 +3117,18 @@ def close(
         # Determine which PRs to close
         all_prs_to_close = [source_pr] + [pr for pr, _ in all_similar_prs]
 
-        # Perform preview close operation
-        async def _close_parallel(
-            prs: list[PullRequestInfo], preview_mode: bool
-        ) -> list[CloseResult]:
-            close_manager = AsyncCloseManager(
-                token=token,
-                progress_tracker=progress_tracker,
-                preview_mode=preview_mode,
-            )
-            async with close_manager:
-                # Convert to list of tuples (PR, None) for consistency
-                pr_tuples: list[tuple[PullRequestInfo, ComparisonResult | None]] = [
-                    (pr, None) for pr in prs
-                ]
-                return await close_manager.close_prs_parallel(pr_tuples)
-
-        # Perform preview to check which PRs can be closed
         if dry_run:
             # Dry run: evaluate in preview mode and report what *would*
             # be closed, then stop.  No prompt, no actual close — safe to
             # run unattended under a read-only token.
-            if progress_tracker:
-                progress_tracker.start()
-                console.print()
-            else:
-                console.print(
-                    f"\n🧪 Dry run: evaluating {len(all_prs_to_close)} "
-                    "pull requests..."
-                )
-
-            close_results = asyncio.run(_close_parallel(all_prs_to_close, True))
-
-            if progress_tracker:
-                progress_tracker.stop()
-                console.print()
-
-            closeable_count = sum(
-                1 for r in close_results if r.status.value == "closed"
-            )
-            console.print(
-                f"\n🧪 Dry run: would close {closeable_count}/"
-                f"{len(all_prs_to_close)} PRs (no changes made)"
-            )
+            _run_close_dry_run(ctx, all_prs_to_close)
             return
 
-        if not no_confirm:
-            if progress_tracker:
-                progress_tracker.start()
-                console.print()
-            else:
-                console.print(
-                    f"\n🚀 Evaluating {len(all_prs_to_close)} pull requests..."
-                )
-
-            close_results = asyncio.run(_close_parallel(all_prs_to_close, True))
-
-            if progress_tracker:
-                progress_tracker.stop()
-                console.print()
-
-            # Count closeable PRs
-            closed_count = sum(1 for r in close_results if r.status.value == "closed")
-            total_to_close = len(all_prs_to_close)
-
-            if not no_confirm:
-                console.print(f"\nCloseable {closed_count}/{total_to_close} PRs")
-
-                # Generate continuation SHA and prompt user
-                if closed_count > 0:
-                    commit_messages = github_client.get_pull_request_commits(
-                        owner, repo_name, pr_number
-                    )
-                    first_commit_line = (
-                        commit_messages[0].split("\n")[0] if commit_messages else ""
-                    )
-                    continue_sha_hash = _generate_continue_sha(
-                        source_pr, first_commit_line
-                    )
-                    console.print()
-                    console.print(f"To proceed with closing enter: {continue_sha_hash}")
-
-                    # Check if in test mode (don't prompt during tests)
-                    if "pytest" in sys.modules or os.getenv("TESTING"):
-                        console.print(
-                            "⚠️ Test mode detected - skipping interactive prompt"
-                        )
-                        return
-
-                    user_input = typer.prompt(
-                        "\nEnter the string above to continue (or press Enter to cancel)"
-                    ).strip()
-
-                    if user_input == continue_sha_hash:
-                        # Run actual close on closeable PRs only
-                        console.print(
-                            f"\n🔨 Closing {closed_count} closeable pull requests..."
-                        )
-                        closeable_prs = []
-                        for i, result in enumerate(close_results):
-                            if (
-                                result.status.value == "closed"
-                            ):  # These were preview "closed"
-                                closeable_prs.append(all_prs_to_close[i])
-
-                        if progress_tracker:
-                            progress_tracker.start()
-
-                        final_results = asyncio.run(
-                            _close_parallel(closeable_prs, False)
-                        )
-
-                        if progress_tracker:
-                            progress_tracker.stop()
-
-                        # Count final results
-                        final_closed = sum(
-                            1 for r in final_results if r.status.value == "closed"
-                        )
-                        final_failed = sum(
-                            1 for r in final_results if r.status.value == "failed"
-                        )
-
-                        console.print(
-                            f"\n🚀 Final Results: {final_closed} closed, {final_failed} failed"
-                        )
-
-                    else:
-                        console.print("\n❌ Operation cancelled by user")
-                        return
-                else:
-                    console.print("\n❌ No PRs are eligible for closing")
-                    return
-        else:
+        if no_confirm:
             # No confirmation - close immediately
-            if progress_tracker:
-                progress_tracker.start()
-            console.print(f"\n🚀 Closing {len(all_prs_to_close)} pull requests...")
-
-            close_results = asyncio.run(_close_parallel(all_prs_to_close, False))
-
-            if progress_tracker:
-                progress_tracker.stop()
-
-            # Count results
-            closed_count = sum(1 for r in close_results if r.status.value == "closed")
-            failed_count = sum(1 for r in close_results if r.status.value == "failed")
-
-            console.print(
-                f"\n🚀 Final Results: {closed_count} closed, {failed_count} failed"
-            )
+            _run_immediate_close(ctx, all_prs_to_close)
+        else:
+            _run_interactive_close(ctx, all_prs_to_close)
 
     except DependamergeError as exc:
         # Our structured errors handle display and exit themselves

--- a/src/dependamerge/github_async.py
+++ b/src/dependamerge/github_async.py
@@ -281,6 +281,7 @@ class GitHubAsync:
         self._required_checks_cache: dict[str, list[dict[str, Any]]] = {}
         self._branch_protection_cache: dict[str, dict[str, Any]] = {}
         self._requires_signatures_cache: dict[str, bool] = {}
+        self._requires_strict_checks_cache: dict[str, bool] = {}
 
         # Cache for the token's OAuth scopes.  ``_token_scopes_fetched``
         # distinguishes "not looked up yet" from "looked up, but this token
@@ -1340,6 +1341,182 @@ class GitHubAsync:
             reliable = False
             self.log.debug(
                 "Error checking rulesets for signature requirement on %s/%s:%s: %s",
+                owner,
+                repo,
+                branch,
+                e,
+            )
+
+        return False, reliable
+
+    async def requires_strict_status_checks(
+        self, owner: str, repo: str, branch: str = "main"
+    ) -> bool:
+        """Check whether a branch requires PR heads to be up to date.
+
+        GitHub only rejects the merge of a ``behind`` PR when the
+        branch's protection enforces the *strict* status-check policy
+        ("Require branches to be up to date before merging").  Without
+        it, a behind-but-green PR merges fine and any proactive rebase
+        is wasted work (plus a full CI re-run).  The merge pipeline
+        uses this to rebase **only when GitHub would actually demand
+        it**.
+
+        Uses two complementary sources:
+
+        1. **Classic branch protection** –
+           ``required_status_checks.strict`` on the branch protection
+           REST payload (already cached by :meth:`get_branch_protection`).
+        2. **Repository rulesets** – any active ruleset targeting the
+           branch whose ``required_status_checks`` rule sets
+           ``strict_required_status_checks_policy``.
+
+        Returns:
+            True if either mechanism requires the branch to be up to
+            date before merging.
+
+        Results are cached per ``owner/repo@branch`` for the session;
+        verdicts derived from transient API errors are not cached so a
+        momentary outage cannot pin a wrong answer for the whole run.
+        """
+        cache_key = f"{owner}/{repo}@{branch}"
+        cached = self._requires_strict_checks_cache.get(cache_key)
+        if cached is not None:
+            return cached
+        result, reliable = await self._requires_strict_status_checks_uncached(
+            owner, repo, branch
+        )
+        if reliable:
+            self._requires_strict_checks_cache[cache_key] = result
+        return result
+
+    async def _requires_strict_status_checks_uncached(
+        self, owner: str, repo: str, branch: str
+    ) -> tuple[bool, bool]:
+        """Uncached implementation of :meth:`requires_strict_status_checks`.
+
+        Returns:
+            Tuple of ``(requires_strict, reliable)``.  ``reliable`` is
+            False when a transient API error prevented a definitive
+            verdict — a ``True`` verdict is always reliable (positive
+            evidence), but an error-derived ``False`` must not be
+            cached because the requirement may simply have been
+            unreadable at that moment.
+        """
+        reliable = True
+        # --- 1. Classic branch protection ---
+        try:
+            protection = await self.get_branch_protection(owner, repo, branch)
+            checks = protection.get("required_status_checks")
+            if isinstance(checks, dict) and checks.get("strict") is True:
+                self.log.debug(
+                    "Branch %s/%s:%s requires up-to-date heads "
+                    "(classic protection strict checks)",
+                    owner,
+                    repo,
+                    branch,
+                )
+                return True, True
+        except Exception as e:
+            # get_branch_protection already maps 404 to {}; anything
+            # surfacing here is a transient failure.
+            reliable = False
+            self.log.debug(
+                "Error checking classic strict-checks policy for %s/%s:%s: %s",
+                owner,
+                repo,
+                branch,
+                e,
+            )
+
+        # --- 2. Repository rulesets ---
+        try:
+            default_branch: str | None = None
+            try:
+                repo_data = await self.get(f"/repos/{owner}/{repo}")
+                if isinstance(repo_data, dict):
+                    default_branch = repo_data.get("default_branch")
+            except Exception as e:
+                self.log.debug(
+                    "Could not resolve default branch for %s/%s: %s",
+                    owner,
+                    repo,
+                    e,
+                )
+
+            ruleset_ids: list[int] = []
+            page = 1
+            per_page = 100
+            while True:
+                page_rulesets = await self.get(
+                    f"/repos/{owner}/{repo}/rulesets?per_page={per_page}&page={page}"
+                )
+                if not isinstance(page_rulesets, list) or not page_rulesets:
+                    break
+                for rs in page_rulesets:
+                    if isinstance(rs, dict):
+                        rs_id = rs.get("id")
+                        if rs_id is not None:
+                            ruleset_ids.append(int(rs_id))
+                if len(page_rulesets) < per_page:
+                    break
+                page += 1
+
+            for ruleset_id in ruleset_ids:
+                try:
+                    detail = await self.get(
+                        f"/repos/{owner}/{repo}/rulesets/{ruleset_id}"
+                    )
+                    if not isinstance(detail, dict):
+                        continue
+                except Exception as detail_err:
+                    # An unreadable ruleset could hide a strict
+                    # required_status_checks rule — the eventual False
+                    # verdict is no longer definitive.
+                    reliable = False
+                    self.log.debug(
+                        "Could not fetch ruleset %s for %s/%s: %s",
+                        ruleset_id,
+                        owner,
+                        repo,
+                        detail_err,
+                    )
+                    continue
+
+                if detail.get("enforcement") != "active":
+                    continue
+                conditions = detail.get("conditions", {})
+                if isinstance(conditions, dict) and not self._ruleset_applies_to_branch(
+                    conditions, branch, default_branch
+                ):
+                    continue
+                rules = detail.get("rules", [])
+                if not isinstance(rules, list):
+                    continue
+                for rule in rules:
+                    if (
+                        isinstance(rule, dict)
+                        and rule.get("type") == "required_status_checks"
+                    ):
+                        params = rule.get("parameters")
+                        if (
+                            isinstance(params, dict)
+                            and params.get("strict_required_status_checks_policy")
+                            is True
+                        ):
+                            self.log.debug(
+                                "Branch %s/%s:%s requires up-to-date "
+                                "heads (ruleset: %s)",
+                                owner,
+                                repo,
+                                branch,
+                                detail.get("name", "unknown"),
+                            )
+                            return True, True
+        except Exception as e:
+            reliable = False
+            self.log.debug(
+                "Error checking rulesets for strict-checks policy on %s/%s:%s: %s",
                 owner,
                 repo,
                 branch,

--- a/src/dependamerge/merge_manager.py
+++ b/src/dependamerge/merge_manager.py
@@ -1614,6 +1614,73 @@ class AsyncMergeManager:
                         )
                     return result
 
+                # The wait can expire with the PR still blocked on a
+                # pre-commit.ci run that will never finish.  Step 0.5
+                # only retriggers a run that was already stale when
+                # processing *started*; a run that went pending shortly
+                # before this run began crosses the stuck threshold
+                # *during* the wait above, so without this re-check the
+                # merge below fails on the pending check without the
+                # recovery macro ever being posted.  The helper re-gates
+                # on required-check status, pending age, and duplicate
+                # comments, so this is a no-op unless the run is
+                # genuinely stuck.
+                if (
+                    pr_info.mergeable_state == "blocked"
+                    and self._github_client is not None
+                ):
+                    late_precommit_fixed = await self._trigger_stale_precommit_ci(
+                        pr_info
+                    )
+                    if late_precommit_fixed:
+                        # pre-commit.ci now reports success.  Auto-merge
+                        # was armed before the wait, so GitHub may merge
+                        # the PR the moment the check lands — re-fetch
+                        # and short-circuit on a closed PR before
+                        # attempting a manual merge below.
+                        late_updated: Any = None
+                        try:
+                            late_updated = await self._github_client.get(
+                                f"/repos/{repo_owner}/{repo_name}"
+                                f"/pulls/{pr_info.number}"
+                            )
+                        except Exception as e:
+                            self.log.debug(
+                                "Failed to refresh PR %s state after "
+                                "post-wait pre-commit.ci rerun: %s",
+                                pr_key_for_wait,
+                                e,
+                            )
+                        if isinstance(late_updated, dict):
+                            if late_updated.get("state") == "closed":
+                                pr_info.state = "closed"
+                                if late_updated.get("merged", False):
+                                    result.status = MergeStatus.MERGED
+                                    self._pr_status(
+                                        f"✅ Merged (auto-merge): {pr_info.html_url}",
+                                        level="debug",
+                                    )
+                                else:
+                                    result.status = MergeStatus.CLOSED
+                                    result.error = (
+                                        "PR closed without merging during "
+                                        "auto-merge wait "
+                                        "(no operator follow-up needed)"
+                                    )
+                                    self._pr_status(
+                                        f"🚪 Closed without merging: "
+                                        f"{pr_info.html_url}",
+                                        level="warning",
+                                    )
+                                return result
+                            pr_info.mergeable = late_updated.get("mergeable")
+                            pr_info.mergeable_state = late_updated.get(
+                                "mergeable_state"
+                            )
+                            updated_head = (late_updated.get("head") or {}).get("sha")
+                            if updated_head:
+                                pr_info.head_sha = updated_head
+
             result.status = MergeStatus.MERGING
             if self.preview_mode:
                 self._simulate_preview_merge(pr_info, result)

--- a/src/dependamerge/merge_manager.py
+++ b/src/dependamerge/merge_manager.py
@@ -680,19 +680,18 @@ class AsyncMergeManager:
         tracker.track_pr_state(pr_key, state)
 
     def _pr_status(self, message: str, *, level: str = "info") -> None:
-        """Emit a per-PR status line.
+        """Emit a per-PR status line to the log.
 
-        Preview mode prints the line (the \"\U0001f50d Dependamerge
-        Evaluation\" section requires exactly one line per PR).  Real
-        merges keep the console clean — progress is conveyed by the
-        Rich tracker counters and the reasons are reported in the
-        end-of-run summary — so the message goes to the log only.
+        Per-PR lines go to the log only — in both preview and real
+        runs.  Progress is conveyed by the Rich tracker counters
+        ("Mergeable" in preview, "Merged" in real runs) and the
+        per-PR reasons are reported in the end-of-run summary
+        (:func:`cli._print_failed_pr_details`), so printing one
+        console line per PR here would only duplicate the grouped
+        PR listing already shown before the run.
         """
-        if self.preview_mode:
-            log_and_print(self.log, self._console, message, level=level)
-        else:
-            log_func = getattr(self.log, level.lower(), self.log.info)
-            log_func(message)
+        log_func = getattr(self.log, level.lower(), self.log.info)
+        log_func(message)
 
     async def _merge_single_pr_with_semaphore(
         self, pr_info: PullRequestInfo
@@ -2325,16 +2324,18 @@ class AsyncMergeManager:
     ) -> None:
         """Simulate the Step 6 merge outcome for preview mode.
 
-        Preview output must be SINGLE LINE per PR for clean evaluation
-        display: each PR should produce exactly one line under the
-        "\U0001f50d Dependamerge Evaluation" heading. Mutates ``result`` in place.
+        Mutates ``result`` in place.  No console output: preview
+        progress is conveyed by the Rich tracker counters (with
+        preview-accurate labels such as "Mergeable") and the per-PR
+        outcomes/reasons are reported in the end-of-run summary, so
+        per-PR lines here go to the log only.
         """
         if pr_info.mergeable_state == "behind" and not self.fix_out_of_date:
             result.status = MergeStatus.SKIPPED
             result.error = "PR is behind base branch and --no-fix option is set"
-            self._console.print(
+            self._pr_status(
                 f"\u23ed\ufe0f Skipped: {pr_info.html_url} [behind, rebase disabled]",
-                markup=False,
+                level="debug",
             )
         elif pr_info.mergeable_state == "behind" and self.fix_out_of_date:
             # Behind PRs merge directly unless branch protection
@@ -2345,31 +2346,28 @@ class AsyncMergeManager:
             # Use ``warning`` (not ``error``) so the MERGED result
             # does not carry a contradictory error message.
             result.warning = "behind base branch"
-            self._console.print(
-                f"\u26a0\ufe0f Rebase/merge: {pr_info.html_url} [behind base branch]",
-                markup=False,
+            self._pr_status(
+                f"\u2611\ufe0f Approve/merge: {pr_info.html_url} [behind base branch]",
+                level="debug",
             )
         elif pr_info.mergeable_state == "dirty":
             result.status = MergeStatus.BLOCKED
             result.error = "PR has merge conflicts"
-            self._console.print(
+            self._pr_status(
                 f"\U0001f6d1 Blocked: {pr_info.html_url} [merge conflicts]",
-                markup=False,
+                level="debug",
             )
         elif pr_info.mergeable is False and pr_info.mergeable_state == "blocked":
             result.status = MergeStatus.BLOCKED
             result.error = "PR blocked by failing checks"
-            self._console.print(
+            self._pr_status(
                 f"\U0001f6d1 Blocked: {pr_info.html_url} [blocked by failing checks]",
-                markup=False,
+                level="debug",
             )
         else:
             # Simulate successful merge in preview mode
             result.status = MergeStatus.MERGED
-            # Single line summary for successful preview
-            log_and_print(
-                self.log,
-                self._console,
+            self._pr_status(
                 f"\u2611\ufe0f Approve/merge: {pr_info.html_url}",
                 level="debug",
             )

--- a/src/dependamerge/merge_manager.py
+++ b/src/dependamerge/merge_manager.py
@@ -682,7 +682,7 @@ class AsyncMergeManager:
     def _pr_status(self, message: str, *, level: str = "info") -> None:
         """Emit a per-PR status line.
 
-        Preview mode prints the line (the \"🔍 Dependamerge
+        Preview mode prints the line (the \"\U0001f50d Dependamerge
         Evaluation\" section requires exactly one line per PR).  Real
         merges keep the console clean — progress is conveyed by the
         Rich tracker counters and the reasons are reported in the
@@ -1397,36 +1397,87 @@ class AsyncMergeManager:
                 )
                 return result
 
-            # Handle rebase if needed before merge.
-            #
-            # Dispatched to the dedicated ``rebase`` module so the
-            # local-vs-REST decision tree, the local-git workflow,
-            # and the post-rebase polling loop all live in one
-            # place where they can be tested in isolation.
-            #
-            # ``mergeable_state`` is a single value, so ``blocked``
-            # (failing required check) masks ``behind`` (stale head).
-            # A required check that *failed* on a branch that is
-            # *behind base* was judged against pre-rebase content —
-            # e.g. an org-required workflow audit that the base branch
-            # has since fixed — and only a rebase re-runs it against
-            # the current base.  Mirror the engine ladder's
-            # "stale failing verdict" rung here: when a blocked PR's
-            # block reason is check-related and the compare API shows
-            # the head demonstrably behind, refresh the branch before
-            # treating the failure as terminal.
-            needs_rebase = pr_info.mergeable_state == "behind"
+            # Analyse the block reason once per PR snapshot.  Step 5's
+            # staleness probe, Step 5.5's wait pre-check, and Step 6's
+            # auto-merge skip gate all consult the same analysis, and
+            # each call costs ~4 API requests (reviews, comments,
+            # check runs, combined status).  Fetching it once here and
+            # passing the result through collapses the previous two to
+            # three calls per blocked PR into one.
+            # ``blocked_analysis_ok`` records whether the analysis
+            # itself succeeded: the Step 5.5 pre-check treats an
+            # analysis *failure* (as opposed to a None/inconclusive
+            # reason) as "do not wait".
+            blocked_reason: str | None = None
+            blocked_analysis_ok = False
             if (
-                not needs_rebase
-                and self.fix_out_of_date
+                pr_info.mergeable_state == "blocked"
                 and not self.preview_mode
-                and pr_info.mergeable_state == "blocked"
                 and self._github_client is not None
             ):
-                needs_rebase = await self._blocked_pr_needs_rebase(
-                    pr_info, repo_owner, repo_name
-                )
-            if needs_rebase and self.fix_out_of_date:
+                try:
+                    blocked_reason = await self._github_client.analyze_block_reason(
+                        repo_owner,
+                        repo_name,
+                        pr_info.number,
+                        pr_info.head_sha,
+                        base_branch=pr_info.base_branch,
+                    )
+                    blocked_analysis_ok = True
+                except Exception as exc:
+                    self.log.debug(
+                        "analyze_block_reason failed for %s/%s#%s: %s",
+                        repo_owner,
+                        repo_name,
+                        pr_info.number,
+                        exc,
+                    )
+
+            # Handle rebase if needed before merge.
+            #
+            # Rebases are expensive: they restart every required CI
+            # check (minutes of wall-clock time per PR), and same-repo
+            # batches compound the cost because every sibling merge
+            # moves the base again.  So Step 5 rebases **only when
+            # GitHub actually requires it**:
+            #
+            # - ``behind`` alone is NOT enough.  GitHub happily merges
+            #   a behind-but-green PR unless the branch's protection
+            #   enforces the *strict* status-check policy ("require
+            #   branches to be up to date before merging"), so we
+            #   probe that policy (cached per repo/branch) and
+            #   otherwise send the PR straight to the merge attempt.
+            #   Should a merge still be rejected for staleness, the
+            #   reactive path in ``_handle_merge_failure`` recovers.
+            # - ``blocked`` masks ``behind`` (``mergeable_state`` is a
+            #   single value).  A required check that *failed* on a
+            #   head demonstrably behind base was judged against
+            #   pre-rebase content — e.g. an org-required workflow
+            #   audit that the base branch has since fixed — and only
+            #   a rebase re-runs it against the current base.  Pending
+            #   checks are excluded: they resolve on their own, no
+            #   rebase required.
+            #
+            # The rebase itself is dispatched to the dedicated
+            # ``rebase`` module so the macro-vs-local-vs-REST decision
+            # tree, the local-git workflow, and the post-rebase
+            # polling loop all live in one place where they can be
+            # tested in isolation.
+            needs_rebase = False
+            if (
+                self.fix_out_of_date
+                and not self.preview_mode
+                and self._github_client is not None
+            ):
+                if pr_info.mergeable_state == "behind":
+                    needs_rebase = await self._behind_pr_requires_rebase(
+                        pr_info, repo_owner, repo_name
+                    )
+                elif pr_info.mergeable_state == "blocked" and blocked_analysis_ok:
+                    needs_rebase = await self._blocked_pr_needs_rebase(
+                        pr_info, repo_owner, repo_name, blocked_reason
+                    )
+            if needs_rebase:
                 rebase_ctx = rebase.RebaseContext(
                     github_client=self._github_client,
                     token=self.token,
@@ -1439,6 +1490,7 @@ class AsyncMergeManager:
                     rebased_prs=self._rebased_prs,
                     enable_auto_merge=self._enable_auto_merge_with_approval,
                     track_pr_state=self._track_pr_state,
+                    request_dependabot_rebase=self._request_dependabot_rebase,
                 )
                 outcome = await rebase.perform_step5_rebase(
                     ctx=rebase_ctx,
@@ -1452,9 +1504,9 @@ class AsyncMergeManager:
                     return result
 
             # If the PR is still blocked (e.g. by a pending
-            # required status check such as pre-commit.ci), behind
-            # base branch, or unstable (a non-required check failed),
-            # enable auto-merge and wait for required checks to
+            # required status check such as pre-commit.ci) or
+            # unstable (a non-required check failed), enable
+            # auto-merge and wait for required checks to
             # complete. Skipped when:
             #   * preview_mode (no side effects)
             #   * force_level == "all" (force semantics bypass wait)
@@ -1466,15 +1518,13 @@ class AsyncMergeManager:
             #     delay the inevitable failure/merge by up to
             #     merge_timeout.
             #
-            # Note that ``behind`` PRs go through Step 5.5 regardless
-            # of ``fix_out_of_date``: even when we will not rebase the
-            # PR ourselves, enabling auto-merge gives GitHub the chance
-            # to finish merging once required checks land, and the
-            # resulting AUTO_MERGE_PENDING outcome is friendlier than
-            # a 405 manual-merge failure. This also covers the brief
-            # window after Dependabot/pre-commit-ci rebase a PR where
-            # GitHub still reports ``behind`` while it recomputes
-            # mergeability.
+            # ``behind`` PRs deliberately do NOT wait here: unless
+            # branch protection enforces the strict up-to-date policy
+            # (in which case Step 5 already refreshed the branch), a
+            # behind-but-green PR merges directly, so parking it in
+            # the wait loop — where the state never advances on its
+            # own — would just burn the full ``merge_timeout`` before
+            # the merge attempt that was going to succeed anyway.
             #
             # We accept any ``mergeable`` value (including ``False``)
             # when the state is one of these auto-merge-rescuable
@@ -1501,7 +1551,7 @@ class AsyncMergeManager:
             # (GitHub still computing the value, or a required check
             # transiently failing) so a genuinely not-yet-ready PR is
             # not merged prematurely.
-            state_is_waitable = pr_info.mergeable_state in ("blocked", "behind") or (
+            state_is_waitable = pr_info.mergeable_state == "blocked" or (
                 pr_info.mergeable_state == "unstable" and pr_info.mergeable is not True
             )
             base_should_wait = (
@@ -1512,51 +1562,30 @@ class AsyncMergeManager:
                 and not already_rebased
             )
 
-            # For ``blocked`` PRs (but not ``behind``, which only
-            # needs a rebase to clear), consult analyze_block_reason
-            # before entering the wait loop so we don't burn the
-            # full merge_timeout on PRs blocked for reasons that
-            # cannot resolve on their own.
+            # For ``blocked`` PRs, consult the block-reason analysis
+            # (computed once above) before entering the wait loop so
+            # we don't burn the full merge_timeout on PRs blocked for
+            # reasons that cannot resolve on their own.
             should_wait = base_should_wait
-            if (
-                base_should_wait
-                and pr_info.mergeable_state == "blocked"
-                and self._github_client is not None
-            ):
-                pre_block_reason: str | None = None
-                try:
-                    pre_block_reason = await self._github_client.analyze_block_reason(
-                        repo_owner,
-                        repo_name,
-                        pr_info.number,
-                        pr_info.head_sha,
-                        base_branch=pr_info.base_branch,
-                    )
-                except Exception as exc:
-                    self.log.debug(
-                        "analyze_block_reason failed for %s during "
-                        "Step 5.5 pre-check: %s",
-                        pr_key_for_wait,
-                        exc,
-                    )
+            if base_should_wait and pr_info.mergeable_state == "blocked":
+                if not blocked_analysis_ok:
                     # Treat analysis failures as 'do not wait' so we
                     # don't burn the full ``merge_timeout`` on a PR
                     # whose block reason we cannot classify. The PR
                     # will fall through to the Step 6 skip gate (which
-                    # also calls ``analyze_block_reason``) and either
-                    # defer to auto-merge or surface a manual-merge
-                    # error promptly.
+                    # re-consults the analysis) and either defer to
+                    # auto-merge or surface a manual-merge error
+                    # promptly.
                     should_wait = False
-
-                if should_wait and pre_block_reason is not None:
+                elif blocked_reason is not None:
                     if not self._block_reason_indicates_pending_checks(
-                        pre_block_reason
+                        blocked_reason
                     ):
                         self.log.debug(
                             "Skipping Step 5.5 wait for %s: block "
                             "reason '%s' will not resolve on its own",
                             pr_key_for_wait,
-                            pre_block_reason,
+                            blocked_reason,
                         )
                         should_wait = False
 
@@ -1750,7 +1779,19 @@ class AsyncMergeManager:
                         auto_merge_pending_checks = True
                     else:
                         block_reason: str | None = None
-                        if self._github_client is not None:
+                        analysis_fresh = False
+                        if (
+                            blocked_analysis_ok
+                            and not should_wait
+                            and not already_rebased
+                        ):
+                            # Nothing has changed since the analysis
+                            # at the top of the flow (no Step 5
+                            # rebase, no Step 5.5 wait), so reuse it
+                            # instead of re-spending its ~4 API calls.
+                            block_reason = blocked_reason
+                            analysis_fresh = True
+                        if not analysis_fresh and self._github_client is not None:
                             try:
                                 block_reason = (
                                     await self._github_client.analyze_block_reason(
@@ -1947,8 +1988,31 @@ class AsyncMergeManager:
                             "(no operator follow-up needed)"
                         )
                         self._pr_status(
-                            f"🚪 Closed without merging: {pr_info.html_url}",
+                            f"\U0001f6aa Closed without merging: {pr_info.html_url}",
                             level="info",
+                        )
+                        return result
+
+                    # A ``behind`` PR whose merge was rejected but that
+                    # has auto-merge armed is not a failure: the
+                    # reactive recovery in ``_handle_merge_failure``
+                    # requested a dependabot rebase and armed
+                    # auto-merge, so GitHub completes the merge
+                    # server-side once the rebase lands and required
+                    # checks pass.
+                    if (
+                        pr_info.mergeable_state == "behind"
+                        and pr_key in self._auto_merge_enabled
+                    ):
+                        result.status = MergeStatus.AUTO_MERGE_PENDING
+                        result.error = (
+                            "auto-merge pending: behind base branch "
+                            "(rebase requested)"
+                        )
+                        self._pr_status(
+                            f"\u23f3 Waiting: {pr_info.html_url} "
+                            "[behind base branch; rebase requested]",
+                            level="debug",
                         )
                         return result
 
@@ -2263,37 +2327,40 @@ class AsyncMergeManager:
 
         Preview output must be SINGLE LINE per PR for clean evaluation
         display: each PR should produce exactly one line under the
-        "🔍 Dependamerge Evaluation" heading. Mutates ``result`` in place.
+        "\U0001f50d Dependamerge Evaluation" heading. Mutates ``result`` in place.
         """
         if pr_info.mergeable_state == "behind" and not self.fix_out_of_date:
             result.status = MergeStatus.SKIPPED
             result.error = "PR is behind base branch and --no-fix option is set"
             self._console.print(
-                f"⏭️ Skipped: {pr_info.html_url} [behind, rebase disabled]",
+                f"\u23ed\ufe0f Skipped: {pr_info.html_url} [behind, rebase disabled]",
                 markup=False,
             )
         elif pr_info.mergeable_state == "behind" and self.fix_out_of_date:
-            # For behind PRs with fix enabled, show warning with rebase info
-            result.status = MergeStatus.MERGED  # Would succeed after rebase
+            # Behind PRs merge directly unless branch protection
+            # requires up-to-date heads, in which case the real run
+            # refreshes the branch first — either way the PR counts
+            # as mergeable.
+            result.status = MergeStatus.MERGED
             # Use ``warning`` (not ``error``) so the MERGED result
             # does not carry a contradictory error message.
             result.warning = "behind base branch"
             self._console.print(
-                f"⚠️ Rebase/merge: {pr_info.html_url} [behind base branch]",
+                f"\u26a0\ufe0f Rebase/merge: {pr_info.html_url} [behind base branch]",
                 markup=False,
             )
         elif pr_info.mergeable_state == "dirty":
             result.status = MergeStatus.BLOCKED
             result.error = "PR has merge conflicts"
             self._console.print(
-                f"🛑 Blocked: {pr_info.html_url} [merge conflicts]",
+                f"\U0001f6d1 Blocked: {pr_info.html_url} [merge conflicts]",
                 markup=False,
             )
         elif pr_info.mergeable is False and pr_info.mergeable_state == "blocked":
             result.status = MergeStatus.BLOCKED
             result.error = "PR blocked by failing checks"
             self._console.print(
-                f"🛑 Blocked: {pr_info.html_url} [blocked by failing checks]",
+                f"\U0001f6d1 Blocked: {pr_info.html_url} [blocked by failing checks]",
                 markup=False,
             )
         else:
@@ -2303,7 +2370,7 @@ class AsyncMergeManager:
             log_and_print(
                 self.log,
                 self._console,
-                f"☑️ Approve/merge: {pr_info.html_url}",
+                f"\u2611\ufe0f Approve/merge: {pr_info.html_url}",
                 level="debug",
             )
 
@@ -2408,59 +2475,101 @@ class AsyncMergeManager:
             or "queued" in reason_lower
         )
 
-    async def _blocked_pr_needs_rebase(
+    async def _behind_pr_requires_rebase(
         self,
         pr_info: PullRequestInfo,
         repo_owner: str,
         repo_name: str,
     ) -> bool:
+        """Return True when GitHub would refuse to merge this behind PR.
+
+        A ``behind`` PR only needs a branch refresh before merging
+        when the base branch's protection enforces the *strict*
+        status-check policy ("require branches to be up to date
+        before merging").  Everywhere else GitHub merges a
+        behind-but-green PR directly, and a proactive rebase would
+        just restart CI (minutes per PR), invalidate sibling merges'
+        check runs, and — on signature-requiring repos — drag in the
+        signing workflow.  The policy probe is cached per
+        repo/branch, so same-repo batches pay for it once.
+
+        Any probe failure counts as "not required": the merge attempt
+        itself is the authoritative test, and the reactive path in
+        ``_handle_merge_failure`` recovers if GitHub rejects it.
+        """
+        if self._github_client is None:
+            return False
+        try:
+            strict = await self._github_client.requires_strict_status_checks(
+                repo_owner,
+                repo_name,
+                pr_info.base_branch or "main",
+            )
+        except Exception as exc:
+            self.log.debug(
+                "requires_strict_status_checks failed for %s/%s: %s",
+                repo_owner,
+                repo_name,
+                exc,
+            )
+            return False
+        # Strict ``is True`` comparison so AsyncMock defaults in tests
+        # (truthy Mock objects) never route PRs into the rebase path.
+        if strict is not True:
+            return False
+        self._pr_status(
+            f"\U0001f504 Stale head: {pr_info.html_url} "
+            "[behind base; branch protection requires up-to-date "
+            "heads — refreshing before merge]",
+            level="debug",
+        )
+        return True
+
+    async def _blocked_pr_needs_rebase(
+        self,
+        pr_info: PullRequestInfo,
+        repo_owner: str,
+        repo_name: str,
+        block_reason: str | None,
+    ) -> bool:
         """Decide whether a ``blocked`` PR is really stale-and-fixable.
 
         Implements the staleness probe behind Step 5's
         blocked-masks-behind handling: a ``blocked`` PR is treated
-        like ``behind`` when **both** hold:
+        like ``behind`` when **all** hold:
 
-        1. Its block reason is check-related (failing, missing, or
-           pending checks) — the only class of blockage a branch
-           refresh can cure, because the refresh re-runs checks
-           against the current base.
-        2. The compare API confirms the head is at least one commit
+        1. Its block reason is check-related (failing or missing
+           checks) — the only class of blockage a branch refresh can
+           cure, because the refresh re-runs checks against the
+           current base.
+        2. The block reason is NOT merely *pending* checks: those
+           resolve on their own once the checks finish, so a rebase
+           would restart them for nothing (and, mid-batch, restart
+           them repeatedly as sibling merges advance the base).
+        3. The compare API confirms the head is at least one commit
            behind the base branch.  ``None`` (comparison failed)
            counts as "not behind": a rebase is a write action and a
            CI-time expense, so it must rest on positive evidence.
 
-        The two probes run in this order so the cheaper classification
-        gates the extra compare call.
+        The classification gates run first so the extra compare call
+        is only spent on plausible candidates.
 
         Args:
             pr_info: The pull request under evaluation.
             repo_owner: Base repository owner.
             repo_name: Base repository name.
+            block_reason: The result of ``analyze_block_reason()``
+                computed once at the top of ``_merge_single_pr`` (may
+                be ``None`` when the analysis returned nothing).
 
         Returns:
             True when the PR should take the Step 5 rebase path.
         """
         if self._github_client is None:
             return False
-        pr_key = f"{repo_owner}/{repo_name}#{pr_info.number}"
-        block_reason: str | None = None
-        try:
-            block_reason = await self._github_client.analyze_block_reason(
-                repo_owner,
-                repo_name,
-                pr_info.number,
-                pr_info.head_sha,
-                base_branch=pr_info.base_branch,
-            )
-        except Exception as exc:
-            self.log.debug(
-                "analyze_block_reason failed for %s during Step 5 "
-                "staleness probe: %s",
-                pr_key,
-                exc,
-            )
-            return False
         if not self._block_reason_indicates_check_blockage(block_reason):
+            return False
+        if self._block_reason_indicates_pending_checks(block_reason):
             return False
 
         behind_by = await self._github_client.get_behind_by(
@@ -5585,6 +5694,26 @@ class AsyncMergeManager:
 
         # Check if the branch is out of date and we can fix it
         if self.fix_out_of_date and pr_info.mergeable_state == "behind":
+            if is_dependabot(pr_info.author):
+                # Prefer the ``@dependabot rebase`` macro over REST
+                # ``update-branch``: the REST endpoint creates an
+                # unsigned merge commit that can violate
+                # signature-requiring branch protection, while
+                # dependabot force-pushes a freshly signed rebase.
+                # The macro completes asynchronously (minutes), so an
+                # immediate retry is pointless — arm auto-merge so
+                # GitHub finishes the merge server-side once the
+                # rebase lands and checks pass, and let the caller's
+                # not-merged classification report AUTO_MERGE_PENDING.
+                self.log.info(
+                    f"PR {owner}/{repo}#{pr_info.number} is behind - "
+                    "requesting dependabot rebase"
+                )
+                if self._dependabot_is_rebasing(
+                    pr_info.body
+                ) or await self._request_dependabot_rebase(pr_info, owner, repo):
+                    await self._enable_auto_merge_with_approval(pr_info, owner, repo)
+                return False
             try:
                 self.log.info(
                     f"PR {owner}/{repo}#{pr_info.number} is behind - updating branch"

--- a/src/dependamerge/merge_manager.py
+++ b/src/dependamerge/merge_manager.py
@@ -1673,10 +1673,18 @@ class AsyncMergeManager:
                                         level="warning",
                                     )
                                 return result
-                            pr_info.mergeable = late_updated.get("mergeable")
-                            pr_info.mergeable_state = late_updated.get(
-                                "mergeable_state"
-                            )
+                            # Only accept concrete values: GitHub
+                            # returns null / "" / "unknown" while it
+                            # recomputes mergeability right after the
+                            # check lands, and clobbering the known
+                            # snapshot with those would change the
+                            # downstream routing (mirrors the guards in
+                            # the ``_wait_for_auto_merge`` refresh).
+                            if late_updated.get("mergeable") is not None:
+                                pr_info.mergeable = late_updated.get("mergeable")
+                            late_state = late_updated.get("mergeable_state")
+                            if late_state not in (None, "", "unknown"):
+                                pr_info.mergeable_state = late_state
                             updated_head = (late_updated.get("head") or {}).get("sha")
                             if updated_head:
                                 pr_info.head_sha = updated_head

--- a/src/dependamerge/merge_manager.py
+++ b/src/dependamerge/merge_manager.py
@@ -1853,6 +1853,35 @@ class AsyncMergeManager:
                         ):
                             merged = True
 
+                    # A 405 "Required workflows … are not satisfied"
+                    # rejection means ruleset-required workflows are
+                    # still *executing* on the head commit — a pending
+                    # condition, unlike the terminal "… failed"
+                    # variant.  Wait for them to finish and retry
+                    # rather than failing a PR whose checks are still
+                    # green.  Skipped when Step 5/5.5 already spent
+                    # this PR's wait budget (the workflows are then
+                    # genuinely slower than merge_timeout) and under
+                    # --force=all (force semantics bypass waits).
+                    if (
+                        not merged
+                        and not should_wait
+                        and not already_rebased
+                        and self.force_level != "all"
+                    ):
+                        last_merge_exc = self._last_merge_exception.get(pr_key)
+                        if (
+                            last_merge_exc is not None
+                            and self._merge_error_indicates_pending_workflows(
+                                str(last_merge_exc)
+                            )
+                        ):
+                            merged = (
+                                await self._wait_for_required_workflows_and_retry(
+                                    pr_info, repo_owner, repo_name
+                                )
+                            )
+
                 if merged is None:
                     # Auto-merge is active — PR will merge asynchronously.
                     # Tailor the reason to the actual ``mergeable_state``
@@ -2964,6 +2993,38 @@ class AsyncMergeManager:
             or "approving review" in text
             or "review required" in text
         )
+
+    @staticmethod
+    def _merge_error_indicates_pending_workflows(error_text: str) -> bool:
+        """Detect still-executing required workflows in a merge error body.
+
+        GitHub's merge endpoint rejects with 405 "Repository rule
+        violations found … Required workflows 'X' are not satisfied"
+        while ruleset-required workflows are still *executing* on the
+        head commit — a pending condition that clears by itself once
+        they finish.  That is distinct from the failure variant
+        ("Required workflows 'X' … fail…"), where a workflow ran and
+        reported failure: terminal, retrying cannot help.
+
+        Only the clause starting at the ``required workflow`` wording
+        is inspected, because the enhanced exception text always begins
+        with "Failed to merge PR …" — matching ``fail`` against the
+        whole message would classify every rejection as terminal.  A
+        workflow *name* containing "fail" also suppresses the match;
+        that conservative false negative merely preserves the previous
+        fail-fast behaviour.
+        """
+        if not error_text:
+            return False
+        text = error_text.lower()
+        idx = text.find("required workflow")
+        if idx == -1:
+            return False
+        clause = text[idx:]
+        # Trim the PR-state context ``_validate_merge_result`` appends
+        # after GitHub's detail so it cannot influence classification.
+        clause = clause.split(" (pr state:", 1)[0]
+        return "not satisfied" in clause and "fail" not in clause
 
     async def _check_merge_requirements(
         self, pr_info: PullRequestInfo
@@ -4358,6 +4419,111 @@ class AsyncMergeManager:
             f"_merge_pr_with_retry returning False for {owner}/{repo}#{pr_info.number} after all retries"
         )
         return False
+
+    async def _wait_for_required_workflows_and_retry(
+        self, pr_info: PullRequestInfo, owner: str, repo: str
+    ) -> bool:
+        """Wait out still-executing required workflows, then retry the merge.
+
+        Recovery for a merge rejected with 405 "Repository rule
+        violations found … Required workflows '…' are not satisfied"
+        (see :meth:`_merge_error_indicates_pending_workflows`): the
+        ruleset-required workflows are still running, so the rejection
+        is pending, not terminal.  Alternates between waiting for the
+        PR to leave a blocked/unstable state and re-attempting the
+        merge, all under one shared deadline of ``merge_timeout`` (the
+        same shared-budget pattern conflict recovery uses for its
+        rebase/checks phases) so the recovery can never double-spend
+        the wait budget.  Each cycle dispatches a *single* merge call
+        rather than :meth:`_merge_pr_with_retry`, whose internal
+        retry ladder would multiply the number of merge attempts.
+
+        The loop also covers the stale-``clean`` snapshot case (the
+        REST ``mergeable_state`` can lag behind or be blind to ruleset
+        workflows): when the wait exits immediately because the cached
+        state already looks mergeable, the failed re-merge plus the
+        interval sleep below degrade gracefully into a bounded
+        merge-poll loop.
+
+        Returns True when a retry merged the PR (or it merged on its
+        own during the wait); False otherwise, leaving the last stored
+        merge exception in place for the caller's failure reporting.
+        """
+        if self._github_client is None or self.preview_mode or self._no_wait:
+            return False
+
+        pr_key = f"{owner}/{repo}#{pr_info.number}"
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + self._merge_timeout
+        if self._run_deadline is not None:
+            deadline = min(deadline, self._run_deadline)
+
+        merge_method = self._pr_merge_methods.get(
+            f"{owner}/{repo}", self.default_merge_method
+        )
+
+        self._pr_status(
+            f"⏳ Waiting: {pr_info.html_url} [required workflows still running]",
+            level="info",
+        )
+
+        # Refresh so the wait loop starts from live state rather than
+        # the (possibly stale-``clean``) snapshot that let the doomed
+        # merge dispatch in the first place.
+        try:
+            refreshed = await self._github_client.get(
+                f"/repos/{owner}/{repo}/pulls/{pr_info.number}"
+            )
+            if isinstance(refreshed, dict):
+                if refreshed.get("mergeable") is not None:
+                    pr_info.mergeable = refreshed.get("mergeable")
+                refreshed_state = refreshed.get("mergeable_state")
+                if refreshed_state not in (None, "", "unknown"):
+                    pr_info.mergeable_state = refreshed_state
+                refreshed_head = (refreshed.get("head") or {}).get("sha")
+                if refreshed_head:
+                    pr_info.head_sha = refreshed_head
+        except Exception as exc:
+            self.log.debug(
+                "Failed to refresh %s before required-workflows wait: %s",
+                pr_key,
+                exc,
+            )
+
+        self._track_pr_state(pr_info, "waiting")
+        try:
+            while True:
+                closed, merged_during = await self._wait_for_auto_merge(
+                    pr_info,
+                    owner,
+                    repo,
+                    continue_states=("blocked", "unstable"),
+                    deadline=deadline,
+                )
+                if closed:
+                    return merged_during
+                try:
+                    merged = await self._github_client.merge_pull_request(
+                        owner, repo, pr_info.number, merge_method
+                    )
+                except GitHubPermissionError:
+                    raise
+                except Exception as exc:
+                    self._last_merge_exception[pr_key] = exc
+                    if not self._merge_error_indicates_pending_workflows(str(exc)):
+                        # The rejection reason changed (e.g. a workflow
+                        # finished and *failed*) — terminal; let the
+                        # caller classify and report it.
+                        return False
+                    merged = False
+                if merged:
+                    return True
+                remaining = deadline - loop.time()
+                if remaining <= 0:
+                    return False
+                await asyncio.sleep(min(self._merge_recheck_interval, remaining))
+        finally:
+            self._track_pr_state(pr_info, None)
 
     async def _is_pr_already_merged(
         self, pr_info: PullRequestInfo, owner: str, repo: str

--- a/src/dependamerge/merge_manager.py
+++ b/src/dependamerge/merge_manager.py
@@ -1525,6 +1525,19 @@ class AsyncMergeManager:
             # own — would just burn the full ``merge_timeout`` before
             # the merge attempt that was going to succeed anyway.
             #
+            # Exception: when Step 5 just dispatched an *asynchronous*
+            # rebase (local force-push or the ``@dependabot rebase``
+            # macro) and auto-merge could not be armed, those paths
+            # leave ``_rebased_prs`` unset precisely so this wait can
+            # bridge the gap while the rebase lands and GitHub
+            # recomputes mergeability — the snapshot still reads
+            # ``behind`` because neither path refreshes ``pr_info``.
+            # Without the wait, Step 6 would fire a manual merge
+            # against the stale state and 405.  ``needs_rebase``
+            # captures "Step 5 actually ran" and the
+            # ``not already_rebased`` guard below excludes the
+            # auto-merge-armed case.
+            #
             # We accept any ``mergeable`` value (including ``False``)
             # when the state is one of these auto-merge-rescuable
             # states, because GitHub returns ``mergeable=False``
@@ -1550,8 +1563,13 @@ class AsyncMergeManager:
             # (GitHub still computing the value, or a required check
             # transiently failing) so a genuinely not-yet-ready PR is
             # not merged prematurely.
-            state_is_waitable = pr_info.mergeable_state == "blocked" or (
-                pr_info.mergeable_state == "unstable" and pr_info.mergeable is not True
+            state_is_waitable = (
+                pr_info.mergeable_state == "blocked"
+                or (
+                    pr_info.mergeable_state == "unstable"
+                    and pr_info.mergeable is not True
+                )
+                or (pr_info.mergeable_state == "behind" and needs_rebase)
             )
             base_should_wait = (
                 not self.preview_mode

--- a/src/dependamerge/progress_tracker.py
+++ b/src/dependamerge/progress_tracker.py
@@ -490,6 +490,7 @@ class MergeProgressTracker(ProgressTracker):
         is_close_operation: bool = False,
         operation_label: str | None = None,
         operation_icon: str | None = None,
+        preview: bool = False,
     ):
         """Initialize merge progress tracker.
 
@@ -501,8 +502,14 @@ class MergeProgressTracker(ProgressTracker):
                 ``"Searching for similar PRs"`` (merge) or
                 ``"Closing PRs"`` (close).
             operation_icon: Custom emoji icon for the heading.  When
-                ``None``, defaults to ``"🔀"`` / ``"🔍"`` (merge) or
-                ``"🚪"`` (close) depending on context.
+                ``None``, defaults to ``"\U0001f500"`` / ``"\U0001f50d"`` (merge) or
+                ``"\U0001f6aa"`` (close) depending on context.
+            preview: Whether this tracks a preview (evaluation) run.
+                Preview runs perform no merges, so the terminal
+                counters render with evaluation labels ("Mergeable" /
+                "Would fail") instead of the execution labels
+                ("Merged" / "Failed") that would misstate what
+                happened.
         """
         super().__init__(organization, show_pr_stats=True)
         self.similar_prs_found = 0
@@ -516,6 +523,7 @@ class MergeProgressTracker(ProgressTracker):
         # PRs that are blocked and cannot be merged by this run.
         self.prs_blocked = 0
         self.is_close_operation = is_close_operation
+        self.preview = preview
         self._custom_label = operation_label
         self._custom_icon = operation_icon
         # PR-level progress (used for repo-scoped operations)
@@ -700,13 +708,17 @@ class MergeProgressTracker(ProgressTracker):
                     f"{state_key.capitalize()}: {state_counts[state_key]}"
                 )
         if self.prs_merged > 0:
-            stats_parts.append(f"✅ Merged: {self.prs_merged}")
+            # A preview run merges nothing — the counter records PRs
+            # judged mergeable, so label it accordingly.
+            merged_label = "\u2705 Mergeable" if self.preview else "\u2705 Merged"
+            stats_parts.append(f"{merged_label}: {self.prs_merged}")
         if self.prs_pending > 0:
-            stats_parts.append(f"🤖 Pending: {self.prs_pending}")
+            stats_parts.append(f"\U0001f916 Pending: {self.prs_pending}")
         if self.prs_closed > 0:
-            stats_parts.append(f"🚪 Closed: {self.prs_closed}")
+            stats_parts.append(f"\U0001f6aa Closed: {self.prs_closed}")
         if self.prs_failed > 0:
-            stats_parts.append(f"❌ Failed: {self.prs_failed}")
+            failed_label = "\u274c Would fail" if self.preview else "\u274c Failed"
+            stats_parts.append(f"{failed_label}: {self.prs_failed}")
         if self.prs_skipped > 0:
             stats_parts.append(f"⏭️ Skipped: {self.prs_skipped}")
         if self.prs_blocked > 0:
@@ -776,6 +788,7 @@ class DummyProgressTracker(ProgressTracker):
         self.prs_pending = 0
         self.prs_closed = 0
         self.is_close_operation = False
+        self.preview = False
         self._custom_label: str | None = None
         self._custom_icon: str | None = None
         self.total_prs = 0

--- a/src/dependamerge/rebase.py
+++ b/src/dependamerge/rebase.py
@@ -52,6 +52,7 @@ from typing import TYPE_CHECKING, Any
 from rich.console import Console
 
 from . import git_ops
+from .bot_identity import is_dependabot
 from .git_ops import (
     GitError,
     add_remote,
@@ -110,6 +111,20 @@ class RebaseContext:
     # Default ``None`` keeps existing test constructions working and
     # makes the tracker strictly optional for isolated use.
     track_pr_state: Callable[[PullRequestInfo, str | None], None] | None = None
+    # Optional async callable equivalent to
+    # ``manager._request_dependabot_rebase``: posts ``@dependabot
+    # rebase`` on the PR (idempotent — the manager implementation
+    # skips duplicate comments) and returns True when the rebase is
+    # considered requested.  When provided, dependabot PRs that would
+    # otherwise take the local-rebase path use the macro instead:
+    # dependabot force-pushes a freshly *signed* rebase, so there is
+    # no need to clone + rebase + sign locally (which can require
+    # interactive key access, e.g. a YubiKey PIN prompt).  Default
+    # ``None`` preserves the local path for isolated use and existing
+    # tests.
+    request_dependabot_rebase: (
+        Callable[[PullRequestInfo, str, str], Awaitable[bool]] | None
+    ) = None
 
 
 @dataclass
@@ -600,6 +615,24 @@ async def perform_step5_rebase(
     )
 
     if use_local:
+        # For dependabot PRs, prefer the ``@dependabot rebase`` comment
+        # macro over a local clone + rebase + sign: dependabot
+        # force-pushes a freshly signed rebase itself, which satisfies
+        # the very signature requirement that routed us to the local
+        # path — without touching the operator's signing key (a local
+        # rebase on a signature-requiring repo can trigger interactive
+        # prompts, e.g. a YubiKey PIN).  Falls back to the local path
+        # when the macro cannot be posted.
+        if is_dependabot(pr_info.author) and ctx.request_dependabot_rebase is not None:
+            handled = await _run_dependabot_macro_path(
+                ctx=ctx,
+                pr_info=pr_info,
+                owner=owner,
+                repo=repo,
+                local_reason=local_reason,
+            )
+            if handled:
+                return Step5Outcome()
         await _run_local_path(
             ctx=ctx,
             pr_info=pr_info,
@@ -718,6 +751,76 @@ async def _run_local_path(
             pr_info.html_url,
         )
 
+
+
+async def _run_dependabot_macro_path(
+    *,
+    ctx: RebaseContext,
+    pr_info: PullRequestInfo,
+    owner: str,
+    repo: str,
+    local_reason: str,
+) -> bool:
+    """Request a rebase via the ``@dependabot rebase`` macro.
+
+    Used instead of the local-rebase path for dependabot PRs: the bot
+    rebases the branch onto the current base and force-pushes a
+    commit signed with its own key, preserving the ``Verified`` badge
+    that signature-requiring branch protection demands.
+
+    The rebase completes asynchronously (dependabot typically takes
+    one to a few minutes), so this path never waits for it.  It mirrors
+    the local path's auto-merge contract instead:
+
+    - Auto-merge armed → mark ``_rebased_prs`` so Step 5.5 skips the
+      PR and Step 6's skip gate routes it to ``AUTO_MERGE_PENDING``;
+      GitHub merges server-side once the rebase lands and checks pass.
+    - Auto-merge unavailable → leave the PR unmarked so Step 5.5
+      still runs its bounded wait for the rebase + checks.
+
+    Returns True when the macro was posted (or was already pending);
+    False when it could not be requested — the caller then falls back
+    to the local-rebase path.
+    """
+    if ctx.request_dependabot_rebase is None:
+        return False
+
+    ctx.log.debug(
+        "Dependabot rebase macro: %s [%s]",
+        pr_info.html_url,
+        local_reason,
+    )
+    try:
+        requested = await ctx.request_dependabot_rebase(pr_info, owner, repo)
+    except Exception as exc:
+        ctx.log.debug(
+            "Dependabot rebase request raised for %s: %s",
+            pr_info.html_url,
+            exc,
+        )
+        requested = False
+    if not requested:
+        return False
+
+    try:
+        auto_merge_ok = await ctx.enable_auto_merge(pr_info, owner, repo)
+    except Exception as exc:
+        ctx.log.debug(
+            "Could not enable auto-merge after dependabot rebase "
+            "request for %s: %s",
+            pr_info.html_url,
+            exc,
+        )
+        auto_merge_ok = False
+
+    # Same marking rule as the local path: only skip Step 5.5 when
+    # auto-merge is armed to finish the job server-side.
+    if auto_merge_ok:
+        ctx.rebased_prs.add(f"{owner}/{repo}#{pr_info.number}")
+
+    ctx.log.debug("Rebase requested (dependabot macro): %s", pr_info.html_url)
+    _set_tracker_state(ctx, pr_info, "rebased")
+    return True
 
 
 async def _run_rest_path(

--- a/tests/test_auto_merge.py
+++ b/tests/test_auto_merge.py
@@ -1004,25 +1004,23 @@ class TestStep5_5HandlesMergeableNone:
 
 
 class TestStep5_5BehindWithoutFix:
-    """``behind`` PRs route through Step 5.5 regardless of ``fix_out_of_date``.
+    """``behind`` PRs skip Step 5.5 and go straight to the merge attempt.
 
-    A common real-world pattern: Dependabot or pre-commit-ci has just
-    rebased the PR. GitHub briefly reports ``mergeable_state: "behind"``
-    while it recomputes mergeability, and the new commit's required
-    checks are still running. Without this routing, dependamerge would
-    immediately fail those PRs with a 405 instead of enabling
-    auto-merge and letting GitHub finish the merge once checks pass.
-
-    The user's ``--no-fix`` intent is preserved by *not rebasing the
-    branch ourselves*; enabling auto-merge is a separate, non-rewriting
-    operation that has no effect unless branch protection is satisfied.
+    GitHub merges a behind-but-green PR directly unless branch
+    protection enforces the strict up-to-date policy (which Step 5
+    handles by refreshing the branch first).  Parking a behind PR in
+    the Step 5.5 wait loop — where the state never advances on its
+    own — would just burn the full ``merge_timeout`` before a merge
+    attempt that was going to succeed anyway.  If GitHub does reject
+    the merge, the reactive path in ``_handle_merge_failure``
+    recovers (dependabot rebase macro / REST update-branch).
     """
 
     @pytest.mark.asyncio
-    async def test_step_5_5_routes_behind_no_fix_to_auto_merge_pending(
+    async def test_behind_no_fix_routes_straight_to_merge(
         self,
     ) -> None:
-        """behind + fix_out_of_date=False → AUTO_MERGE_PENDING (not FAILED)."""
+        """behind + fix_out_of_date=False → direct merge, no wait."""
         mgr, client = make_merge_manager(
             preview_mode=False,
             merge_timeout=0.1,
@@ -1036,8 +1034,6 @@ class TestStep5_5BehindWithoutFix:
             }
         )
 
-        # Auto-merge can be enabled, but the PR stays ``behind`` for
-        # the duration of the (very short) wait loop.
         client.enable_auto_merge = AsyncMock(return_value=True)
         client.post_issue_comment = AsyncMock()
         client.get = AsyncMock(
@@ -1048,10 +1044,6 @@ class TestStep5_5BehindWithoutFix:
             }
         )
         client.get_required_status_checks = AsyncMock(return_value=[])
-        # ``behind`` PRs do not consult analyze_block_reason in the
-        # Step 5.5 pre-check (only ``blocked`` does), but the Step 6
-        # skip gate treats ``behind`` as auto-merge-eligible without
-        # calling it either, so we don't need a return value.
         client.analyze_block_reason = AsyncMock(return_value="behind base branch")
 
         no_g2g = GitHub2GerritDetectionResult()
@@ -1095,15 +1087,12 @@ class TestStep5_5BehindWithoutFix:
         ):
             result = await mgr._merge_single_pr(pr)
 
-        # Auto-merge was enabled despite fix_out_of_date=False.
-        client.enable_auto_merge.assert_awaited_once_with("PR_kwDOTestNode42", "merge")
-        assert "owner/repo#42" in mgr._auto_merge_enabled
-        # Wait timed out while still ``behind``; the Step 6 skip gate
-        # routes to AUTO_MERGE_PENDING and the manual merge does NOT
-        # run (which would otherwise 405 against the unfinished
-        # required checks).
-        assert result.status == MergeStatus.AUTO_MERGE_PENDING
-        mock_merge_retry.assert_not_called()
+        # No Step 5.5 wait, no auto-merge arming — the merge attempt
+        # itself is the arbiter for behind PRs.
+        client.enable_auto_merge.assert_not_awaited()
+        assert "owner/repo#42" not in mgr._auto_merge_enabled
+        assert result.status == MergeStatus.MERGED
+        mock_merge_retry.assert_awaited_once()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_auto_merge.py
+++ b/tests/test_auto_merge.py
@@ -12,10 +12,12 @@ Covers:
 - Invalid merge-timeout fallback to the default.
 """
 
+from contextlib import ExitStack
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from dependamerge import rebase as rebase_module
 from dependamerge.github2gerrit_detector import GitHub2GerritDetectionResult
 from dependamerge.merge_manager import MergeStatus
 from dependamerge.models import PullRequestInfo
@@ -1091,6 +1093,229 @@ class TestStep5_5BehindWithoutFix:
         # itself is the arbiter for behind PRs.
         client.enable_auto_merge.assert_not_awaited()
         assert "owner/repo#42" not in mgr._auto_merge_enabled
+        assert result.status == MergeStatus.MERGED
+        mock_merge_retry.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# 18b. Step 5.5: behind + asynchronous Step 5 rebase → bounded wait
+# ---------------------------------------------------------------------------
+
+
+class TestStep5_5BehindAfterAsyncRebase:
+    """``behind`` PRs wait in Step 5.5 after an *asynchronous* rebase.
+
+    The local force-push and ``@dependabot rebase`` macro paths do
+    not refresh ``pr_info``, so the snapshot still reads ``behind``
+    when Step 5 returns.  When auto-merge could not be armed, those
+    paths deliberately leave ``_rebased_prs`` unset so Step 5.5 can
+    bridge the gap while the rebase lands and GitHub recomputes
+    mergeability; skipping the wait would fire a manual merge
+    against the stale state and 405 transiently.  When auto-merge
+    *was* armed, the rebase path marks ``_rebased_prs`` and the wait
+    is skipped (auto-merge finishes the job server-side).
+    """
+
+    @staticmethod
+    def _behind_pr() -> PullRequestInfo:
+        pr: PullRequestInfo = _DEFAULT_PR.model_copy(
+            update={
+                "mergeable_state": "behind",
+                "mergeable": True,
+                "state": "open",
+            }
+        )
+        return pr
+
+    @staticmethod
+    def _enter_common_patches(stack: ExitStack, mgr, *, requires_rebase: bool) -> None:
+        no_g2g = GitHub2GerritDetectionResult()
+        for p in (
+            patch.object(
+                mgr,
+                "_detect_github2gerrit",
+                new_callable=AsyncMock,
+                return_value=no_g2g,
+            ),
+            patch.object(
+                mgr,
+                "_get_merge_method_for_repo",
+                new_callable=AsyncMock,
+                return_value="merge",
+            ),
+            patch.object(
+                mgr,
+                "_trigger_stale_precommit_ci",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+            patch.object(
+                mgr,
+                "_behind_pr_requires_rebase",
+                new_callable=AsyncMock,
+                return_value=requires_rebase,
+            ),
+            patch.object(
+                mgr,
+                "_check_merge_requirements",
+                new_callable=AsyncMock,
+                return_value=(True, ""),
+            ),
+            patch.object(
+                mgr,
+                "_approve_pr",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
+        ):
+            stack.enter_context(p)
+
+    @pytest.mark.asyncio
+    async def test_behind_async_rebase_without_auto_merge_waits(
+        self,
+    ) -> None:
+        """Async rebase, auto-merge unavailable → Step 5.5 wait runs."""
+        mgr, client = make_merge_manager(
+            preview_mode=False,
+            merge_timeout=0.1,
+            fix_out_of_date=True,
+        )
+        pr = self._behind_pr()
+        client.post_issue_comment = AsyncMock()
+
+        # Simulate the macro/local path: rebase dispatched, auto-merge
+        # could not be armed, so ``_rebased_prs`` stays unset and
+        # ``pr_info`` is not refreshed (still ``behind``).
+        step5 = AsyncMock(return_value=rebase_module.Step5Outcome())
+
+        with ExitStack() as stack:
+            self._enter_common_patches(stack, mgr, requires_rebase=True)
+            stack.enter_context(
+                patch.object(rebase_module, "perform_step5_rebase", step5)
+            )
+            stack.enter_context(
+                patch.object(
+                    mgr,
+                    "_enable_auto_merge_with_approval",
+                    new_callable=AsyncMock,
+                    return_value=False,
+                )
+            )
+            mock_wait = stack.enter_context(
+                patch.object(
+                    mgr,
+                    "_wait_for_auto_merge",
+                    new_callable=AsyncMock,
+                    return_value=(False, False),
+                )
+            )
+            mock_merge_retry = stack.enter_context(
+                patch.object(
+                    mgr,
+                    "_merge_pr_with_retry",
+                    new_callable=AsyncMock,
+                    return_value=True,
+                )
+            )
+            result = await mgr._merge_single_pr(pr)
+
+        step5.assert_awaited_once()
+        # The Step 5.5 wait bridged the async rebase before Step 6.
+        mock_wait.assert_awaited_once()
+        assert result.status == MergeStatus.MERGED
+        mock_merge_retry.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_behind_async_rebase_with_auto_merge_skips_wait(
+        self,
+    ) -> None:
+        """Async rebase with auto-merge armed → no Step 5.5 wait."""
+        mgr, client = make_merge_manager(
+            preview_mode=False,
+            merge_timeout=0.1,
+            fix_out_of_date=True,
+        )
+        pr = self._behind_pr()
+        client.post_issue_comment = AsyncMock()
+
+        # Simulate the macro/local path arming auto-merge: the rebase
+        # helper marks ``_rebased_prs`` so Step 5.5 must be skipped
+        # (auto-merge finishes server-side; waiting here would only
+        # double the merge_timeout).
+        async def _step5(*, ctx, pr_info, owner, repo):
+            ctx.rebased_prs.add(f"{owner}/{repo}#{pr_info.number}")
+            return rebase_module.Step5Outcome()
+
+        step5 = AsyncMock(side_effect=_step5)
+
+        with ExitStack() as stack:
+            self._enter_common_patches(stack, mgr, requires_rebase=True)
+            stack.enter_context(
+                patch.object(rebase_module, "perform_step5_rebase", step5)
+            )
+            mock_wait = stack.enter_context(
+                patch.object(
+                    mgr,
+                    "_wait_for_auto_merge",
+                    new_callable=AsyncMock,
+                    return_value=(False, False),
+                )
+            )
+            mock_merge_retry = stack.enter_context(
+                patch.object(
+                    mgr,
+                    "_merge_pr_with_retry",
+                    new_callable=AsyncMock,
+                    return_value=True,
+                )
+            )
+            result = await mgr._merge_single_pr(pr)
+
+        step5.assert_awaited_once()
+        mock_wait.assert_not_awaited()
+        assert result.status == MergeStatus.MERGED
+        mock_merge_retry.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_behind_without_step5_rebase_still_skips_wait(
+        self,
+    ) -> None:
+        """behind + no strict policy (no rebase) → no Step 5.5 wait."""
+        mgr, client = make_merge_manager(
+            preview_mode=False,
+            merge_timeout=0.1,
+            fix_out_of_date=True,
+        )
+        pr = self._behind_pr()
+        client.post_issue_comment = AsyncMock()
+
+        step5 = AsyncMock(return_value=rebase_module.Step5Outcome())
+
+        with ExitStack() as stack:
+            self._enter_common_patches(stack, mgr, requires_rebase=False)
+            stack.enter_context(
+                patch.object(rebase_module, "perform_step5_rebase", step5)
+            )
+            mock_wait = stack.enter_context(
+                patch.object(
+                    mgr,
+                    "_wait_for_auto_merge",
+                    new_callable=AsyncMock,
+                    return_value=(False, False),
+                )
+            )
+            mock_merge_retry = stack.enter_context(
+                patch.object(
+                    mgr,
+                    "_merge_pr_with_retry",
+                    new_callable=AsyncMock,
+                    return_value=True,
+                )
+            )
+            result = await mgr._merge_single_pr(pr)
+
+        step5.assert_not_awaited()
+        mock_wait.assert_not_awaited()
         assert result.status == MergeStatus.MERGED
         mock_merge_retry.assert_awaited_once()
 

--- a/tests/test_behind_pr_handling.py
+++ b/tests/test_behind_pr_handling.py
@@ -129,7 +129,7 @@ class TestBehindPRHandling:
 
     @pytest.mark.asyncio
     async def test_actual_run_performs_rebase_for_behind_pr(self):
-        """Test that actual run properly rebases behind PRs."""
+        """Behind PR + strict up-to-date policy → rebase before merge."""
 
         pr_info = PullRequestInfo(
             number=123,
@@ -185,6 +185,9 @@ class TestBehindPRHandling:
             mock_client = AsyncMock()
             mock_client.update_branch.return_value = None  # Successful rebase
             mock_client.merge_pull_request.return_value = True  # Successful merge
+            # Branch protection demands up-to-date heads — the only
+            # case where Step 5 still rebases proactively.
+            mock_client.requires_strict_status_checks = AsyncMock(return_value=True)
             merge_manager._github_client = mock_client
 
             # Mock the async get method for PR info refresh
@@ -208,6 +211,71 @@ class TestBehindPRHandling:
         mock_client.update_branch.assert_called_once_with("org", "repo", 123)
 
         # Verify merge was attempted after rebase
+        mock_client.merge_pull_request.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_behind_pr_without_strict_policy_merges_directly(self):
+        """Behind PR + no strict policy → direct merge, no rebase.
+
+        GitHub merges a behind-but-green PR unless branch protection
+        requires up-to-date heads, so a proactive rebase would only
+        restart CI for nothing.  This is the common case that made
+        bulk merges slow: every sibling merge put the remaining PRs
+        ``behind``, and each was rebased (and its checks re-run)
+        without GitHub ever requiring it.
+        """
+
+        pr_info = PullRequestInfo(
+            number=123,
+            title="Test PR",
+            body="Test body",
+            author="dependabot[bot]",
+            head_sha="abc123",
+            base_branch="main",
+            head_branch="feature",
+            state="open",
+            mergeable=True,
+            mergeable_state="behind",
+            behind_by=2,
+            files_changed=[],
+            repository_full_name="org/repo",
+            html_url="https://github.com/org/repo/pull/123",
+            reviews=[],
+            review_comments=[],
+        )
+
+        async with AsyncMergeManager(
+            token="fake_token",
+            merge_method="squash",
+            max_retries=1,
+            concurrency=1,
+            fix_out_of_date=True,
+            progress_tracker=None,
+            preview_mode=False,
+            dismiss_copilot=False,
+        ) as merge_manager:
+            mock_client = AsyncMock()
+            mock_client.merge_pull_request.return_value = True
+            mock_client.requires_strict_status_checks = AsyncMock(return_value=False)
+            merge_manager._github_client = mock_client
+            mock_client.get.return_value = {
+                "mergeable": True,
+                "mergeable_state": "behind",
+                "state": "open",
+            }
+            with patch.object(
+                merge_manager,
+                "_check_merge_requirements",
+                return_value=(True, ""),
+            ):
+                with patch.object(merge_manager, "_approve_pr", return_value=None):
+                    result = await merge_manager._merge_single_pr(pr_info)
+
+        assert result.status == MergeStatus.MERGED
+        # No branch refresh and no auto-merge wait — the merge call
+        # itself is the arbiter.
+        mock_client.update_branch.assert_not_called()
+        mock_client.enable_auto_merge.assert_not_called()
         mock_client.merge_pull_request.assert_called_once()
 
     @pytest.mark.asyncio
@@ -248,6 +316,8 @@ class TestBehindPRHandling:
             mock_client = AsyncMock()
             # Make rebase fail
             mock_client.update_branch.side_effect = Exception("Rebase conflict")
+            # Strict policy forces the Step 5 rebase path.
+            mock_client.requires_strict_status_checks = AsyncMock(return_value=True)
             merge_manager._github_client = mock_client
 
             # Mock other required methods
@@ -340,7 +410,7 @@ class TestBehindPRHandling:
 
     @pytest.mark.asyncio
     async def test_proactive_rebase_success(self):
-        """Test that proactive rebase works correctly for behind PRs."""
+        """Strict up-to-date policy → proactive rebase then merge."""
 
         pr_info = PullRequestInfo(
             number=123,
@@ -397,6 +467,8 @@ class TestBehindPRHandling:
             # Mock successful rebase and merge
             mock_client.update_branch.return_value = None
             mock_client.merge_pull_request.return_value = True
+            # Strict policy forces the Step 5 rebase path.
+            mock_client.requires_strict_status_checks = AsyncMock(return_value=True)
             merge_manager._github_client = mock_client
 
             # Mock PR info refresh after rebase
@@ -474,6 +546,8 @@ class TestBehindPRHandling:
             mock_client = AsyncMock()
             mock_client.update_branch.return_value = None
             mock_client.merge_pull_request.return_value = True
+            # Strict policy forces the Step 5 rebase path.
+            mock_client.requires_strict_status_checks = AsyncMock(return_value=True)
             merge_manager._github_client = mock_client
 
             # Mock the async get method for PR status polling
@@ -553,6 +627,6 @@ class TestBehindPRHandling:
         # the line must be surfaced as a warning, identify the PR, and
         # explain that it is behind its base branch.
         call_args = mock_console.print.call_args[0][0]
-        assert "⚠️" in call_args  # surfaced as a warning
+        assert "\u26a0\ufe0f" in call_args  # surfaced as a warning
         assert pr_info.html_url in call_args  # identifies the PR
         assert "behind" in call_args.lower()  # explains the reason

--- a/tests/test_behind_pr_handling.py
+++ b/tests/test_behind_pr_handling.py
@@ -567,8 +567,14 @@ class TestBehindPRHandling:
         assert call_count > 1
 
     @pytest.mark.asyncio
-    async def test_single_line_preview_output_format(self):
-        """Test that preview produces exactly one line of output per PR."""
+    async def test_preview_produces_no_per_pr_console_output(self):
+        """Preview emits NO per-PR console lines.
+
+        Preview progress is conveyed by the Rich tracker counters
+        ("Mergeable") and the end-of-run summary reports per-PR
+        reasons, so printing a line per PR here would only duplicate
+        the grouped PR listing shown before the run.
+        """
 
         pr_info = PullRequestInfo(
             number=123,
@@ -616,17 +622,10 @@ class TestBehindPRHandling:
                 return_value=(True, "PR is behind - will rebase before merge"),
             ):
                 with patch.object(merge_manager, "_approve_pr", return_value=None):
-                    await merge_manager._merge_single_pr(pr_info)
+                    result = await merge_manager._merge_single_pr(pr_info)
 
-        # Verify exactly one print call was made (single-line output)
-        assert mock_console.print.call_count == 1
-
-        # Verify the *semantic content* of the single-line preview rather
-        # than its exact structure/wording. This keeps the test robust to
-        # cosmetic output changes (reordering, relabelling, emoji tweaks):
-        # the line must be surfaced as a warning, identify the PR, and
-        # explain that it is behind its base branch.
-        call_args = mock_console.print.call_args[0][0]
-        assert "\u26a0\ufe0f" in call_args  # surfaced as a warning
-        assert pr_info.html_url in call_args  # identifies the PR
-        assert "behind" in call_args.lower()  # explains the reason
+        # No per-PR console lines; the outcome carries the details
+        # for the end-of-run summary instead.
+        assert mock_console.print.call_count == 0
+        assert result.status == MergeStatus.MERGED
+        assert result.warning == "behind base branch"

--- a/tests/test_blocked_masks_behind.py
+++ b/tests/test_blocked_masks_behind.py
@@ -18,6 +18,7 @@ tests cover:
 """
 
 from contextlib import ExitStack
+from typing import Any
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -189,7 +190,7 @@ class TestBlockedPrNeedsRebase:
 # ---------------------------------------------------------------------------
 
 
-def _step5_patches(mgr: AsyncMergeManager) -> list:
+def _step5_patches(mgr: AsyncMergeManager) -> list[Any]:
     """Common patches to drive _merge_single_pr up to Step 5."""
     no_g2g = GitHub2GerritDetectionResult()
     return [

--- a/tests/test_blocked_masks_behind.py
+++ b/tests/test_blocked_masks_behind.py
@@ -92,19 +92,23 @@ class TestBlockReasonIndicatesCheckBlockage:
 
 
 class TestBlockedPrNeedsRebase:
-    """Staleness probe for blocked PRs."""
+    """Staleness probe for blocked PRs.
+
+    The block reason itself is analysed once in ``_merge_single_pr``
+    and passed in, so the probe receives it as an argument and only
+    spends API budget on the compare call.
+    """
 
     @pytest.mark.asyncio
     async def test_failing_check_and_behind_triggers_rebase(self) -> None:
         """Failing check + demonstrably behind → rebase path."""
         mgr, client = make_merge_manager(fix_out_of_date=True)
-        client.analyze_block_reason = AsyncMock(
-            return_value="Blocked by failing check: Zizmor Scan 🌈"
-        )
         client.get_behind_by = AsyncMock(return_value=2)
         pr = _BLOCKED_PR.model_copy()
 
-        assert await mgr._blocked_pr_needs_rebase(pr, "owner", "repo")
+        assert await mgr._blocked_pr_needs_rebase(
+            pr, "owner", "repo", "Blocked by failing check: Zizmor Scan \U0001f308"
+        )
         # The probe records the evidence on the PR for later steps.
         assert pr.behind_by == 2
 
@@ -112,51 +116,70 @@ class TestBlockedPrNeedsRebase:
     async def test_up_to_date_head_does_not_rebase(self) -> None:
         """Failing check but head not behind → no rebase."""
         mgr, client = make_merge_manager(fix_out_of_date=True)
-        client.analyze_block_reason = AsyncMock(
-            return_value="Blocked by failing check: Zizmor Scan 🌈"
-        )
         client.get_behind_by = AsyncMock(return_value=0)
 
         assert not await mgr._blocked_pr_needs_rebase(
-            _BLOCKED_PR.model_copy(), "owner", "repo"
+            _BLOCKED_PR.model_copy(),
+            "owner",
+            "repo",
+            "Blocked by failing check: Zizmor Scan \U0001f308",
         )
 
     @pytest.mark.asyncio
     async def test_unknown_staleness_does_not_rebase(self) -> None:
         """Compare failure (None) counts as not behind, not as behind."""
         mgr, client = make_merge_manager(fix_out_of_date=True)
-        client.analyze_block_reason = AsyncMock(
-            return_value="Blocked by failing check: Zizmor Scan 🌈"
-        )
         client.get_behind_by = AsyncMock(return_value=None)
 
         assert not await mgr._blocked_pr_needs_rebase(
-            _BLOCKED_PR.model_copy(), "owner", "repo"
+            _BLOCKED_PR.model_copy(),
+            "owner",
+            "repo",
+            "Blocked by failing check: Zizmor Scan \U0001f308",
         )
 
     @pytest.mark.asyncio
     async def test_non_check_blockage_skips_compare_probe(self) -> None:
         """Approval blockage → False without spending the compare call."""
         mgr, client = make_merge_manager(fix_out_of_date=True)
-        client.analyze_block_reason = AsyncMock(
-            return_value="Blocked by branch protection (requires approval)"
-        )
         client.get_behind_by = AsyncMock(return_value=5)
 
         assert not await mgr._blocked_pr_needs_rebase(
-            _BLOCKED_PR.model_copy(), "owner", "repo"
+            _BLOCKED_PR.model_copy(),
+            "owner",
+            "repo",
+            "Blocked by branch protection (requires approval)",
         )
         client.get_behind_by.assert_not_awaited()
 
     @pytest.mark.asyncio
-    async def test_analyze_failure_does_not_rebase(self) -> None:
-        """analyze_block_reason raising → treat as not rebasable."""
+    async def test_pending_checks_do_not_rebase(self) -> None:
+        """Pending checks resolve on their own — never rebase for them.
+
+        A rebase restarts every required check, and in a same-repo
+        batch each sibling merge advances the base again — so
+        rebasing a PR whose checks are merely *pending* causes the
+        CI-restart churn this probe exists to avoid.
+        """
         mgr, client = make_merge_manager(fix_out_of_date=True)
-        client.analyze_block_reason = AsyncMock(side_effect=RuntimeError("boom"))
         client.get_behind_by = AsyncMock(return_value=5)
 
         assert not await mgr._blocked_pr_needs_rebase(
-            _BLOCKED_PR.model_copy(), "owner", "repo"
+            _BLOCKED_PR.model_copy(),
+            "owner",
+            "repo",
+            "Blocked by pending required check: DCO",
+        )
+        client.get_behind_by.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_missing_analysis_does_not_rebase(self) -> None:
+        """``None`` block reason (analysis empty) → not rebasable."""
+        mgr, client = make_merge_manager(fix_out_of_date=True)
+        client.get_behind_by = AsyncMock(return_value=5)
+
+        assert not await mgr._blocked_pr_needs_rebase(
+            _BLOCKED_PR.model_copy(), "owner", "repo", None
         )
         client.get_behind_by.assert_not_awaited()
 

--- a/tests/test_local_rebase_signing.py
+++ b/tests/test_local_rebase_signing.py
@@ -323,6 +323,8 @@ class TestStep5DispatchLocalRebase:
         client.analyze_block_reason = AsyncMock(return_value=None)
         client.get_required_status_checks = AsyncMock(return_value=[])
         client.requires_commit_signatures = AsyncMock(return_value=True)
+        # Strict up-to-date policy → Step 5 rebases proactively.
+        client.requires_strict_status_checks = AsyncMock(return_value=True)
 
         with (
             patch(
@@ -407,6 +409,8 @@ class TestStep5DispatchLocalRebase:
         client.analyze_block_reason = AsyncMock(return_value=None)
         client.get_required_status_checks = AsyncMock(return_value=[])
         client.requires_commit_signatures = AsyncMock(return_value=True)
+        # Strict up-to-date policy → Step 5 rebases proactively.
+        client.requires_strict_status_checks = AsyncMock(return_value=True)
 
         with (
             patch(
@@ -493,6 +497,8 @@ class TestStep5DispatchLocalRebase:
         client.get_required_status_checks = AsyncMock(return_value=[])
         # Unsigned base → gate returns False → REST path.
         client.requires_commit_signatures = AsyncMock(return_value=False)
+        # Strict up-to-date policy → Step 5 rebases proactively.
+        client.requires_strict_status_checks = AsyncMock(return_value=True)
 
         with (
             patch(
@@ -570,6 +576,8 @@ class TestStep5DispatchLocalRebase:
         client.analyze_block_reason = AsyncMock(return_value=None)
         client.get_required_status_checks = AsyncMock(return_value=[])
         client.requires_commit_signatures = AsyncMock(return_value=True)
+        # Strict up-to-date policy → Step 5 rebases proactively.
+        client.requires_strict_status_checks = AsyncMock(return_value=True)
 
         with (
             patch(
@@ -621,7 +629,181 @@ class TestStep5DispatchLocalRebase:
 
 
 # ---------------------------------------------------------------------------
-# 3. _authed_clone_url helper
+# 3. Step 5 dispatch: dependabot PRs use the rebase macro, not local git
+# ---------------------------------------------------------------------------
+
+
+class TestStep5DispatchDependabotMacro:
+    """Dependabot + signature-requiring base → ``@dependabot rebase``.
+
+    The local clone+rebase+sign workflow exists to preserve verified
+    signatures, but dependabot can do that itself: the macro makes it
+    force-push a freshly *signed* rebase.  Using the macro avoids
+    touching the operator's signing key (a local rebase can trigger
+    interactive prompts, e.g. a YubiKey PIN) — so when the gate says
+    "local", dependabot PRs take the macro path instead.
+    """
+
+    @pytest.mark.asyncio
+    async def test_dependabot_signature_repo_uses_macro(self) -> None:
+        """Macro posted; neither local rebase nor REST update-branch."""
+        mgr, client = _make_mgr(merge_timeout=0.1, fix_out_of_date=True)
+        pr = _make_pr(author="dependabot[bot]", mergeable_state="behind")
+
+        client.update_branch = AsyncMock()
+        client.enable_auto_merge = AsyncMock(return_value=True)
+        client.post_issue_comment = AsyncMock()
+        client.get = AsyncMock(
+            return_value={
+                "mergeable": True,
+                "mergeable_state": "behind",
+                "state": "open",
+            }
+        )
+        client.analyze_block_reason = AsyncMock(return_value=None)
+        client.get_required_status_checks = AsyncMock(return_value=[])
+        # Signed base + verified head → gate selects the local path…
+        client.requires_commit_signatures = AsyncMock(return_value=True)
+        client.check_pr_commit_signatures = AsyncMock(return_value=(True, []))
+        # …and the strict policy forces the Step 5 rebase.
+        client.requires_strict_status_checks = AsyncMock(return_value=True)
+
+        with (
+            patch(
+                "dependamerge.rebase.local_rebase_pr",
+                new_callable=AsyncMock,
+                return_value=True,
+            ) as mock_local_rebase,
+            patch.object(
+                mgr,
+                "_detect_github2gerrit",
+                new_callable=AsyncMock,
+                return_value=GitHub2GerritDetectionResult(),
+            ),
+            patch.object(
+                mgr,
+                "_get_merge_method_for_repo",
+                new_callable=AsyncMock,
+                return_value="merge",
+            ),
+            patch.object(
+                mgr,
+                "_trigger_stale_precommit_ci",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+            patch.object(
+                mgr,
+                "_check_merge_requirements",
+                new_callable=AsyncMock,
+                return_value=(True, ""),
+            ),
+            patch.object(
+                mgr,
+                "_approve_pr",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
+            patch.object(
+                mgr,
+                "_merge_pr_with_retry",
+                new_callable=AsyncMock,
+                return_value=True,
+            ) as mock_merge_retry,
+        ):
+            result = await mgr._merge_single_pr(pr)
+
+        # The macro was posted; the signing-sensitive paths were not.
+        # (Auto-merge enablement posts its own audit comment, so check
+        # for the macro among the calls rather than exactly one call.)
+        assert ("owner", "repo", 42, "@dependabot rebase") in [
+            c.args for c in client.post_issue_comment.await_args_list
+        ]
+        mock_local_rebase.assert_not_awaited()
+        client.update_branch.assert_not_awaited()
+        # Auto-merge armed → PR marked rebased and routed to
+        # AUTO_MERGE_PENDING; no manual merge attempt races the
+        # asynchronous dependabot rebase.
+        assert "owner/repo#42" in mgr._rebased_prs
+        assert "owner/repo#42" in mgr._auto_merge_enabled
+        assert result.status == MergeStatus.AUTO_MERGE_PENDING
+        mock_merge_retry.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_macro_post_failure_falls_back_to_local(self) -> None:
+        """Macro cannot be posted → the local path still protects signatures."""
+        mgr, client = _make_mgr(merge_timeout=0.1, fix_out_of_date=True)
+        pr = _make_pr(author="dependabot[bot]", mergeable_state="behind")
+
+        client.update_branch = AsyncMock()
+        client.enable_auto_merge = AsyncMock(return_value=True)
+        client.post_issue_comment = AsyncMock(side_effect=RuntimeError("403"))
+        client.get = AsyncMock(
+            return_value={
+                "mergeable": True,
+                "mergeable_state": "clean",
+                "state": "open",
+            }
+        )
+        client.analyze_block_reason = AsyncMock(return_value=None)
+        client.get_required_status_checks = AsyncMock(return_value=[])
+        client.requires_commit_signatures = AsyncMock(return_value=True)
+        client.check_pr_commit_signatures = AsyncMock(return_value=(True, []))
+        client.requires_strict_status_checks = AsyncMock(return_value=True)
+
+        with (
+            patch(
+                "dependamerge.rebase.local_rebase_pr",
+                new_callable=AsyncMock,
+                return_value=True,
+            ) as mock_local_rebase,
+            patch.object(
+                mgr,
+                "_detect_github2gerrit",
+                new_callable=AsyncMock,
+                return_value=GitHub2GerritDetectionResult(),
+            ),
+            patch.object(
+                mgr,
+                "_get_merge_method_for_repo",
+                new_callable=AsyncMock,
+                return_value="merge",
+            ),
+            patch.object(
+                mgr,
+                "_trigger_stale_precommit_ci",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+            patch.object(
+                mgr,
+                "_check_merge_requirements",
+                new_callable=AsyncMock,
+                return_value=(True, ""),
+            ),
+            patch.object(
+                mgr,
+                "_approve_pr",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
+            patch.object(
+                mgr,
+                "_merge_pr_with_retry",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
+        ):
+            await mgr._merge_single_pr(pr)
+
+        # Fallback: local rebase ran; REST update-branch still never
+        # fired (signature preservation invariant).
+        mock_local_rebase.assert_awaited_once()
+        client.update_branch.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# 4. _authed_clone_url helper
 # ---------------------------------------------------------------------------
 
 
@@ -684,6 +866,8 @@ class TestLocalRebaseAutoMergeUnavailable:
         client.analyze_block_reason = AsyncMock(return_value=None)
         client.get_required_status_checks = AsyncMock(return_value=[])
         client.requires_commit_signatures = AsyncMock(return_value=True)
+        # Strict up-to-date policy → Step 5 rebases proactively.
+        client.requires_strict_status_checks = AsyncMock(return_value=True)
         client.post_issue_comment = AsyncMock()
 
         with (

--- a/tests/test_merge_state_tracking.py
+++ b/tests/test_merge_state_tracking.py
@@ -177,6 +177,53 @@ class TestDisplayRendering:
         plain = tracker._generate_display_text().plain
         assert "Polishing: 1" in plain
 
+    def test_preview_counters_use_evaluation_labels(self) -> None:
+        """Preview runs merge nothing — counters must say so.
+
+        A preview tracker showing "✅ Merged: 42" misleads the
+        operator into thinking merges happened; the run only judged
+        the PRs mergeable.  Failure counts are likewise predictions,
+        not events.
+        """
+        tracker = MergeProgressTracker(
+            "org",
+            operation_label="Evaluating PRs",
+            operation_icon="\U0001f50d",
+            preview=True,
+        )
+        tracker.rich_available = True
+        tracker.set_total_prs(3)
+        tracker.merge_success("org/repo#1")
+        tracker.merge_failure("org/repo#2")
+        tracker.merge_blocked("org/repo#3")
+
+        plain = tracker._generate_display_text().plain
+        assert "\U0001f50d Evaluating PRs in" in plain
+        assert "\u2705 Mergeable: 1" in plain
+        assert "\u274c Would fail: 1" in plain
+        # Neutral labels stay unchanged.
+        assert "\U0001f6d1 Blocked: 1" in plain
+        # Execution labels must not appear anywhere in preview.
+        assert "Merged:" not in plain
+        assert "Failed:" not in plain
+
+    def test_execute_counters_keep_execution_labels(self) -> None:
+        tracker = MergeProgressTracker(
+            "org",
+            operation_label="Merging PRs",
+            operation_icon="\u25b6\ufe0f",
+        )
+        tracker.rich_available = True
+        tracker.set_total_prs(2)
+        tracker.merge_success("org/repo#1")
+        tracker.merge_failure("org/repo#2")
+
+        plain = tracker._generate_display_text().plain
+        assert "\u2705 Merged: 1" in plain
+        assert "\u274c Failed: 1" in plain
+        assert "Mergeable" not in plain
+        assert "Would fail" not in plain
+
 
 class TestRecordTerminalOutcome:
     """_record_terminal_outcome maps MergeStatus onto tracker methods."""

--- a/tests/test_precommit_ci_trigger.py
+++ b/tests/test_precommit_ci_trigger.py
@@ -15,13 +15,16 @@ Covers:
 - Ruleset branch filtering (_ruleset_applies_to_branch)
 """
 
+from contextlib import ExitStack
 from datetime import datetime, timedelta, timezone
 from typing import Any
 from unittest.mock import AsyncMock, patch
 
 import pytest
 
+from dependamerge.github2gerrit_detector import GitHub2GerritDetectionResult
 from dependamerge.github_async import GitHubAsync
+from dependamerge.merge_manager import MergeStatus
 from dependamerge.models import PullRequestInfo
 
 
@@ -672,3 +675,167 @@ class TestRulesetAppliesToBranch:
         }
         assert self._method(cond, "main", default_branch="main") is False
         assert self._method(cond, "feature/x", default_branch="main") is True
+
+
+# ---------------------------------------------------------------------------
+# 9. Post-wait staleness re-check in _merge_single_pr (Step 5.5)
+# ---------------------------------------------------------------------------
+class TestPostWaitRetrigger:
+    """Step 5.5 must re-check pre-commit.ci staleness after its wait.
+
+    Step 0.5 only retriggers a run that was already stale when
+    processing started; a run that went pending shortly before the run
+    began crosses the stuck threshold *during* the Step 5.5 wait.
+    These tests drive ``_merge_single_pr`` with the wait mocked to
+    expire while the PR is still blocked and assert the retrigger is
+    invoked a second time (post-wait) and the flow routes correctly
+    afterwards.
+    """
+
+    @staticmethod
+    def _step5_5_patches(mgr, trigger_mock, merge_retry_mock):
+        """Common patch set to reach Step 5.5 with a blocked PR."""
+        no_g2g = GitHub2GerritDetectionResult()
+        return (
+            patch.object(
+                mgr,
+                "_detect_github2gerrit",
+                new_callable=AsyncMock,
+                return_value=no_g2g,
+            ),
+            patch.object(
+                mgr,
+                "_get_merge_method_for_repo",
+                new_callable=AsyncMock,
+                return_value="merge",
+            ),
+            patch.object(mgr, "_trigger_stale_precommit_ci", trigger_mock),
+            patch.object(
+                mgr,
+                "_check_merge_requirements",
+                new_callable=AsyncMock,
+                return_value=(True, ""),
+            ),
+            patch.object(
+                mgr,
+                "_blocked_pr_needs_rebase",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+            patch.object(
+                mgr,
+                "_approve_pr",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
+            patch.object(
+                mgr,
+                "_wait_for_auto_merge",
+                new_callable=AsyncMock,
+                return_value=(False, False),
+            ),
+            patch.object(mgr, "_merge_pr_with_retry", merge_retry_mock),
+        )
+
+    def _make_blocked_pr(self):
+        return _make_pr_info(
+            node_id="PR_kwDOTestNode42",
+            mergeable_state="blocked",
+            mergeable=True,
+            state="open",
+        )
+
+    @pytest.mark.asyncio
+    async def test_retrigger_fires_after_wait_and_detects_auto_merge(self):
+        """Post-wait retrigger succeeds; auto-merge landed the PR."""
+        mgr, client = _make_manager()
+        pr = self._make_blocked_pr()
+
+        client.enable_auto_merge = AsyncMock(return_value=True)
+        client.analyze_block_reason = AsyncMock(
+            return_value="Blocked by pending required check: pre-commit.ci - pr"
+        )
+        # Post-retrigger refresh: auto-merge fired the moment the
+        # check landed, so the PR is already closed and merged.
+        client.get = AsyncMock(return_value={"state": "closed", "merged": True})
+
+        # Step 0.5 finds the run not yet stale (False); the post-wait
+        # re-check finds it stuck and recovers it (True).
+        trigger = AsyncMock(side_effect=[False, True])
+        merge_retry = AsyncMock(return_value=True)
+
+        patches = self._step5_5_patches(mgr, trigger, merge_retry)
+        with ExitStack() as stack:
+            for p in patches:
+                stack.enter_context(p)
+            result = await mgr._merge_single_pr(pr)
+
+        assert trigger.await_count == 2
+        assert result.status == MergeStatus.MERGED
+        merge_retry.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_retrigger_failure_still_routes_to_auto_merge_pending(self):
+        """Retrigger cannot recover; flow falls through to Step 6."""
+        mgr, client = _make_manager()
+        pr = self._make_blocked_pr()
+
+        client.enable_auto_merge = AsyncMock(return_value=True)
+        client.analyze_block_reason = AsyncMock(
+            return_value="Blocked by pending required check: pre-commit.ci - pr"
+        )
+        client.get = AsyncMock(return_value={})
+
+        trigger = AsyncMock(return_value=False)
+        merge_retry = AsyncMock(return_value=True)
+
+        patches = self._step5_5_patches(mgr, trigger, merge_retry)
+        with ExitStack() as stack:
+            for p in patches:
+                stack.enter_context(p)
+            result = await mgr._merge_single_pr(pr)
+
+        # Called at Step 0.5 AND again after the wait expired.
+        assert trigger.await_count == 2
+        # Auto-merge is armed and the block reason is pending checks,
+        # so the run defers to auto-merge rather than failing.
+        assert result.status == MergeStatus.AUTO_MERGE_PENDING
+        merge_retry.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_retrigger_success_with_open_pr_proceeds_to_merge(self):
+        """Retrigger succeeds and the PR is now clean: manual merge runs."""
+        mgr, client = _make_manager()
+        pr = self._make_blocked_pr()
+
+        client.enable_auto_merge = AsyncMock(return_value=True)
+        client.analyze_block_reason = AsyncMock(
+            return_value="Blocked by pending required check: pre-commit.ci - pr"
+        )
+        # Post-retrigger refresh: still open, now clean.
+        client.get = AsyncMock(
+            return_value={
+                "state": "open",
+                "merged": False,
+                "mergeable": True,
+                "mergeable_state": "clean",
+                "head": {"sha": "def789refresh"},
+            }
+        )
+
+        trigger = AsyncMock(side_effect=[False, True])
+        merge_retry = AsyncMock(return_value=True)
+
+        patches = self._step5_5_patches(mgr, trigger, merge_retry)
+        with ExitStack() as stack:
+            for p in patches:
+                stack.enter_context(p)
+            result = await mgr._merge_single_pr(pr)
+
+        assert trigger.await_count == 2
+        # The refresh updated the snapshot from the live payload.
+        assert pr.mergeable_state == "clean"
+        assert pr.head_sha == "def789refresh"
+        # Clean state bypasses the auto-merge skip gate: manual merge.
+        merge_retry.assert_called_once()
+        assert result.status == MergeStatus.MERGED

--- a/tests/test_precommit_ci_trigger.py
+++ b/tests/test_precommit_ci_trigger.py
@@ -839,3 +839,47 @@ class TestPostWaitRetrigger:
         # Clean state bypasses the auto-merge skip gate: manual merge.
         merge_retry.assert_called_once()
         assert result.status == MergeStatus.MERGED
+
+    @pytest.mark.asyncio
+    async def test_refresh_ignores_still_computing_payload(self):
+        """A null/unknown refresh payload must not clobber the snapshot.
+
+        GitHub returns ``mergeable: null`` / ``mergeable_state:
+        "unknown"`` while recomputing mergeability right after the
+        check lands; the post-wait refresh must keep the known
+        concrete values so downstream routing is unchanged.
+        """
+        mgr, client = _make_manager()
+        pr = self._make_blocked_pr()
+
+        client.enable_auto_merge = AsyncMock(return_value=True)
+        client.analyze_block_reason = AsyncMock(
+            return_value="Blocked by pending required check: pre-commit.ci - pr"
+        )
+        # Post-retrigger refresh: GitHub is still recomputing.
+        client.get = AsyncMock(
+            return_value={
+                "state": "open",
+                "merged": False,
+                "mergeable": None,
+                "mergeable_state": "unknown",
+            }
+        )
+
+        trigger = AsyncMock(side_effect=[False, True])
+        merge_retry = AsyncMock(return_value=True)
+
+        patches = self._step5_5_patches(mgr, trigger, merge_retry)
+        with ExitStack() as stack:
+            for p in patches:
+                stack.enter_context(p)
+            result = await mgr._merge_single_pr(pr)
+
+        assert trigger.await_count == 2
+        # The concrete snapshot survives the transient payload.
+        assert pr.mergeable is True
+        assert pr.mergeable_state == "blocked"
+        # Still blocked with auto-merge armed and a pending-checks
+        # block reason: the run defers to auto-merge.
+        assert result.status == MergeStatus.AUTO_MERGE_PENDING
+        merge_retry.assert_not_called()

--- a/tests/test_reactive_behind_recovery.py
+++ b/tests/test_reactive_behind_recovery.py
@@ -1,0 +1,204 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 The Linux Foundation
+
+"""Tests for reactive behind-PR recovery after a rejected merge.
+
+Step 5 only rebases proactively when branch protection demands
+up-to-date heads.  When that probe misses (or the base moved after
+it ran) and GitHub rejects the merge with the PR ``behind``, the
+recovery is reactive:
+
+- ``_handle_merge_failure``: dependabot PRs get the ``@dependabot
+  rebase`` macro (signed rebase, no immediate retry) with auto-merge
+  armed; other authors keep the REST ``update-branch`` + retry path.
+- ``_merge_single_pr``'s not-merged classification: a behind PR left
+  with auto-merge armed reports ``AUTO_MERGE_PENDING`` instead of a
+  spurious failure.
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from dependamerge.github2gerrit_detector import GitHub2GerritDetectionResult
+from dependamerge.merge_manager import MergeStatus
+from dependamerge.models import PullRequestInfo
+from tests.conftest import make_merge_manager
+
+_BEHIND_PR = PullRequestInfo(
+    number=88,
+    node_id="PR_kwDOTestNode88",
+    title="Chore: Bump zizmor from 1.4.0 to 1.5.0",
+    body="Dependabot PR",
+    author="dependabot[bot]",
+    head_sha="abc123",
+    base_branch="main",
+    head_branch="dependabot/pip/zizmor-1.5.0",
+    state="open",
+    mergeable=True,
+    mergeable_state="behind",
+    behind_by=1,
+    files_changed=[],
+    repository_full_name="owner/repo",
+    html_url="https://github.com/owner/repo/pull/88",
+    reviews=[],
+    review_comments=[],
+)
+
+
+class TestHandleMergeFailureBehind:
+    """Reactive branch-refresh strategy after a rejected merge."""
+
+    @pytest.mark.asyncio
+    async def test_dependabot_behind_uses_macro_not_update_branch(self) -> None:
+        """Dependabot PR → macro + auto-merge armed, no REST update."""
+        mgr, client = make_merge_manager(fix_out_of_date=True)
+        client.get = AsyncMock(return_value=[])  # no existing comments
+        client.post_issue_comment = AsyncMock()
+        client.update_branch = AsyncMock()
+        arm = AsyncMock(return_value=True)
+
+        pr = _BEHIND_PR.model_copy()
+        with patch.object(mgr, "_enable_auto_merge_with_approval", arm):
+            should_retry = await mgr._handle_merge_failure(pr, "owner", "repo")
+
+        # No immediate retry: dependabot rebases asynchronously.
+        assert should_retry is False
+        client.post_issue_comment.assert_awaited_once_with(
+            "owner", "repo", 88, "@dependabot rebase"
+        )
+        client.update_branch.assert_not_awaited()
+        arm.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_dependabot_self_rebase_not_duplicated(self) -> None:
+        """A dependabot self-rebase in progress → no duplicate macro."""
+        mgr, client = make_merge_manager(fix_out_of_date=True)
+        client.get = AsyncMock(return_value=[])
+        client.post_issue_comment = AsyncMock()
+        client.update_branch = AsyncMock()
+        arm = AsyncMock(return_value=True)
+
+        pr = _BEHIND_PR.model_copy(update={"body": "Dependabot is rebasing this PR"})
+        with patch.object(mgr, "_enable_auto_merge_with_approval", arm):
+            should_retry = await mgr._handle_merge_failure(pr, "owner", "repo")
+
+        assert should_retry is False
+        client.post_issue_comment.assert_not_awaited()
+        client.update_branch.assert_not_awaited()
+        arm.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_non_dependabot_behind_uses_update_branch(self) -> None:
+        """Non-dependabot bots keep the REST update-branch + retry path."""
+        mgr, client = make_merge_manager(fix_out_of_date=True)
+        client.update_branch = AsyncMock()
+
+        pr = _BEHIND_PR.model_copy(update={"author": "pre-commit-ci[bot]"})
+        should_retry = await mgr._handle_merge_failure(pr, "owner", "repo")
+
+        assert should_retry is True
+        client.update_branch.assert_awaited_once_with("owner", "repo", 88)
+
+    @pytest.mark.asyncio
+    async def test_no_fix_disables_recovery(self) -> None:
+        """--no-fix → no macro, no update-branch, no retry."""
+        mgr, client = make_merge_manager(fix_out_of_date=False)
+        client.post_issue_comment = AsyncMock()
+        client.update_branch = AsyncMock()
+
+        should_retry = await mgr._handle_merge_failure(
+            _BEHIND_PR.model_copy(), "owner", "repo"
+        )
+
+        assert should_retry is False
+        client.post_issue_comment.assert_not_awaited()
+        client.update_branch.assert_not_awaited()
+
+
+class TestBehindAutoMergePendingClassification:
+    """Behind + auto-merge armed after a failed merge → AUTO_MERGE_PENDING."""
+
+    @pytest.mark.asyncio
+    async def test_failed_merge_with_armed_auto_merge_reports_pending(
+        self,
+    ) -> None:
+        mgr, client = make_merge_manager(
+            preview_mode=False, fix_out_of_date=True, merge_timeout=0.1
+        )
+        pr = _BEHIND_PR.model_copy()
+
+        # Behind + non-strict → Step 5 skips the rebase and Step 5.5
+        # skips the wait; the direct merge attempt fails, and the
+        # reactive recovery (exercised separately above) armed
+        # auto-merge for this PR.
+        client.requires_strict_status_checks = AsyncMock(return_value=False)
+        client.get = AsyncMock(
+            return_value={
+                "mergeable": True,
+                "mergeable_state": "behind",
+                "state": "open",
+                "merged": False,
+            }
+        )
+        client.get_required_status_checks = AsyncMock(return_value=[])
+
+        # The reactive recovery arms auto-merge *during* the failed
+        # merge attempt (inside ``_merge_pr_with_retry`` →
+        # ``_handle_merge_failure``), so mimic that here: the key is
+        # NOT armed when the Step 6 skip gate runs, only afterwards.
+        async def _fail_and_arm(
+            pr_info: PullRequestInfo, owner: str, repo: str
+        ) -> bool:
+            mgr._auto_merge_enabled.add("owner/repo#88")
+            return False
+
+        no_g2g = GitHub2GerritDetectionResult()
+        with (
+            patch.object(
+                mgr,
+                "_detect_github2gerrit",
+                new_callable=AsyncMock,
+                return_value=no_g2g,
+            ),
+            patch.object(
+                mgr,
+                "_get_merge_method_for_repo",
+                new_callable=AsyncMock,
+                return_value="merge",
+            ),
+            patch.object(
+                mgr,
+                "_trigger_stale_precommit_ci",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+            patch.object(
+                mgr,
+                "_check_merge_requirements",
+                new_callable=AsyncMock,
+                return_value=(True, ""),
+            ),
+            patch.object(
+                mgr,
+                "_approve_pr",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
+            patch.object(
+                mgr,
+                "_approve_and_retry_if_review_required",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+            patch.object(
+                mgr,
+                "_merge_pr_with_retry",
+                side_effect=_fail_and_arm,
+            ),
+        ):
+            result = await mgr._merge_single_pr(pr)
+
+        assert result.status == MergeStatus.AUTO_MERGE_PENDING
+        assert result.error is not None
+        assert "behind" in result.error

--- a/tests/test_strict_status_checks.py
+++ b/tests/test_strict_status_checks.py
@@ -1,0 +1,271 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 The Linux Foundation
+
+"""Tests for the strict up-to-date policy probe and Step 5 gating.
+
+A ``behind`` PR only needs a branch refresh before merging when the
+base branch's protection enforces the *strict* status-check policy
+("Require branches to be up to date before merging").  These tests
+cover:
+
+- ``GitHubAsync.requires_strict_status_checks`` (classic branch
+  protection + repository rulesets, caching, reliability semantics)
+- ``AsyncMergeManager._behind_pr_requires_rebase`` (the Step 5 gate
+  that consults the probe)
+"""
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from dependamerge.github_async import GitHubAsync
+from dependamerge.models import PullRequestInfo
+from tests.conftest import make_merge_manager
+
+_BEHIND_PR = PullRequestInfo(
+    number=77,
+    node_id="PR_kwDOTestNode77",
+    title="Chore: Bump step-security/harden-runner from 2.19.4 to 2.20.0",
+    body="Dependabot PR",
+    author="dependabot[bot]",
+    head_sha="abc123",
+    base_branch="main",
+    head_branch="dependabot/github_actions/harden-runner-2.20.0",
+    state="open",
+    mergeable=True,
+    mergeable_state="behind",
+    behind_by=1,
+    files_changed=[],
+    repository_full_name="owner/repo",
+    html_url="https://github.com/owner/repo/pull/77",
+    reviews=[],
+    review_comments=[],
+)
+
+
+def _api() -> AsyncMock:
+    """AsyncMock GitHubAsync with real ruleset-condition matching."""
+    api = AsyncMock(spec=GitHubAsync)
+    api.log = AsyncMock()
+    api.log.debug = lambda *a, **kw: None
+    api._ruleset_applies_to_branch = GitHubAsync._ruleset_applies_to_branch
+    return api
+
+
+def _ruleset_get(
+    rulesets: list[dict[str, Any]],
+    details: dict[int, dict[str, Any]],
+):
+    """Build a ``get`` side effect serving repo metadata + rulesets."""
+
+    async def _get(path: str, *args: Any, **kwargs: Any) -> Any:
+        if path == "/repos/owner/repo":
+            return {"default_branch": "main"}
+        if "/rulesets?" in path:
+            # Single page of rulesets (fewer than per_page entries, so
+            # the caller's pagination loop stops after one request).
+            return rulesets
+        for rs_id, detail in details.items():
+            if path.endswith(f"/rulesets/{rs_id}"):
+                return detail
+        raise AssertionError(f"unexpected GET {path}")
+
+    return _get
+
+
+class TestRequiresStrictStatusChecks:
+    """Classic + ruleset detection of the strict up-to-date policy."""
+
+    @pytest.mark.asyncio
+    async def test_classic_strict_policy_detected(self) -> None:
+        api = _api()
+        api.get_branch_protection = AsyncMock(
+            return_value={"required_status_checks": {"strict": True}}
+        )
+        result, reliable = await GitHubAsync._requires_strict_status_checks_uncached(
+            api, "owner", "repo", "main"
+        )
+        assert result is True
+        assert reliable is True
+
+    @pytest.mark.asyncio
+    async def test_classic_non_strict_without_rulesets(self) -> None:
+        api = _api()
+        api.get_branch_protection = AsyncMock(
+            return_value={"required_status_checks": {"strict": False}}
+        )
+        api.get = AsyncMock(side_effect=_ruleset_get([], {}))
+        result, reliable = await GitHubAsync._requires_strict_status_checks_uncached(
+            api, "owner", "repo", "main"
+        )
+        assert result is False
+        assert reliable is True
+
+    @pytest.mark.asyncio
+    async def test_no_protection_at_all(self) -> None:
+        api = _api()
+        # get_branch_protection maps 404 to {} itself.
+        api.get_branch_protection = AsyncMock(return_value={})
+        api.get = AsyncMock(side_effect=_ruleset_get([], {}))
+        result, reliable = await GitHubAsync._requires_strict_status_checks_uncached(
+            api, "owner", "repo", "main"
+        )
+        assert result is False
+        assert reliable is True
+
+    @pytest.mark.asyncio
+    async def test_ruleset_strict_policy_detected(self) -> None:
+        api = _api()
+        api.get_branch_protection = AsyncMock(return_value={})
+        detail = {
+            "id": 7,
+            "enforcement": "active",
+            "name": "main protection",
+            "conditions": {"ref_name": {"include": ["~DEFAULT_BRANCH"]}},
+            "rules": [
+                {
+                    "type": "required_status_checks",
+                    "parameters": {
+                        "strict_required_status_checks_policy": True,
+                        "required_status_checks": [{"context": "build"}],
+                    },
+                }
+            ],
+        }
+        api.get = AsyncMock(side_effect=_ruleset_get([{"id": 7}], {7: detail}))
+        result, reliable = await GitHubAsync._requires_strict_status_checks_uncached(
+            api, "owner", "repo", "main"
+        )
+        assert result is True
+        assert reliable is True
+
+    @pytest.mark.asyncio
+    async def test_ruleset_without_strict_policy_is_false(self) -> None:
+        api = _api()
+        api.get_branch_protection = AsyncMock(return_value={})
+        detail = {
+            "id": 7,
+            "enforcement": "active",
+            "name": "main protection",
+            "conditions": {"ref_name": {"include": ["~DEFAULT_BRANCH"]}},
+            "rules": [
+                {
+                    "type": "required_status_checks",
+                    "parameters": {
+                        "strict_required_status_checks_policy": False,
+                        "required_status_checks": [{"context": "build"}],
+                    },
+                }
+            ],
+        }
+        api.get = AsyncMock(side_effect=_ruleset_get([{"id": 7}], {7: detail}))
+        result, reliable = await GitHubAsync._requires_strict_status_checks_uncached(
+            api, "owner", "repo", "main"
+        )
+        assert result is False
+        assert reliable is True
+
+    @pytest.mark.asyncio
+    async def test_inactive_ruleset_is_ignored(self) -> None:
+        api = _api()
+        api.get_branch_protection = AsyncMock(return_value={})
+        detail = {
+            "id": 7,
+            "enforcement": "disabled",
+            "conditions": {"ref_name": {"include": ["~ALL"]}},
+            "rules": [
+                {
+                    "type": "required_status_checks",
+                    "parameters": {"strict_required_status_checks_policy": True},
+                }
+            ],
+        }
+        api.get = AsyncMock(side_effect=_ruleset_get([{"id": 7}], {7: detail}))
+        result, reliable = await GitHubAsync._requires_strict_status_checks_uncached(
+            api, "owner", "repo", "main"
+        )
+        assert result is False
+        assert reliable is True
+
+    @pytest.mark.asyncio
+    async def test_api_errors_yield_unreliable_false(self) -> None:
+        api = _api()
+        api.get_branch_protection = AsyncMock(side_effect=Exception("boom"))
+        api.get = AsyncMock(side_effect=Exception("boom"))
+        result, reliable = await GitHubAsync._requires_strict_status_checks_uncached(
+            api, "owner", "repo", "main"
+        )
+        assert result is False
+        # Error-derived False verdicts are flagged unreliable so the
+        # public method will not cache them.
+        assert reliable is False
+
+    @pytest.mark.asyncio
+    async def test_reliable_verdict_is_cached(self) -> None:
+        api = _api()
+        api._requires_strict_checks_cache = {}
+        api._requires_strict_status_checks_uncached = AsyncMock(
+            return_value=(True, True)
+        )
+        first = await GitHubAsync.requires_strict_status_checks(api, "owner", "repo")
+        second = await GitHubAsync.requires_strict_status_checks(api, "owner", "repo")
+        assert first is True
+        assert second is True
+        api._requires_strict_status_checks_uncached.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_unreliable_verdict_not_cached(self) -> None:
+        api = _api()
+        api._requires_strict_checks_cache = {}
+        api._requires_strict_status_checks_uncached = AsyncMock(
+            return_value=(False, False)
+        )
+        await GitHubAsync.requires_strict_status_checks(api, "owner", "repo")
+        await GitHubAsync.requires_strict_status_checks(api, "owner", "repo")
+        assert api._requires_strict_status_checks_uncached.await_count == 2
+        assert api._requires_strict_checks_cache == {}
+
+
+class TestBehindPrRequiresRebase:
+    """Step 5 gate: rebase a behind PR only under the strict policy."""
+
+    @pytest.mark.asyncio
+    async def test_strict_policy_requires_rebase(self) -> None:
+        mgr, client = make_merge_manager(fix_out_of_date=True)
+        client.requires_strict_status_checks = AsyncMock(return_value=True)
+
+        assert await mgr._behind_pr_requires_rebase(
+            _BEHIND_PR.model_copy(), "owner", "repo"
+        )
+
+    @pytest.mark.asyncio
+    async def test_non_strict_policy_skips_rebase(self) -> None:
+        mgr, client = make_merge_manager(fix_out_of_date=True)
+        client.requires_strict_status_checks = AsyncMock(return_value=False)
+
+        assert not await mgr._behind_pr_requires_rebase(
+            _BEHIND_PR.model_copy(), "owner", "repo"
+        )
+
+    @pytest.mark.asyncio
+    async def test_probe_failure_skips_rebase(self) -> None:
+        """Probe errors fail to 'no rebase': the merge attempt decides."""
+        mgr, client = make_merge_manager(fix_out_of_date=True)
+        client.requires_strict_status_checks = AsyncMock(
+            side_effect=RuntimeError("boom")
+        )
+
+        assert not await mgr._behind_pr_requires_rebase(
+            _BEHIND_PR.model_copy(), "owner", "repo"
+        )
+
+    @pytest.mark.asyncio
+    async def test_truthy_non_true_verdict_skips_rebase(self) -> None:
+        """AsyncMock-default truthy values must not trigger rebases."""
+        mgr, client = make_merge_manager(fix_out_of_date=True)
+        client.requires_strict_status_checks = AsyncMock(return_value=MagicMock())
+
+        assert not await mgr._behind_pr_requires_rebase(
+            _BEHIND_PR.model_copy(), "owner", "repo"
+        )

--- a/tests/test_transient_merge_errors.py
+++ b/tests/test_transient_merge_errors.py
@@ -735,3 +735,346 @@ class TestFailureSummarySurfacesGitHubDetail:
         # The actionable GitHub message is returned, trimmed of the
         # appended PR-state context.
         assert summary == "Required workflows 'Autolabeler' are not satisfied"
+
+
+# -------------------------------------------------------------------
+# Pending required-workflows classification and recovery
+# -------------------------------------------------------------------
+
+
+def _make_405_workflows_not_satisfied_exception() -> Exception:
+    """405 carrying GitHub's "Required workflows ... not satisfied" body.
+
+    Mirrors the enhanced error produced by ``_validate_merge_result``
+    when ruleset-required workflows are still *executing* on the head
+    commit — a pending condition, not a terminal failure.
+    """
+    return Exception(
+        "Failed to merge PR #39 in org/repo. Error: Client error "
+        "'405 Method Not Allowed' for url "
+        "'https://api.github.com/repos/org/repo/pulls/39/merge'. "
+        "GitHub: Repository rule violations found Required workflows "
+        "'Verify Token Permissions' are not satisfied (PR state: open, "
+        "mergeable: True, mergeable_state: blocked) "
+        "[blocked by branch protection / required checks]"
+    )
+
+
+def _make_405_workflows_failed_exception() -> Exception:
+    """405 whose required-workflows clause reports a *failure*."""
+    return Exception(
+        "Failed to merge PR #39 in org/repo. Error: Client error "
+        "'405 Method Not Allowed' for url "
+        "'https://api.github.com/repos/org/repo/pulls/39/merge'. "
+        "GitHub: Repository rule violations found Required workflows "
+        "'Verify Token Permissions' failed (PR state: open, "
+        "mergeable: True, mergeable_state: blocked)"
+    )
+
+
+class TestMergeErrorIndicatesPendingWorkflows:
+    """Classification of 405 required-workflows rejection bodies."""
+
+    def _mgr(self) -> AsyncMergeManager:
+        mgr, _client = make_merge_manager(merge_method="merge")
+        return mgr
+
+    def test_not_satisfied_is_pending(self):
+        """ "not satisfied" (workflows still executing) is pending."""
+        mgr = self._mgr()
+        exc = _make_405_workflows_not_satisfied_exception()
+        assert mgr._merge_error_indicates_pending_workflows(str(exc)) is True
+
+    def test_failed_variant_is_terminal(self):
+        """A workflow that ran and failed must stay terminal."""
+        mgr = self._mgr()
+        exc = _make_405_workflows_failed_exception()
+        assert mgr._merge_error_indicates_pending_workflows(str(exc)) is False
+
+    def test_leading_failed_to_merge_prefix_does_not_poison(self):
+        """The "Failed to merge PR" prefix must not read as failure.
+
+        Only the clause from the ``required workflow`` wording onward
+        is inspected; the enhanced exception text always starts with
+        "Failed to merge PR …".
+        """
+        mgr = self._mgr()
+        text = (
+            "Failed to merge PR #39 in org/repo. "
+            "GitHub: Required workflows 'CI' are not satisfied"
+        )
+        assert mgr._merge_error_indicates_pending_workflows(text) is True
+
+    def test_pr_state_suffix_is_trimmed(self):
+        """Failure wording after the PR-state context is ignored."""
+        mgr = self._mgr()
+        text = (
+            "Failed to merge PR #39 in org/repo. "
+            "GitHub: Required workflows 'CI' are not satisfied "
+            "(PR state: open, mergeable: False, mergeable_state: "
+            "blocked) [blocked by failing checks]"
+        )
+        assert mgr._merge_error_indicates_pending_workflows(text) is True
+
+    def test_required_status_checks_not_matched(self):
+        """Status-check violations are a different condition."""
+        mgr = self._mgr()
+        text = (
+            "Failed to merge PR #39 in org/repo. "
+            "GitHub: Repository rule violations found Required status "
+            'check "pre-commit.ci - pr" is expected.'
+        )
+        assert mgr._merge_error_indicates_pending_workflows(text) is False
+
+    def test_empty_text_returns_false(self):
+        mgr = self._mgr()
+        assert mgr._merge_error_indicates_pending_workflows("") is False
+
+
+class TestWaitForRequiredWorkflowsAndRetry:
+    """Behaviour of the pending-workflows wait-and-retry recovery."""
+
+    def _make_mgr(self, **overrides):
+        defaults = {"merge_method": "merge", "preview_mode": False}
+        defaults.update(overrides)
+        return make_merge_manager(**defaults)
+
+    @pytest.mark.asyncio
+    async def test_preview_mode_returns_false_without_side_effects(self):
+        mgr, client = self._make_mgr(preview_mode=True)
+        pr = _make_pr_info(mergeable_state="blocked")
+
+        result = await mgr._wait_for_required_workflows_and_retry(pr, "org", "repo")
+
+        assert result is False
+        client.merge_pull_request.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_merged_during_wait_returns_true(self):
+        mgr, client = self._make_mgr()
+        pr = _make_pr_info(mergeable_state="blocked")
+        client.get = AsyncMock(
+            return_value={
+                "mergeable": True,
+                "mergeable_state": "blocked",
+                "state": "open",
+            }
+        )
+
+        with patch.object(
+            mgr,
+            "_wait_for_auto_merge",
+            new_callable=AsyncMock,
+            return_value=(True, True),
+        ):
+            result = await mgr._wait_for_required_workflows_and_retry(pr, "org", "repo")
+
+        assert result is True
+        client.merge_pull_request.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_closed_without_merge_returns_false(self):
+        mgr, client = self._make_mgr()
+        pr = _make_pr_info(mergeable_state="blocked")
+        client.get = AsyncMock(return_value={})
+
+        with patch.object(
+            mgr,
+            "_wait_for_auto_merge",
+            new_callable=AsyncMock,
+            return_value=(True, False),
+        ):
+            result = await mgr._wait_for_required_workflows_and_retry(pr, "org", "repo")
+
+        assert result is False
+        client.merge_pull_request.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_wait_then_merge_succeeds(self):
+        """Workflows finish during the wait; the retry lands the merge."""
+        mgr, client = self._make_mgr()
+        pr = _make_pr_info(mergeable_state="blocked")
+        client.get = AsyncMock(
+            return_value={
+                "mergeable": True,
+                "mergeable_state": "blocked",
+                "state": "open",
+            }
+        )
+        client.merge_pull_request = AsyncMock(return_value=True)
+
+        with patch.object(
+            mgr,
+            "_wait_for_auto_merge",
+            new_callable=AsyncMock,
+            return_value=(False, False),
+        ):
+            result = await mgr._wait_for_required_workflows_and_retry(pr, "org", "repo")
+
+        assert result is True
+        client.merge_pull_request.assert_awaited_once_with("org", "repo", 39, "merge")
+
+    @pytest.mark.asyncio
+    async def test_different_rejection_reason_stops_recovery(self):
+        """A changed rejection reason is left to the caller's classifier."""
+        mgr, client = self._make_mgr()
+        pr = _make_pr_info(mergeable_state="blocked")
+        client.get = AsyncMock(return_value={})
+        terminal_exc = _make_405_workflows_failed_exception()
+        client.merge_pull_request = AsyncMock(side_effect=terminal_exc)
+
+        with patch.object(
+            mgr,
+            "_wait_for_auto_merge",
+            new_callable=AsyncMock,
+            return_value=(False, False),
+        ):
+            result = await mgr._wait_for_required_workflows_and_retry(pr, "org", "repo")
+
+        assert result is False
+        # The terminal exception is stored for failure reporting.
+        assert mgr._last_merge_exception["org/repo#39"] is terminal_exc
+        client.merge_pull_request.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_still_pending_at_deadline_returns_false(self):
+        """Workflows never finish: recovery is bounded by merge_timeout."""
+        mgr, client = self._make_mgr(merge_timeout=0.1)
+        pr = _make_pr_info(mergeable_state="blocked")
+        client.get = AsyncMock(
+            return_value={
+                "mergeable": True,
+                "mergeable_state": "blocked",
+                "state": "open",
+            }
+        )
+        client.merge_pull_request = AsyncMock(
+            side_effect=_make_405_workflows_not_satisfied_exception()
+        )
+
+        with patch.object(
+            mgr,
+            "_wait_for_auto_merge",
+            new_callable=AsyncMock,
+            return_value=(False, False),
+        ):
+            result = await mgr._wait_for_required_workflows_and_retry(pr, "org", "repo")
+
+        assert result is False
+        # At least one retry was dispatched before the budget expired.
+        assert client.merge_pull_request.await_count >= 1
+
+
+class TestPendingWorkflowsMergeSinglePrRouting:
+    """_merge_single_pr routes 405 pending-workflows rejections to recovery."""
+
+    def _patches(self, mgr, merge_retry, wf_recovery):
+        from dependamerge.github2gerrit_detector import (
+            GitHub2GerritDetectionResult,
+        )
+
+        no_g2g = GitHub2GerritDetectionResult()
+        return (
+            patch.object(
+                mgr,
+                "_detect_github2gerrit",
+                new_callable=AsyncMock,
+                return_value=no_g2g,
+            ),
+            patch.object(
+                mgr,
+                "_get_merge_method_for_repo",
+                new_callable=AsyncMock,
+                return_value="merge",
+            ),
+            patch.object(
+                mgr,
+                "_trigger_stale_precommit_ci",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+            patch.object(
+                mgr,
+                "_check_merge_requirements",
+                new_callable=AsyncMock,
+                return_value=(True, ""),
+            ),
+            patch.object(
+                mgr,
+                "_approve_and_retry_if_review_required",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+            patch.object(
+                mgr,
+                "_fetch_pr_state_now",
+                new_callable=AsyncMock,
+                return_value=("open", False),
+            ),
+            patch.object(
+                mgr,
+                "_detect_stuck_required_check",
+                new_callable=AsyncMock,
+                return_value=(False, None, 0.0),
+            ),
+            patch.object(mgr, "_merge_pr_with_retry", merge_retry),
+            patch.object(mgr, "_wait_for_required_workflows_and_retry", wf_recovery),
+        )
+
+    @pytest.mark.asyncio
+    async def test_not_satisfied_rejection_invokes_recovery(self):
+        """ "not satisfied" → wait-and-retry recovery merges the PR."""
+        from contextlib import ExitStack
+
+        from dependamerge.merge_manager import MergeStatus
+
+        mgr, client = make_merge_manager(merge_method="merge", preview_mode=False)
+        pr = _make_pr_info(mergeable_state="clean", mergeable=True)
+        client.get = AsyncMock(return_value={})
+        client.get_required_status_checks = AsyncMock(return_value=[])
+
+        async def failing_merge(pr_info, owner, repo):
+            mgr._last_merge_exception[f"{owner}/{repo}#{pr_info.number}"] = (
+                _make_405_workflows_not_satisfied_exception()
+            )
+            return False
+
+        merge_retry = AsyncMock(side_effect=failing_merge)
+        wf_recovery = AsyncMock(return_value=True)
+
+        with ExitStack() as stack:
+            for p in self._patches(mgr, merge_retry, wf_recovery):
+                stack.enter_context(p)
+            result = await mgr._merge_single_pr(pr)
+
+        wf_recovery.assert_awaited_once()
+        assert result.status == MergeStatus.MERGED
+
+    @pytest.mark.asyncio
+    async def test_failed_rejection_skips_recovery(self):
+        """ "failed" → terminal: no wait-and-retry, PR reported failed."""
+        from contextlib import ExitStack
+
+        from dependamerge.merge_manager import MergeStatus
+
+        mgr, client = make_merge_manager(merge_method="merge", preview_mode=False)
+        pr = _make_pr_info(mergeable_state="clean", mergeable=True)
+        client.get = AsyncMock(return_value={})
+        client.get_required_status_checks = AsyncMock(return_value=[])
+
+        async def failing_merge(pr_info, owner, repo):
+            mgr._last_merge_exception[f"{owner}/{repo}#{pr_info.number}"] = (
+                _make_405_workflows_failed_exception()
+            )
+            return False
+
+        merge_retry = AsyncMock(side_effect=failing_merge)
+        wf_recovery = AsyncMock(return_value=True)
+
+        with ExitStack() as stack:
+            for p in self._patches(mgr, merge_retry, wf_recovery):
+                stack.enter_context(p)
+            result = await mgr._merge_single_pr(pr)
+
+        wf_recovery.assert_not_awaited()
+        assert result.status == MergeStatus.FAILED


### PR DESCRIPTION
## Summary

Merge-pipeline fixes from production-observed bulk merge runs. The first two changes continue the theme from #362: trust GitHub's authoritative signals and wait/retrigger where the condition is pending, failing fast only when it is genuinely terminal. The later changes extend that principle to rebasing — perform branch refreshes only when GitHub actually requires them — and port the Rich counter output to the preview (no `--no-confirm`) pass.

## Changes

### Retrigger stuck pre-commit.ci runs after the merge wait

- **Root cause**: the Step 0.5 staleness probe only retriggers a `pre-commit.ci - pr` run that was already pending for more than 300s when PR processing *started*. A run that went pending shortly before the run began ages past the stuck threshold *during* the Step 5.5 auto-merge wait, but nothing re-evaluated staleness there — the wait expired and the merge failed on the still-pending check without the `pre-commit.ci run` recovery macro ever being posted. Observed on `lfreleng-actions/test-makefile-helm-chart#70`: failed after 5m20s with "Required status checks not satisfied" and no retrigger comment.
- **Fix**: re-check pre-commit.ci staleness when the Step 5.5 wait exits with the PR still blocked. The helper re-gates on required-check status, pending age, and duplicate trigger comments, so the re-check is a no-op unless the run is genuinely stuck. When the retrigger recovers the check, the PR snapshot is refreshed and a PR that auto-merge already landed is short-circuited to MERGED instead of attempting a doomed manual merge.

### Treat merge-time "workflows not satisfied" rejections as pending

- **Root cause**: #362 taught the *pre-merge* block-reason analysis to recognise still-running ruleset workflows, but that only helps when the block is visible before the merge is dispatched. When GitHub rejects the merge itself with 405 "Repository rule violations found / Required workflows … are not satisfied" (ruleset-required workflows still *executing* on the head commit), the merge-error classifier treated it like any other 405 — a permanent error — and failed the PR. Observed on `lfreleng-actions/http-api-tool-docker#313`, which went green on its own minutes later.
- **Fix**: classify the two rejection variants apart — "not satisfied" (still running → pending) vs "failed" (a workflow ran and reported failure → terminal). Pending rejections route to a new wait-and-retry recovery that alternates between waiting for the PR to leave a blocked/unstable state and re-dispatching a single merge, under one shared `merge_timeout` deadline so the recovery cannot double-spend the wait budget. Skipped when Step 5/5.5 already spent the PR's wait budget and under `--force=all`. Classification inspects only the clause from the "required workflow" wording onward, because the enhanced exception text always begins with "Failed to merge PR" and would otherwise read as terminal.

### Rebase only when GitHub requires it

- **Root cause**: Step 5 proactively rebased every `behind` PR. In same-repo batches every sibling merge put the remaining PRs `behind`, so each was rebased in turn: all required CI checks restarted (minutes per PR), the local clone+rebase+sign workflow fired on signature-requiring repos (interactive signing-key prompts, e.g. a YubiKey PIN), and merges then failed spuriously with 405 "Required workflows are not satisfied" because the restarted checks had not completed. Observed at the tail of an owner-wide run over `lftools-uv` (14 dependabot PRs): merging slowed to a crawl and ~9 PRs reported spurious failures.
- **Fix**: GitHub only refuses to merge a behind-but-green PR when branch protection enforces the strict status-check policy ("require branches to be up to date before merging"), so:
  - Step 5 probes that policy (new `requires_strict_status_checks`, classic protection + rulesets, cached per repo/branch) and otherwise sends behind PRs straight to the merge attempt.
  - Behind PRs no longer enter the Step 5.5 auto-merge wait, which burned `merge_timeout` before a merge that was going to succeed anyway.
  - The blocked-masks-behind staleness probe fires only for failing/missing required checks; pending checks resolve on their own and never justify a rebase.
  - Dependabot PRs that would take the local-rebase path use the `@dependabot rebase` macro instead: dependabot force-pushes a freshly *signed* rebase, so the operator's signing key is never touched. The local path remains for `pre-commit-ci[bot]` (no macro exists).
  - Reactive recovery when a merge is still rejected with the PR `behind`: dependabot PRs get the rebase macro with auto-merge armed (reported as AUTO_MERGE_PENDING rather than a failure); other authors keep the REST update-branch retry.

### Analyze the block reason once per PR

- **Root cause**: `analyze_block_reason()` costs ~4 API calls (reviews, comments, check runs, combined status) and blocked PRs paid it two to three times against the same snapshot (Step 5 staleness probe, Step 5.5 wait pre-check, Step 6 skip gate). Combined with the global rate limiter this deepened the lock-step ~30s merge waves observed in production.
- **Fix**: compute the analysis once at the top of `_merge_single_pr` and pass it through; the Step 6 gate re-analyzes only when the snapshot changed (a Step 5 rebase or a Step 5.5 wait ran in between).

### Use accurate preview counters

- **Root cause**: the preview (no `--no-confirm`) pass never received the Rich counter treatment the execute pass got: it printed one `☑️ Approve/merge:` console line per PR (duplicating the grouped PR listing shown beforehand) and the live counter claimed `✅ Merged: 42` when nothing had been merged.
- **Fix**: per-PR status lines go to the log only in preview too; the tracker heading reads "Evaluating PRs" and its counters use evaluation labels — "Mergeable" instead of "Merged", "Would fail" instead of "Failed" (neutral categories keep their names). The preview confirmation prompt now reports not-mergeable PRs (URL plus reason) via the shared failed-PR detail report, mirroring the execute pass where reasons appear only in the end-of-run summary.
- **Follow-up**: the confirmed-merge pass printed a redundant "🔨 Merging N mergeable pull requests..." banner immediately before the "🚀 Merging N pull requests..." banner and the Rich tracker heading; the duplicate line is removed from all three confirmed-merge paths (single-PR, repo, and owner modes) and the README sample output updated to match.

### Wait for asynchronous Step 5 rebases to land

- **Root cause** (Copilot review catch): the "rebase only when required" change stopped treating `behind` as waitable in Step 5.5, but the local force-push and `@dependabot rebase` macro paths deliberately leave `_rebased_prs` unset when auto-merge cannot be armed so that Step 5.5 can bridge the gap while the rebase lands. Neither path refreshes `pr_info`, so the snapshot still read `behind`, the wait was skipped, and Step 6 fired a manual merge against the stale state — yielding avoidable transient 405s.
- **Fix**: admit `behind` into the Step 5.5 wait only when Step 5 actually dispatched a rebase for the PR (`needs_rebase`); the existing `already_rebased` guard keeps the auto-merge-armed case out of the wait, and behind PRs that never needed a rebase still merge directly.

### Decompose the close command

- basedpyright flagged the ~400-line `close` command as too complex to analyze. It now follows the merge pipeline's shape: a `_CloseContext` dataclass carries shared state and each phase (override validation, similar-PR search, analysis summary, dry-run, interactive close, immediate close) lives in a dedicated helper. No behavior change; also removes two dead `merged_count` assignments left by the banner cleanup and parameterizes a bare `list` annotation in `test_blocked_masks_behind.py`.

## Testing

- Post-wait retrigger tests driving `_merge_single_pr` end-to-end (`test_precommit_ci_trigger.py`): recovery detected as auto-merge landing (MERGED), retrigger failure falling through to AUTO_MERGE_PENDING, and refresh-then-manual-merge for a recovered-but-open PR.
- Classification and recovery tests for the pending-workflows path (`test_transient_merge_errors.py`): not-satisfied vs failed variants, "Failed to merge PR" prefix and PR-state suffix immunity, preview-mode guard, merged/closed-during-wait outcomes, wait-then-retry success, reason-change abort, deadline bounding, and `_merge_single_pr` routing for both variants.
- Strict-policy probe tests (`test_strict_status_checks.py`): classic + ruleset detection, caching/reliability semantics, and the Step 5 gate (including AsyncMock-default immunity).
- Reactive recovery tests (`test_reactive_behind_recovery.py`): dependabot macro vs REST update-branch routing, self-rebase dedupe, `--no-fix` guard, and the behind+armed AUTO_MERGE_PENDING classification.
- Rebase dispatch tests (`test_local_rebase_signing.py`): dependabot + signature repo takes the macro path (no local rebase, no REST update-branch), macro-post failure falls back to local; existing local/REST invariants updated for the strict-policy gate.
- Behind-PR routing tests (`test_behind_pr_handling.py`, `test_auto_merge.py`, `test_blocked_masks_behind.py`): non-strict behind PRs merge directly with no rebase and no Step 5.5 wait; the staleness probe rejects pending-check reasons.
- Preview counter tests (`test_merge_state_tracking.py`, `test_behind_pr_handling.py`): "Mergeable"/"Would fail" labels in preview, execution labels unchanged, and zero per-PR console lines in preview.
- Step 5.5 async-rebase gate tests (`test_auto_merge.py`, `TestStep5_5BehindAfterAsyncRebase`): async rebase without auto-merge enters the bounded wait, async rebase with auto-merge armed skips it, and behind-without-rebase still merges directly.
- Full suite: 1416 passed, 13 skipped. `prek run --all-files` green; no editor/basedpyright errors or warnings other than the pre-existing complexity warning deferred to a separate refactor.

