### PR TITLE
Fix: Add --override gate for human-authored Gerrit changes

### DIFF
--- a/src/dependamerge/cli.py
+++ b/src/dependamerge/cli.py
@@ -155,6 +155,21 @@ def _generate_override_sha(
     return sha_hash[:16]
 
 
+def _generate_gerrit_override_sha(change: GerritChangeInfo) -> str:
+    """
+    Generate a SHA hash based on Gerrit change owner and subject.
+
+    Args:
+        change: Gerrit change information containing owner and subject
+
+    Returns:
+        SHA256 hash string
+    """
+    combined_data = f"{change.owner}:{change.subject.strip()}"
+    sha_hash = hashlib.sha256(combined_data.encode("utf-8")).hexdigest()
+    return sha_hash[:16]
+
+
 def _validate_override_sha(
     provided_sha: str, pr_info: PullRequestInfo, commit_message_first_line: str
 ) -> bool:
@@ -643,7 +658,7 @@ def _maybe_check_merge_permissions(ctx: _MergeContext) -> None:
     """
     if ctx.dry_run:
         console.print(
-            "🧪 Dry run: skipping token permission check " "(no changes will be made)"
+            "🧪 Dry run: skipping token permission check (no changes will be made)"
         )
         return
     _check_merge_permissions(ctx)
@@ -1834,6 +1849,7 @@ def _handle_gerrit_merge(
     netrc_file: Path | None = None,
     netrc_optional: bool = True,
     dry_run: bool = False,
+    override: str | None = None,
 ) -> None:
     """
     Handle merge operation for a Gerrit change URL.
@@ -1849,6 +1865,7 @@ def _handle_gerrit_merge(
         netrc_optional: If True, don't fail if netrc not found.
         dry_run: If True, preview only and never review or submit any
             change, even when ``no_confirm`` is also set.
+        override: SHA hash to override non-automation change restriction.
     """
     # Resolve Gerrit credentials from all sources using centralized function
     try:
@@ -1911,6 +1928,42 @@ def _handle_gerrit_merge(
             console.print("\n❌ Change has been abandoned.")
             raise typer.Exit(1)
 
+        comparator = create_gerrit_comparator(similarity_threshold=similarity_threshold)
+
+        source_is_automation = comparator.is_automation_change(source_change)
+        if source_is_automation:
+            only_automation = True
+        else:
+            expected_sha = _generate_gerrit_override_sha(source_change)
+            if not override:
+                console.print("Source change is not from a recognized automation tool.")
+                console.print(
+                    "To submit this and similar changes, run again with: "
+                    f"--override {expected_sha}"
+                )
+                console.print(
+                    f"This SHA is based on the owner "
+                    f"'{source_change.owner}' and subject "
+                    f"'{source_change.subject[:50]}...'",
+                    style="dim",
+                )
+                raise typer.Exit(0)
+
+            if override != expected_sha:
+                exit_with_error(
+                    ExitCode.VALIDATION_ERROR,
+                    message="❌ Invalid override SHA provided",
+                    details=(
+                        "Expected SHA for this change and owner: "
+                        f"--override {expected_sha}"
+                    ),
+                )
+
+            console.print(
+                "Override SHA validated. Proceeding with non-automation change merge."
+            )
+            only_automation = False
+
         # Check for merge conflicts and attempt rebase if needed
         if source_change.mergeable is False:
             console.print("\n⚠️ Change has merge conflicts. Attempting to rebase...")
@@ -1943,12 +1996,11 @@ def _handle_gerrit_merge(
                 console.print(f"\n❌ Rebase failed: {rebase_result['error']}")
                 raise typer.Exit(1)
 
-        comparator = create_gerrit_comparator(similarity_threshold=similarity_threshold)
-
         console.print(f"\n🔍 Searching for similar changes on {parsed_url.host}...")
         similar_changes = service.find_similar_changes(
             source_change,
             comparator,
+            only_automation=only_automation,
         )
 
         console.print(f"Found {len(similar_changes)} similar changes:")
@@ -2075,7 +2127,9 @@ def merge(
         None, "--token", help="GitHub token (or set GITHUB_TOKEN env var)"
     ),
     override: str | None = typer.Option(
-        None, "--override", help="SHA hash to override non-automation PR restriction"
+        None,
+        "--override",
+        help="SHA hash to override non-automation PR/change restriction",
     ),
     no_fix: bool = typer.Option(
         False,
@@ -2362,6 +2416,7 @@ def merge(
             netrc_file=netrc_file,
             netrc_optional=netrc_optional,
             dry_run=dry_run,
+            override=override,
         )
         return
 
@@ -2751,15 +2806,13 @@ def _print_close_debug_matching(
         f"{ctx.github_client.is_automation_author(source_pr.author)}"
     )
     console.print(
-        "   Extracted package: "
-        f"'{comparator._extract_package_name(source_pr.title)}'"
+        f"   Extracted package: '{comparator._extract_package_name(source_pr.title)}'"
     )
     console.print(f"   Similarity threshold: {similarity_threshold}")
     if source_pr.body:
         console.print(f"   Body preview: {source_pr.body[:100]}...")
         console.print(
-            "   Is dependabot body: "
-            f"{comparator._is_dependabot_body(source_pr.body)}"
+            f"   Is dependabot body: {comparator._is_dependabot_body(source_pr.body)}"
         )
     else:
         console.print("   ⚠️ Source PR has no body")
@@ -2896,7 +2949,7 @@ def _run_close_dry_run(
         console.print()
     else:
         console.print(
-            f"\n🧪 Dry run: evaluating {len(all_prs_to_close)} " "pull requests..."
+            f"\n🧪 Dry run: evaluating {len(all_prs_to_close)} pull requests..."
         )
 
     close_results = _run_close_parallel(ctx, all_prs_to_close, True)

--- a/src/dependamerge/cli.py
+++ b/src/dependamerge/cli.py
@@ -1936,6 +1936,7 @@ def _handle_gerrit_merge(
         else:
             expected_sha = _generate_gerrit_override_sha(source_change)
             if not override:
+                owner = source_change.owner.strip()
                 subject = source_change.subject.strip()
                 subject_preview = (
                     subject if len(subject) <= 50 else f"{subject[:50]}..."
@@ -1947,7 +1948,7 @@ def _handle_gerrit_merge(
                 )
                 console.print(
                     f"This SHA is based on the owner "
-                    f"'{source_change.owner}' and subject "
+                    f"'{owner}' and subject "
                     f"'{subject_preview}'",
                     style="dim",
                 )

--- a/src/dependamerge/cli.py
+++ b/src/dependamerge/cli.py
@@ -165,7 +165,7 @@ def _generate_gerrit_override_sha(change: GerritChangeInfo) -> str:
     Returns:
         SHA256 hash string
     """
-    combined_data = f"{change.owner}:{change.subject.strip()}"
+    combined_data = f"{change.owner.strip()}:{change.subject.strip()}"
     sha_hash = hashlib.sha256(combined_data.encode("utf-8")).hexdigest()
     return sha_hash[:16]
 

--- a/src/dependamerge/cli.py
+++ b/src/dependamerge/cli.py
@@ -144,7 +144,7 @@ def _generate_override_sha(
         commit_message_first_line: First line of the commit message to use as salt
 
     Returns:
-        SHA256 hash string
+        First 16 hex characters of a SHA256 hash string.
     """
     # Create a string combining author info and commit message first line
     combined_data = f"{pr_info.author}:{commit_message_first_line.strip()}"
@@ -1953,7 +1953,7 @@ def _handle_gerrit_merge(
                 )
                 raise typer.Exit(0)
 
-            if override != expected_sha:
+            if override.strip().lower() != expected_sha:
                 exit_with_error(
                     ExitCode.VALIDATION_ERROR,
                     message="❌ Invalid override SHA provided",

--- a/src/dependamerge/cli.py
+++ b/src/dependamerge/cli.py
@@ -1936,6 +1936,10 @@ def _handle_gerrit_merge(
         else:
             expected_sha = _generate_gerrit_override_sha(source_change)
             if not override:
+                subject = source_change.subject.strip()
+                subject_preview = (
+                    subject if len(subject) <= 50 else f"{subject[:50]}..."
+                )
                 console.print("Source change is not from a recognized automation tool.")
                 console.print(
                     "To submit this and similar changes, run again with: "
@@ -1944,7 +1948,7 @@ def _handle_gerrit_merge(
                 console.print(
                     f"This SHA is based on the owner "
                     f"'{source_change.owner}' and subject "
-                    f"'{source_change.subject[:50]}...'",
+                    f"'{subject_preview}'",
                     style="dim",
                 )
                 raise typer.Exit(0)

--- a/src/dependamerge/gerrit/comparator.py
+++ b/src/dependamerge/gerrit/comparator.py
@@ -84,13 +84,19 @@ class GerritChangeComparator:
 
         # Check automation requirements
         if only_automation:
-            source_is_auto = self._is_automation_change(source_change)
-            target_is_auto = self._is_automation_change(target_change)
+            source_is_auto = self.is_automation_change(source_change)
+            target_is_auto = self.is_automation_change(target_change)
 
             if not source_is_auto or not target_is_auto:
                 return GerritComparisonResult.not_similar(
                     "One or both changes are not from automation tools"
                 )
+        elif self._normalize_owner(source_change.owner) != self._normalize_owner(
+            target_change.owner
+        ):
+            return GerritComparisonResult.not_similar(
+                "Change owner does not match source owner"
+            )
 
         # Compare owners (authors)
         owner_score = self._compare_owners(source_change, target_change)
@@ -133,7 +139,7 @@ class GerritChangeComparator:
 
         return GerritComparisonResult.not_similar()
 
-    def _is_automation_change(self, change: GerritChangeInfo) -> bool:
+    def is_automation_change(self, change: GerritChangeInfo) -> bool:
         """
         Check if a change is from an automation tool.
 
@@ -166,6 +172,10 @@ class GerritChangeComparator:
                 return True
 
         return False
+
+    def _is_automation_change(self, change: GerritChangeInfo) -> bool:
+        """Backward-compatible alias for automation detection."""
+        return self.is_automation_change(change)
 
     def _compare_owners(
         self,
@@ -234,9 +244,7 @@ class GerritChangeComparator:
         Normalize subject by removing version-specific information.
         """
         # Remove version numbers
-        subject = re.sub(
-            r"v?\d+\.\d+\.\d+(?:\.\d+)?(?:-[a-zA-Z0-9.-]+)?", "", subject
-        )
+        subject = re.sub(r"v?\d+\.\d+\.\d+(?:\.\d+)?(?:-[a-zA-Z0-9.-]+)?", "", subject)
         # Remove commit hashes
         subject = re.sub(r"\b[a-f0-9]{7,40}\b", "", subject)
         # Remove dates
@@ -275,9 +283,7 @@ class GerritChangeComparator:
 
         return ""
 
-    def _compare_messages(
-        self, message1: str | None, message2: str | None
-    ) -> float:
+    def _compare_messages(self, message1: str | None, message2: str | None) -> float:
         """
         Compare commit messages for similarity.
         """
@@ -326,9 +332,7 @@ class GerritChangeComparator:
 
         return message
 
-    def _compare_automation_patterns(
-        self, message1: str, message2: str
-    ) -> float:
+    def _compare_automation_patterns(self, message1: str, message2: str) -> float:
         """
         Compare messages for specific automation tool patterns.
         """
@@ -370,9 +374,7 @@ class GerritChangeComparator:
     def _extract_dependabot_package(self, message: str) -> str:
         """Extract package name from Dependabot commit message."""
         # Look for "dependency-name: package" pattern
-        yaml_match = re.search(
-            r"dependency-name:\s*([^\s\n]+)", message, re.IGNORECASE
-        )
+        yaml_match = re.search(r"dependency-name:\s*([^\s\n]+)", message, re.IGNORECASE)
         if yaml_match:
             return yaml_match.group(1).strip()
 
@@ -424,12 +426,8 @@ class GerritChangeComparator:
         base_score = intersection / union
 
         # Boost score for workflow files
-        source_workflows = {
-            f for f in source_files if ".github/workflows/" in f
-        }
-        target_workflows = {
-            f for f in target_files if ".github/workflows/" in f
-        }
+        source_workflows = {f for f in source_files if ".github/workflows/" in f}
+        target_workflows = {f for f in target_files if ".github/workflows/" in f}
 
         if source_workflows and target_workflows:
             # Both modify workflow files - consider partial match

--- a/src/dependamerge/gerrit/comparator.py
+++ b/src/dependamerge/gerrit/comparator.py
@@ -91,9 +91,9 @@ class GerritChangeComparator:
                 return GerritComparisonResult.not_similar(
                     "One or both changes are not from automation tools"
                 )
-        elif self._normalize_owner(source_change.owner) != self._normalize_owner(
-            target_change.owner
-        ):
+        elif self._normalize_owner_identity(
+            source_change.owner
+        ) != self._normalize_owner_identity(target_change.owner):
             return GerritComparisonResult.not_similar(
                 "Change owner does not match source owner"
             )
@@ -216,6 +216,15 @@ class GerritChangeComparator:
                 break
 
         return normalized
+
+    def _normalize_owner_identity(self, owner: str) -> str:
+        """
+        Normalize owner identity for hard same-owner gates.
+
+        Unlike similarity scoring, this preserves bot suffixes so distinct
+        Gerrit accounts like "alice" and "alice-bot" do not collapse together.
+        """
+        return owner.lower().strip() if owner else ""
 
     def _compare_subjects(self, subject1: str, subject2: str) -> float:
         """

--- a/src/dependamerge/gerrit/models.py
+++ b/src/dependamerge/gerrit/models.py
@@ -345,9 +345,7 @@ class GerritChangeInfo(BaseModel):
     @property
     def total_lines_changed(self) -> int:
         """Get the total number of lines changed (inserted + deleted)."""
-        return sum(
-            f.lines_inserted + f.lines_deleted for f in self.files_changed
-        )
+        return sum(f.lines_inserted + f.lines_deleted for f in self.files_changed)
 
     def get_label_value(self, label_name: str) -> int | None:
         """
@@ -411,7 +409,8 @@ class GerritChangeInfo(BaseModel):
         Check if the current user has the submit action available.
 
         This checks the actions field returned by Gerrit when
-        CURRENT_ACTIONS is requested.
+        CURRENT_ACTIONS is requested. Gerrit only exposes the submit
+        action once a change is submittable.
 
         Returns:
             True if the submit action is available.
@@ -432,10 +431,8 @@ class GerritChangeInfo(BaseModel):
                 "You may not have permission to give +2 Code-Review on this change"
             )
 
-        if not self.can_submit_action():
-            warnings.append(
-                "You may not have permission to submit this change"
-            )
+        if self.submittable and not self.can_submit_action():
+            warnings.append("You may not have permission to submit this change")
 
         return warnings
 
@@ -443,12 +440,17 @@ class GerritChangeInfo(BaseModel):
         """
         Check if the user has all required permissions for merge operations.
 
-        This checks both +2 Code-Review and submit permissions.
+        This checks +2 Code-Review permissions. Gerrit only exposes the
+        submit action once a change is already submittable, so submit
+        permission is required only for submittable changes.
 
         Returns:
             True if the user has all required permissions.
         """
-        return self.can_code_review_plus_two() and self.can_submit_action()
+        if not self.can_code_review_plus_two():
+            return False
+
+        return not self.submittable or self.can_submit_action()
 
 
 class GerritComparisonResult(BaseModel):

--- a/src/dependamerge/gerrit/service.py
+++ b/src/dependamerge/gerrit/service.py
@@ -170,7 +170,9 @@ class GerritService:
             # Change doesn't exist or has no current revision
             return {"mergeable": None}
         except GerritRestError as exc:
-            log.warning("Failed to fetch mergeable status for %d: %s", change_number, exc)
+            log.warning(
+                "Failed to fetch mergeable status for %d: %s", change_number, exc
+            )
             return {"mergeable": None}
 
     def get_change_info(
@@ -518,6 +520,15 @@ class GerritService:
             if change.number == source_change.number:
                 continue
 
+            if not only_automation and self._owners_differ(source_change, change):
+                log.debug(
+                    "Skipping change %d because owner %r does not match source owner %r",
+                    change.number,
+                    change.owner,
+                    source_change.owner,
+                )
+                continue
+
             # Compare using the provided comparator
             try:
                 if hasattr(comparator, "compare_gerrit_changes"):
@@ -526,13 +537,9 @@ class GerritService:
                     )
                 else:
                     # Fall back to generic comparison if available
-                    result = self._basic_compare(
-                        source_change, change, only_automation
-                    )
+                    result = self._basic_compare(source_change, change, only_automation)
             except Exception as exc:
-                log.debug(
-                    "Error comparing change %d: %s", change.number, exc
-                )
+                log.debug("Error comparing change %d: %s", change.number, exc)
                 continue
 
             if result.is_similar:
@@ -631,15 +638,19 @@ class GerritService:
 
         # Check automation if required
         if only_automation:
-            if not self._is_automation_change(
-                source
-            ) or not self._is_automation_change(target):
+            if not self._is_automation_change(source) or not self._is_automation_change(
+                target
+            ):
                 return GerritComparisonResult.not_similar(
                     "One or both changes are not from automation"
                 )
+        elif self._owners_differ(source, target):
+            return GerritComparisonResult.not_similar(
+                "Change owner does not match source owner"
+            )
 
         # Compare owners
-        if source.owner.lower() == target.owner.lower():
+        if self._normalize_owner(source.owner) == self._normalize_owner(target.owner):
             scores.append(1.0)
             reasons.append("Same author")
         else:
@@ -679,6 +690,33 @@ class GerritService:
 
         text = f"{change.subject} {change.message or ''} {change.owner}".lower()
         return any(indicator in text for indicator in automation_indicators)
+
+    def _owners_differ(
+        self,
+        source: GerritChangeInfo,
+        target: GerritChangeInfo,
+    ) -> bool:
+        """Return True when normalized Gerrit change owners differ."""
+        return self._normalize_owner(source.owner) != self._normalize_owner(
+            target.owner
+        )
+
+    def _normalize_owner(self, owner: str) -> str:
+        """Normalize owner name using the Gerrit comparator rules."""
+        if not owner:
+            return ""
+
+        normalized = owner.lower().strip()
+
+        if normalized.endswith("[bot]"):
+            normalized = normalized[:-5]
+
+        for suffix in ("-bot", "_bot", ".bot"):
+            if normalized.endswith(suffix):
+                normalized = normalized[: -len(suffix)]
+                break
+
+        return normalized
 
     def _compare_subjects(self, subject1: str, subject2: str) -> float:
         """Compare two change subjects for similarity."""

--- a/src/dependamerge/gerrit/service.py
+++ b/src/dependamerge/gerrit/service.py
@@ -696,10 +696,19 @@ class GerritService:
         source: GerritChangeInfo,
         target: GerritChangeInfo,
     ) -> bool:
-        """Return True when normalized Gerrit change owners differ."""
-        return self._normalize_owner(source.owner) != self._normalize_owner(
-            target.owner
+        """Return True when Gerrit change owner identities differ."""
+        return self._normalize_owner_identity(source.owner) != (
+            self._normalize_owner_identity(target.owner)
         )
+
+    def _normalize_owner_identity(self, owner: str) -> str:
+        """
+        Normalize owner identity for hard same-owner gates.
+
+        This preserves bot suffixes so distinct Gerrit accounts like "alice"
+        and "alice-bot" do not collapse together.
+        """
+        return owner.lower().strip() if owner else ""
 
     def _normalize_owner(self, owner: str) -> str:
         """Normalize owner name using the Gerrit comparator rules."""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5,17 +5,23 @@ import hashlib
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
+import typer
+from rich.console import Console
 from typer.testing import CliRunner
 
 from dependamerge.cli import (
     _format_failure_reason,
+    _generate_gerrit_override_sha,
     _generate_override_sha,
+    _handle_gerrit_merge,
     _MergeContext,
     _restart_merge_progress_tracker,
     _validate_override_sha,
     app,
 )
+from dependamerge.gerrit.models import GerritChangeInfo
 from dependamerge.models import PullRequestInfo
+from dependamerge.url_parser import ChangeSource, ParsedUrl
 
 
 class TestCLI:
@@ -583,6 +589,167 @@ class TestCLI:
         # Invalid SHA should fail validation
         assert _validate_override_sha("invalid_sha", mock_pr, commit_message) is False
         assert _validate_override_sha("", mock_pr, commit_message) is False
+
+    def test_generate_gerrit_override_sha(self):
+        """Test Gerrit override SHA generation."""
+        change = GerritChangeInfo(
+            number=123,
+            change_id="I123",
+            project="proj",
+            subject=" CI: Bump github2gerrit workflow to v1.4.3 ",
+            owner="human-user",
+            branch="main",
+            status="NEW",
+        )
+
+        expected = hashlib.sha256(
+            b"human-user:CI: Bump github2gerrit workflow to v1.4.3"
+        ).hexdigest()[:16]
+        assert _generate_gerrit_override_sha(change) == expected
+
+    @staticmethod
+    def _gerrit_parsed_url() -> ParsedUrl:
+        return ParsedUrl(
+            source=ChangeSource.GERRIT,
+            host="gerrit.example.org",
+            base_path=None,
+            project="proj",
+            change_number=123,
+            original_url="https://gerrit.example.org/c/proj/+/123",
+        )
+
+    @staticmethod
+    def _human_gerrit_change() -> GerritChangeInfo:
+        return GerritChangeInfo(
+            number=123,
+            change_id="I123",
+            project="proj",
+            subject="CI: Bump github2gerrit workflow to v1.4.3",
+            owner="human-user",
+            branch="main",
+            status="NEW",
+            permitted_labels={"Code-Review": ["-2", "-1", "0", "+1", "+2"]},
+        )
+
+    @patch("dependamerge.cli.create_gerrit_comparator")
+    @patch("dependamerge.cli.create_gerrit_service")
+    @patch("dependamerge.cli.resolve_gerrit_credentials")
+    def test_gerrit_merge_non_automation_change_no_override(
+        self,
+        mock_resolve_credentials,
+        mock_create_service,
+        mock_create_comparator,
+    ):
+        """Test Gerrit human-authored changes require an override."""
+        change = self._human_gerrit_change()
+        credentials = Mock(is_valid=True, username="user", password="pass")
+        credentials.auth_method_display.return_value = ".netrc file"
+        mock_resolve_credentials.return_value = credentials
+
+        service = Mock(is_authenticated=True)
+        service.get_change_info.return_value = change
+        mock_create_service.return_value = service
+
+        comparator = Mock()
+        comparator.is_automation_change.return_value = False
+        mock_create_comparator.return_value = comparator
+
+        console = Console(record=True, width=120)
+        with pytest.raises(typer.Exit) as exc_info:
+            _handle_gerrit_merge(
+                parsed_url=self._gerrit_parsed_url(),
+                no_confirm=True,
+                similarity_threshold=0.8,
+                verbose=False,
+                console=console,
+            )
+
+        assert exc_info.value.exit_code == 0
+        output = console.export_text()
+        assert "Source change is not from a recognized automation tool" in output
+        assert "--override" in output
+        assert "human-user" in output
+        service.find_similar_changes.assert_not_called()
+
+    @patch("dependamerge.cli.create_gerrit_comparator")
+    @patch("dependamerge.cli.create_gerrit_service")
+    @patch("dependamerge.cli.resolve_gerrit_credentials")
+    def test_gerrit_merge_non_automation_change_valid_override(
+        self,
+        mock_resolve_credentials,
+        mock_create_service,
+        mock_create_comparator,
+    ):
+        """Test valid Gerrit override disables the automation-only scan."""
+        change = self._human_gerrit_change()
+        credentials = Mock(is_valid=True, username="user", password="pass")
+        credentials.auth_method_display.return_value = ".netrc file"
+        mock_resolve_credentials.return_value = credentials
+
+        service = Mock(is_authenticated=True)
+        service.get_change_info.return_value = change
+        service.find_similar_changes.return_value = []
+        mock_create_service.return_value = service
+
+        comparator = Mock()
+        comparator.is_automation_change.return_value = False
+        mock_create_comparator.return_value = comparator
+
+        console = Console(record=True, width=120)
+        _handle_gerrit_merge(
+            parsed_url=self._gerrit_parsed_url(),
+            no_confirm=True,
+            similarity_threshold=0.8,
+            verbose=False,
+            console=console,
+            dry_run=True,
+            override=_generate_gerrit_override_sha(change),
+        )
+
+        output = console.export_text()
+        assert "Override SHA validated" in output
+        service.find_similar_changes.assert_called_once_with(
+            change,
+            comparator,
+            only_automation=False,
+        )
+
+    @patch("dependamerge.cli.create_gerrit_comparator")
+    @patch("dependamerge.cli.create_gerrit_service")
+    @patch("dependamerge.cli.resolve_gerrit_credentials")
+    def test_gerrit_merge_non_automation_change_invalid_override(
+        self,
+        mock_resolve_credentials,
+        mock_create_service,
+        mock_create_comparator,
+    ):
+        """Test invalid Gerrit override exits with validation error."""
+        change = self._human_gerrit_change()
+        credentials = Mock(is_valid=True, username="user", password="pass")
+        credentials.auth_method_display.return_value = ".netrc file"
+        mock_resolve_credentials.return_value = credentials
+
+        service = Mock(is_authenticated=True)
+        service.get_change_info.return_value = change
+        mock_create_service.return_value = service
+
+        comparator = Mock()
+        comparator.is_automation_change.return_value = False
+        mock_create_comparator.return_value = comparator
+
+        console = Console(record=True, width=120)
+        with pytest.raises(SystemExit) as exc_info:
+            _handle_gerrit_merge(
+                parsed_url=self._gerrit_parsed_url(),
+                no_confirm=True,
+                similarity_threshold=0.8,
+                verbose=False,
+                console=console,
+                override="wrongsha",
+            )
+
+        assert exc_info.value.code == 8
+        service.find_similar_changes.assert_not_called()
 
     @patch("dependamerge.cli.GitHubClient")
     @patch("dependamerge.cli.PRComparator")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -669,6 +669,8 @@ class TestCLI:
         assert "Source change is not from a recognized automation tool" in output
         assert "--override" in output
         assert "human-user" in output
+        assert "'CI: Bump github2gerrit workflow to v1.4.3'" in output
+        assert "'CI: Bump github2gerrit workflow to v1.4.3...'" not in output
         service.find_similar_changes.assert_not_called()
 
     @patch("dependamerge.cli.create_gerrit_comparator")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -705,7 +705,7 @@ class TestCLI:
             verbose=False,
             console=console,
             dry_run=True,
-            override=_generate_gerrit_override_sha(change),
+            override=f" {_generate_gerrit_override_sha(change).upper()} ",
         )
 
         output = console.export_text()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -625,7 +625,7 @@ class TestCLI:
             change_id="I123",
             project="proj",
             subject="CI: Bump github2gerrit workflow to v1.4.3",
-            owner="human-user",
+            owner=" human-user ",
             branch="main",
             status="NEW",
             permitted_labels={"Code-Review": ["-2", "-1", "0", "+1", "+2"]},
@@ -669,6 +669,7 @@ class TestCLI:
         assert "Source change is not from a recognized automation tool" in output
         assert "--override" in output
         assert "human-user" in output
+        assert "' human-user '" not in output
         assert "'CI: Bump github2gerrit workflow to v1.4.3'" in output
         assert "'CI: Bump github2gerrit workflow to v1.4.3...'" not in output
         service.find_similar_changes.assert_not_called()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -597,7 +597,7 @@ class TestCLI:
             change_id="I123",
             project="proj",
             subject=" CI: Bump github2gerrit workflow to v1.4.3 ",
-            owner="human-user",
+            owner=" human-user ",
             branch="main",
             status="NEW",
         )

--- a/tests/test_gerrit_comparator.py
+++ b/tests/test_gerrit_comparator.py
@@ -124,6 +124,7 @@ class TestAutomationDetection:
             status="NEW",
         )
         assert comparator._is_automation_change(change) is True
+        assert comparator.is_automation_change(change) is True
 
     def test_detects_renovate(self, comparator):
         """Test detection of Renovate changes."""
@@ -167,6 +168,7 @@ class TestAutomationDetection:
     def test_non_automation_change(self, comparator, human_change):
         """Test that human changes are not detected as automation."""
         assert comparator._is_automation_change(human_change) is False
+        assert comparator.is_automation_change(human_change) is False
 
 
 class TestOwnerComparison:
@@ -557,6 +559,37 @@ class TestCompareGerritChanges:
 
         # Should evaluate similarity without automation check
         assert result.confidence_score > 0.0
+
+    def test_non_automation_requires_same_owner_when_disabled(self):
+        """Test human overrides never match changes from a different owner."""
+        comparator = GerritChangeComparator(similarity_threshold=0.6)
+        source = GerritChangeInfo(
+            number=1,
+            change_id="I1",
+            project="proj",
+            subject="CI: Bump github2gerrit workflow to v1.4.3",
+            message="CI: Bump github2gerrit workflow to v1.4.3",
+            owner="human-user",
+            branch="main",
+            status="NEW",
+            files_changed=[
+                GerritFileChange(filename=".github/workflows/github2gerrit.yaml")
+            ],
+        )
+        target = source.model_copy(
+            update={
+                "number": 2,
+                "change_id": "I2",
+                "owner": "other-human",
+            }
+        )
+
+        result = comparator.compare_gerrit_changes(
+            source, target, only_automation=False
+        )
+
+        assert result.is_similar is False
+        assert "owner does not match" in result.reasons[0]
 
     def test_different_package_updates_not_similar(self, comparator):
         """Test that different package updates are not similar."""

--- a/tests/test_gerrit_comparator.py
+++ b/tests/test_gerrit_comparator.py
@@ -580,7 +580,7 @@ class TestCompareGerritChanges:
             update={
                 "number": 2,
                 "change_id": "I2",
-                "owner": "other-human",
+                "owner": "human-user-bot",
             }
         )
 

--- a/tests/test_gerrit_models.py
+++ b/tests/test_gerrit_models.py
@@ -881,8 +881,8 @@ class TestGerritChangeInfoPermissions:
         assert len(warnings) == 1
         assert "+2 Code-Review" in warnings[0]
 
-    def test_get_permission_warnings_no_submit(self):
-        """Test get_permission_warnings when user lacks submit permission."""
+    def test_get_permission_warnings_not_submittable_no_submit(self):
+        """Test no submit warning when submit permission is indeterminate."""
         change = GerritChangeInfo(
             number=1,
             change_id="I123",
@@ -891,6 +891,26 @@ class TestGerritChangeInfoPermissions:
             owner="user",
             branch="main",
             status="NEW",
+            permitted_labels={
+                "Code-Review": ["-2", "-1", "0", "+1", "+2"],
+            },
+            actions={},
+        )
+
+        warnings = change.get_permission_warnings()
+        assert warnings == []
+
+    def test_get_permission_warnings_submittable_no_submit(self):
+        """Test submit warning when a submittable change lacks submit action."""
+        change = GerritChangeInfo(
+            number=1,
+            change_id="I123",
+            project="proj",
+            subject="Test",
+            owner="user",
+            branch="main",
+            status="NEW",
+            submittable=True,
             permitted_labels={
                 "Code-Review": ["-2", "-1", "0", "+1", "+2"],
             },
@@ -916,7 +936,8 @@ class TestGerritChangeInfoPermissions:
         )
 
         warnings = change.get_permission_warnings()
-        assert len(warnings) == 2
+        assert len(warnings) == 1
+        assert "+2 Code-Review" in warnings[0]
 
     def test_has_required_permissions_true(self):
         """Test has_required_permissions when user has all permissions."""
@@ -958,8 +979,8 @@ class TestGerritChangeInfoPermissions:
 
         assert change.has_required_permissions() is False
 
-    def test_has_required_permissions_false_no_submit(self):
-        """Test has_required_permissions when user lacks submit."""
+    def test_has_required_permissions_true_not_submittable_no_submit(self):
+        """Test submit action is not required before Gerrit exposes it."""
         change = GerritChangeInfo(
             number=1,
             change_id="I123",
@@ -968,6 +989,25 @@ class TestGerritChangeInfoPermissions:
             owner="user",
             branch="main",
             status="NEW",
+            permitted_labels={
+                "Code-Review": ["-2", "-1", "0", "+1", "+2"],
+            },
+            actions={},
+        )
+
+        assert change.has_required_permissions() is True
+
+    def test_has_required_permissions_false_submittable_no_submit(self):
+        """Test submit action is required once a change is submittable."""
+        change = GerritChangeInfo(
+            number=1,
+            change_id="I123",
+            project="proj",
+            subject="Test",
+            owner="user",
+            branch="main",
+            status="NEW",
+            submittable=True,
             permitted_labels={
                 "Code-Review": ["-2", "-1", "0", "+1", "+2"],
             },

--- a/tests/test_gerrit_service.py
+++ b/tests/test_gerrit_service.py
@@ -11,6 +11,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from dependamerge.gerrit.comparator import GerritChangeComparator
 from dependamerge.gerrit.models import (
     GerritChangeInfo,
     GerritComparisonResult,
@@ -633,6 +634,61 @@ class TestGerritServiceFindSimilarChanges:
         assert similar[1][0].number == 3  # 0.85
         assert similar[2][0].number == 1  # 0.70
 
+    @patch("dependamerge.gerrit.service.build_client")
+    @patch("dependamerge.gerrit.service.create_url_builder")
+    def test_find_similar_changes_filters_other_owners_when_not_automation_only(
+        self,
+        mock_url_builder,
+        mock_build_client,
+        mock_client,
+    ):
+        """Test human override scans hard-filter changes to the same owner."""
+        mock_build_client.return_value = mock_client
+
+        source = GerritChangeInfo(
+            number=1,
+            change_id="I1",
+            project="proj",
+            subject="CI: Bump github2gerrit workflow to v1.4.3",
+            message="CI: Bump github2gerrit workflow to v1.4.3",
+            owner="human-user",
+            branch="main",
+            status="NEW",
+            files_changed=[
+                GerritFileChange(filename=".github/workflows/github2gerrit.yaml")
+            ],
+        )
+        mock_client.get.return_value = [
+            {
+                "_number": 2,
+                "change_id": "I2",
+                "project": "other-project",
+                "subject": "CI: Bump github2gerrit workflow to v1.4.3",
+                "branch": "main",
+                "status": "NEW",
+                "owner": {"username": "other-human"},
+                "current_revision": "rev2",
+                "revisions": {
+                    "rev2": {
+                        "commit": {
+                            "message": "CI: Bump github2gerrit workflow to v1.4.3"
+                        },
+                        "files": {
+                            ".github/workflows/github2gerrit.yaml": {"status": "M"}
+                        },
+                    }
+                },
+            }
+        ]
+
+        service = GerritService(host="gerrit.example.org")
+        comparator = GerritChangeComparator(similarity_threshold=0.6)
+        similar = service.find_similar_changes(
+            source, comparator, only_automation=False
+        )
+
+        assert similar == []
+
 
 class TestGerritServiceBasicCompare:
     """Tests for internal basic comparison logic."""
@@ -710,6 +766,42 @@ class TestGerritServiceBasicCompare:
         result = service._basic_compare(source, target, only_automation=False)
 
         assert "Same author" in result.reasons
+
+    @patch("dependamerge.gerrit.service.build_client")
+    @patch("dependamerge.gerrit.service.create_url_builder")
+    def test_basic_compare_requires_same_author_when_not_automation_only(
+        self, mock_url_builder, mock_build_client, mock_client
+    ):
+        """Test fallback comparison rejects cross-owner human override matches."""
+        mock_build_client.return_value = mock_client
+
+        service = GerritService(
+            host="gerrit.example.org",
+            similarity_threshold=0.6,
+        )
+        source = GerritChangeInfo(
+            number=1,
+            change_id="I1",
+            project="proj",
+            subject="Bump package from 1.0 to 2.0",
+            message="Bump package from 1.0 to 2.0",
+            owner="human-user",
+            branch="main",
+            status="NEW",
+            files_changed=[GerritFileChange(filename="package.json", lines_inserted=1)],
+        )
+        target = source.model_copy(
+            update={
+                "number": 2,
+                "change_id": "I2",
+                "owner": "other-human",
+            }
+        )
+
+        result = service._basic_compare(source, target, only_automation=False)
+
+        assert result.is_similar is False
+        assert "owner does not match" in result.reasons[0]
 
 
 class TestCreateGerritService:

--- a/tests/test_gerrit_service.py
+++ b/tests/test_gerrit_service.py
@@ -666,7 +666,7 @@ class TestGerritServiceFindSimilarChanges:
                 "subject": "CI: Bump github2gerrit workflow to v1.4.3",
                 "branch": "main",
                 "status": "NEW",
-                "owner": {"username": "other-human"},
+                "owner": {"username": "human-user-bot"},
                 "current_revision": "rev2",
                 "revisions": {
                     "rev2": {
@@ -794,7 +794,7 @@ class TestGerritServiceBasicCompare:
             update={
                 "number": 2,
                 "change_id": "I2",
-                "owner": "other-human",
+                "owner": "human-user-bot",
             }
         )
 


### PR DESCRIPTION
## Summary

- Mirror the GitHub merge path's automation/--override gate for Gerrit changes: human-authored source changes now prompt for an override SHA instead of silently finding 0 similar changes.
- With a valid Gerrit override, run the similarity scan with only_automation=False while enforcing a same-owner hard gate so other users' changes cannot be reviewed/submitted by a lowered threshold.
- Suppress the false "You may not have permission to submit this change" warning for changes that are not yet submittable, since Gerrit only exposes the submit action once a change is submittable.

This fixes the v0.9.1 behavior reported against https://gerrit.onap.org/r/c/multicloud/k8s/+/146527.

## Testing

- uv run pytest -q
- SKIP=markdownlint uv run pre-commit run --files src/dependamerge/cli.py src/dependamerge/gerrit/comparator.py src/dependamerge/gerrit/service.py src/dependamerge/gerrit/models.py tests/test_cli.py tests/test_gerrit_comparator.py tests/test_gerrit_service.py tests/test_gerrit_models.py