### PR TITLE
Fix: Align Gerrit merge path with GitHub behaviour

### DIFF
--- a/src/dependamerge/cli.py
+++ b/src/dependamerge/cli.py
@@ -37,9 +37,11 @@ from .error_codes import (
 )
 from .gerrit import (
     GerritAuthError,
+    GerritChangeComparator,
     GerritChangeInfo,
     GerritComparisonResult,
     GerritRestError,
+    GerritService,
     GerritSubmitResult,
     create_gerrit_comparator,
     create_gerrit_service,
@@ -64,6 +66,7 @@ from .merge_manager import (
 )
 from .models import ComparisonResult, PullRequestInfo
 from .netrc import (
+    GerritCredentials,
     NetrcParseError,
     resolve_gerrit_credentials,
 )
@@ -1948,6 +1951,376 @@ def _print_gerrit_final_summary(
         console.print(f"   • {url}\n     {reason}", markup=False)
 
 
+def _resolve_gerrit_credentials_or_exit(
+    parsed_url: ParsedUrl | ParsedGerritTopicUrl,
+    no_netrc: bool,
+    netrc_file: Path | None,
+    verbose: bool,
+    console: Console,
+) -> GerritCredentials:
+    """Resolve Gerrit credentials, or print guidance and exit.
+
+    Args:
+        parsed_url: Parsed Gerrit change or topic URL (for the host).
+        no_netrc: If True, skip .netrc credential lookup.
+        netrc_file: Explicit path to a .netrc file.
+        verbose: When True, report which auth method was used.
+        console: Rich console for output.
+
+    Returns:
+        Valid Gerrit credentials.
+
+    Raises:
+        typer.Exit: When no valid credentials can be resolved.
+    """
+    try:
+        credentials = resolve_gerrit_credentials(
+            host=parsed_url.host,
+            use_netrc=not no_netrc,
+            netrc_file=netrc_file,
+        )
+    except NetrcParseError as e:
+        console.print(f"⚠️ Error parsing .netrc file: {e}")
+        credentials = None
+
+    if credentials is None or not credentials.is_valid:
+        console.print("❌ Gerrit credentials not found.")
+        console.print("   Options:")
+        console.print("   1. Create a ~/.netrc file with Gerrit credentials")
+        console.print(
+            "   2. Set GERRIT_USERNAME and GERRIT_PASSWORD environment variables"
+        )
+        console.print(
+            "   Tip: Source your .secrets.gerrit file and run use_lf or use_onap"
+        )
+        raise typer.Exit(1)
+
+    if verbose:
+        console.print(f"🔑 Using credentials from {credentials.auth_method_display()}")
+
+    return credentials
+
+
+def _resolve_gerrit_source_change(
+    service: GerritService,
+    parsed_url: ParsedUrl | ParsedGerritTopicUrl,
+    topic: str | None,
+    credentials: GerritCredentials,
+    console: Console,
+) -> tuple[GerritChangeInfo, list[GerritChangeInfo] | None]:
+    """Fetch and display the source change, validating its state.
+
+    For a topic search URL there is no explicit change number: the
+    first open change in the topic anchors the batch and the rest
+    become candidates.
+
+    Returns:
+        The source change and, when a topic URL was given, the list of
+        open changes sharing that topic (else None).
+
+    Raises:
+        typer.Exit: When no change is found, or the source change is
+            already merged or abandoned.
+    """
+    topic_changes: list[GerritChangeInfo] | None = None
+    if isinstance(parsed_url, ParsedGerritTopicUrl):
+        search_topic = topic or parsed_url.topic
+        console.print(f"📋 Fetching changes with topic '{search_topic}'...")
+        topic_changes = [
+            c for c in service.get_changes_by_topic(search_topic) if c.is_open
+        ]
+        if not topic_changes:
+            console.print(f"❌ No open changes found with topic '{search_topic}'")
+            raise typer.Exit(1)
+        # Refetch the anchor change: list queries omit the label,
+        # permission, and action detail the checks below rely on.
+        source_change = service.get_change_info(topic_changes[0].number)
+    else:
+        console.print(f"📋 Fetching change {parsed_url.change_number}...")
+        source_change = service.get_change_info(parsed_url.change_number)
+
+    if source_change is None:
+        console.print("❌ Change not found")
+        raise typer.Exit(1)
+
+    # Display source change info using Rich table (same style as GitHub)
+    _display_change_info(
+        source_change,
+        console=console,
+        auth_method=credentials.auth_method_display(),
+    )
+
+    if source_change.status == "MERGED":
+        console.print("\n✅ Change is already merged.")
+        raise typer.Exit(0)
+
+    if source_change.status == "ABANDONED":
+        console.print("\n❌ Change has been abandoned.")
+        raise typer.Exit(1)
+
+    return source_change, topic_changes
+
+
+def _resolve_gerrit_only_automation(
+    source_change: GerritChangeInfo,
+    comparator: GerritChangeComparator,
+    override: str | None,
+    console: Console,
+) -> bool:
+    """Decide whether the batch is automation-only, honouring --override.
+
+    Automation source changes match only other automation changes. A
+    non-automation source requires a matching override SHA to proceed
+    and then widens matching beyond automation.
+
+    Returns:
+        True when only automation changes should be matched.
+
+    Raises:
+        typer.Exit: When the source is a non-automation change without a
+            valid override SHA.
+    """
+    if comparator.is_automation_change(source_change):
+        return True
+
+    expected_sha = _generate_gerrit_override_sha(source_change)
+    if not override:
+        owner = source_change.owner.strip()
+        subject = source_change.subject.strip()
+        subject_preview = subject if len(subject) <= 50 else f"{subject[:50]}..."
+        console.print("Source change is not from a recognized automation tool.")
+        console.print(
+            "To submit this and similar changes, run again with: "
+            f"--override {expected_sha}"
+        )
+        console.print(
+            f"This SHA is based on the owner '{owner}' and subject '{subject_preview}'",
+            style="dim",
+        )
+        raise typer.Exit(0)
+
+    if override.strip().lower() != expected_sha:
+        exit_with_error(
+            ExitCode.VALIDATION_ERROR,
+            message="❌ Invalid override SHA provided",
+            details=(
+                f"Expected SHA for this change and owner: --override {expected_sha}"
+            ),
+        )
+
+    console.print(
+        "Override SHA validated. Proceeding with non-automation change merge."
+    )
+    return False
+
+
+def _maybe_rebase_gerrit_change(
+    service: GerritService,
+    source_change: GerritChangeInfo,
+    credentials: GerritCredentials,
+    console: Console,
+) -> GerritChangeInfo:
+    """Rebase the source change when it has merge conflicts.
+
+    Returns:
+        The (possibly refreshed) source change. Unchanged when the
+        change is already mergeable.
+
+    Raises:
+        typer.Exit: When the rebase fails, whether due to conflicts
+            needing manual resolution or another error.
+    """
+    if source_change.mergeable is not False:
+        return source_change
+
+    console.print("\n⚠️ Change has merge conflicts. Attempting to rebase...")
+    rebase_result = service.rebase_change(source_change.number)
+
+    if rebase_result["success"]:
+        console.print("✅ Rebase successful! Refreshing change info...")
+        source_change = service.get_change_info(source_change.number)
+        _display_change_info(
+            source_change,
+            console=console,
+            auth_method=credentials.auth_method_display(),
+        )
+        return source_change
+
+    if rebase_result["conflict"]:
+        console.print("\n❌ Rebase failed due to merge conflicts:")
+        if rebase_result["conflicting_files"]:
+            console.print("\n   Conflicting files:")
+            for file_path in rebase_result["conflicting_files"]:
+                console.print(f"   • {file_path}")
+        console.print(
+            "\n💡 To resolve: manually rebase the change locally and push a new patchset."
+        )
+        console.print(f"   git review -d {source_change.number}")
+        console.print(f"   git rebase origin/{source_change.branch}")
+        console.print("   # resolve conflicts, then:")
+        console.print("   git review")
+        raise typer.Exit(1)
+
+    console.print(f"\n❌ Rebase failed: {rebase_result['error']}")
+    raise typer.Exit(1)
+
+
+def _resolve_gerrit_candidates(
+    service: GerritService,
+    source_change: GerritChangeInfo,
+    parsed_url: ParsedUrl | ParsedGerritTopicUrl,
+    topic: str | None,
+    topic_changes: list[GerritChangeInfo] | None,
+    console: Console,
+) -> list[GerritChangeInfo] | None:
+    """Resolve the candidate changes to compare against, by topic.
+
+    An explicit --topic wins, then the topic from a search URL, then
+    the source change's own topic. A server-side topic query is far
+    cheaper and more reliable than scanning every open change; when no
+    topic is available, None lets the caller fall back to a full scan.
+    """
+    effective_topic = topic or source_change.topic
+    if isinstance(parsed_url, ParsedGerritTopicUrl):
+        effective_topic = topic or parsed_url.topic
+
+    if not effective_topic:
+        console.print(f"\n🔍 Searching for similar changes on {parsed_url.host}...")
+        return None
+
+    console.print(
+        f"\n🔍 Searching for changes with topic "
+        f"'{effective_topic}' on {parsed_url.host}..."
+    )
+    # topic_changes (when set) was fetched with this same topic
+    if topic_changes is not None:
+        return topic_changes
+    return [c for c in service.get_changes_by_topic(effective_topic) if c.is_open]
+
+
+def _find_and_print_similar_changes(
+    service: GerritService,
+    comparator: GerritChangeComparator,
+    source_change: GerritChangeInfo,
+    candidates: list[GerritChangeInfo] | None,
+    only_automation: bool,
+    console: Console,
+) -> list[tuple[GerritChangeInfo, GerritComparisonResult]]:
+    """Score candidates against the source change and print the matches."""
+    similar_changes = service.find_similar_changes(
+        source_change,
+        comparator,
+        only_automation=only_automation,
+        candidates=candidates,
+    )
+
+    console.print(f"Found {len(similar_changes)} similar changes:")
+    for change, comparison in similar_changes:
+        console.print(f"  • {change.project} #{change.number}: {change.subject}")
+        console.print(f"    {_format_gerrit_similarity(comparison)}")
+
+    return similar_changes
+
+
+def _preview_gerrit_submission(
+    source_change: GerritChangeInfo,
+    all_changes: list[tuple[GerritChangeInfo, GerritComparisonResult | None]],
+    no_confirm: bool,
+    dry_run: bool,
+    console: Console,
+) -> bool:
+    """Warn about permissions and preview the run, then decide to proceed.
+
+    Permissions are per-project in Gerrit, so this checks the source
+    change and warns if the user may lack sufficient permissions. It
+    then either stops (dry run), prompts for confirmation
+    (interactive), or proceeds straight to submission (--no-confirm).
+
+    Returns:
+        True when submission should proceed, False when the caller
+        should stop (dry run, or the user declined confirmation).
+    """
+    permission_warnings = source_change.get_permission_warnings()
+    if permission_warnings:
+        console.print("\n⚠️ Permission warnings:")
+        for warning in permission_warnings:
+            console.print(f"   • {warning}")
+        console.print(
+            "\n   Note: Permissions vary by project. The operation may still "
+            "succeed on some changes."
+        )
+
+    if not no_confirm or dry_run:
+        label = "Dry run" if dry_run else "Preview"
+        console.print(
+            f"\n📊 {label}: {len(all_changes)} changes would be reviewed and submitted"
+        )
+        if source_change.has_required_permissions():
+            console.print(
+                "   ✅ You appear to have required permissions (+2 Code-Review, submit)"
+            )
+        else:
+            console.print(
+                "   ⚠️ You may not have all required permissions (see warnings above)"
+            )
+        if dry_run:
+            console.print("\n🧪 Dry run: no changes were reviewed or submitted.")
+            return False
+        if not _confirm_gerrit_submission(source_change, console):
+            return False
+
+    return True
+
+
+def _run_gerrit_submission(
+    parsed_url: ParsedUrl | ParsedGerritTopicUrl,
+    credentials: GerritCredentials,
+    all_changes: list[tuple[GerritChangeInfo, GerritComparisonResult | None]],
+    show_progress: bool,
+    console: Console,
+) -> None:
+    """Submit all changes in parallel and print the final summary.
+
+    Live in-place progress mirrors the GitHub merge path: the submit
+    manager records each change's transitory and terminal states
+    against the tracker while the parallel submission runs, and
+    failures are recapped afterwards by _print_gerrit_final_summary
+    instead of interleaved lines. The tracker is created (unstarted)
+    before the submit manager so it can be handed over, but only
+    started inside the try/finally so it is always stopped, even when
+    submission setup or the run itself raises.
+    """
+    console.print(f"\n🚀 Submitting {len(all_changes)} changes...")
+
+    progress_tracker: MergeProgressTracker | None = None
+    if show_progress:
+        progress_tracker = MergeProgressTracker(
+            parsed_url.host,
+            operation_label="Submitting changes",
+            operation_icon="▶️",
+            unit_label="changes",
+        )
+        progress_tracker.set_total_prs(len(all_changes))
+
+    submit_manager = create_submit_manager(
+        host=parsed_url.host,
+        base_path=parsed_url.base_path,
+        username=credentials.username,
+        password=credentials.password,
+        progress_tracker=progress_tracker,
+    )
+
+    try:
+        if progress_tracker is not None:
+            progress_tracker.start()
+        results = submit_manager.submit_changes_parallel(all_changes)
+    finally:
+        if progress_tracker is not None:
+            progress_tracker.stop()
+
+    _print_gerrit_final_summary(results, all_changes, console)
+
+
 def _handle_gerrit_merge(
     parsed_url: ParsedUrl | ParsedGerritTopicUrl,
     no_confirm: bool,
@@ -1985,31 +2358,9 @@ def _handle_gerrit_merge(
             during submission (in-place counters, matching the GitHub
             merge path) instead of printing per-change status lines.
     """
-    # Resolve Gerrit credentials from all sources using centralized function
-    try:
-        credentials = resolve_gerrit_credentials(
-            host=parsed_url.host,
-            use_netrc=not no_netrc,
-            netrc_file=netrc_file,
-        )
-    except NetrcParseError as e:
-        console.print(f"⚠️ Error parsing .netrc file: {e}")
-        credentials = None
-
-    if credentials is None or not credentials.is_valid:
-        console.print("❌ Gerrit credentials not found.")
-        console.print("   Options:")
-        console.print("   1. Create a ~/.netrc file with Gerrit credentials")
-        console.print(
-            "   2. Set GERRIT_USERNAME and GERRIT_PASSWORD environment variables"
-        )
-        console.print(
-            "   Tip: Source your .secrets.gerrit file and run use_lf or use_onap"
-        )
-        raise typer.Exit(1)
-
-    if verbose:
-        console.print(f"🔑 Using credentials from {credentials.auth_method_display()}")
+    credentials = _resolve_gerrit_credentials_or_exit(
+        parsed_url, no_netrc, netrc_file, verbose, console
+    )
 
     console.print(f"🔍 Examining Gerrit change on {parsed_url.host}...")
 
@@ -2024,159 +2375,25 @@ def _handle_gerrit_merge(
         if not service.is_authenticated:
             console.print("⚠️ Warning: Service created but may not be authenticated")
 
-        # Resolve the source change.  For a topic search URL there is no
-        # explicit change number: the first open change in the topic
-        # anchors the batch and the rest become candidates.
-        topic_changes: list[GerritChangeInfo] | None = None
-        if isinstance(parsed_url, ParsedGerritTopicUrl):
-            search_topic = topic or parsed_url.topic
-            console.print(f"📋 Fetching changes with topic '{search_topic}'...")
-            topic_changes = [
-                c for c in service.get_changes_by_topic(search_topic) if c.is_open
-            ]
-            if not topic_changes:
-                console.print(f"❌ No open changes found with topic '{search_topic}'")
-                raise typer.Exit(1)
-            # Refetch the anchor change: list queries omit the label,
-            # permission, and action detail the checks below rely on.
-            source_change = service.get_change_info(topic_changes[0].number)
-        else:
-            console.print(f"📋 Fetching change {parsed_url.change_number}...")
-            source_change = service.get_change_info(parsed_url.change_number)
-
-        if source_change is None:
-            console.print("❌ Change not found")
-            raise typer.Exit(1)
-
-        # Display source change info using Rich table (same style as GitHub)
-        _display_change_info(
-            source_change,
-            console=console,
-            auth_method=credentials.auth_method_display(),
+        source_change, topic_changes = _resolve_gerrit_source_change(
+            service, parsed_url, topic, credentials, console
         )
-
-        if source_change.status == "MERGED":
-            console.print("\n✅ Change is already merged.")
-            raise typer.Exit(0)
-
-        if source_change.status == "ABANDONED":
-            console.print("\n❌ Change has been abandoned.")
-            raise typer.Exit(1)
 
         comparator = create_gerrit_comparator(similarity_threshold=similarity_threshold)
-
-        source_is_automation = comparator.is_automation_change(source_change)
-        if source_is_automation:
-            only_automation = True
-        else:
-            expected_sha = _generate_gerrit_override_sha(source_change)
-            if not override:
-                owner = source_change.owner.strip()
-                subject = source_change.subject.strip()
-                subject_preview = (
-                    subject if len(subject) <= 50 else f"{subject[:50]}..."
-                )
-                console.print("Source change is not from a recognized automation tool.")
-                console.print(
-                    "To submit this and similar changes, run again with: "
-                    f"--override {expected_sha}"
-                )
-                console.print(
-                    f"This SHA is based on the owner "
-                    f"'{owner}' and subject "
-                    f"'{subject_preview}'",
-                    style="dim",
-                )
-                raise typer.Exit(0)
-
-            if override.strip().lower() != expected_sha:
-                exit_with_error(
-                    ExitCode.VALIDATION_ERROR,
-                    message="❌ Invalid override SHA provided",
-                    details=(
-                        "Expected SHA for this change and owner: "
-                        f"--override {expected_sha}"
-                    ),
-                )
-
-            console.print(
-                "Override SHA validated. Proceeding with non-automation change merge."
-            )
-            only_automation = False
-
-        # Check for merge conflicts and attempt rebase if needed
-        if source_change.mergeable is False:
-            console.print("\n⚠️ Change has merge conflicts. Attempting to rebase...")
-            rebase_result = service.rebase_change(source_change.number)
-
-            if rebase_result["success"]:
-                console.print("✅ Rebase successful! Refreshing change info...")
-                # Refresh the change info after successful rebase
-                source_change = service.get_change_info(source_change.number)
-                _display_change_info(
-                    source_change,
-                    console=console,
-                    auth_method=credentials.auth_method_display(),
-                )
-            elif rebase_result["conflict"]:
-                console.print("\n❌ Rebase failed due to merge conflicts:")
-                if rebase_result["conflicting_files"]:
-                    console.print("\n   Conflicting files:")
-                    for file_path in rebase_result["conflicting_files"]:
-                        console.print(f"   • {file_path}")
-                console.print(
-                    "\n💡 To resolve: manually rebase the change locally and push a new patchset."
-                )
-                console.print(f"   git review -d {source_change.number}")
-                console.print(f"   git rebase origin/{source_change.branch}")
-                console.print("   # resolve conflicts, then:")
-                console.print("   git review")
-                raise typer.Exit(1)
-            else:
-                console.print(f"\n❌ Rebase failed: {rebase_result['error']}")
-                raise typer.Exit(1)
-
-        # Prefer topic-scoped candidate discovery: an explicit --topic
-        # wins, then the topic from a search URL, then the source
-        # change's own topic.  A server-side topic query is far cheaper
-        # and more reliable than scanning every open change.
-        effective_topic = topic or source_change.topic
-        if isinstance(parsed_url, ParsedGerritTopicUrl):
-            effective_topic = topic or parsed_url.topic
-
-        candidates: list[GerritChangeInfo] | None = None
-        if effective_topic:
-            console.print(
-                f"\n🔍 Searching for changes with topic "
-                f"'{effective_topic}' on {parsed_url.host}..."
-            )
-            # topic_changes (when set) was fetched with this same topic
-            if topic_changes is not None:
-                candidates = topic_changes
-            else:
-                candidates = [
-                    c
-                    for c in service.get_changes_by_topic(effective_topic)
-                    if c.is_open
-                ]
-        else:
-            console.print(f"\n🔍 Searching for similar changes on {parsed_url.host}...")
-
-        similar_changes = service.find_similar_changes(
-            source_change,
-            comparator,
-            only_automation=only_automation,
-            candidates=candidates,
+        only_automation = _resolve_gerrit_only_automation(
+            source_change, comparator, override, console
         )
 
-        console.print(f"Found {len(similar_changes)} similar changes:")
+        source_change = _maybe_rebase_gerrit_change(
+            service, source_change, credentials, console
+        )
 
-        if similar_changes:
-            for change, comparison in similar_changes:
-                console.print(
-                    f"  • {change.project} #{change.number}: {change.subject}"
-                )
-                console.print(f"    {_format_gerrit_similarity(comparison)}")
+        candidates = _resolve_gerrit_candidates(
+            service, source_change, parsed_url, topic, topic_changes, console
+        )
+        similar_changes = _find_and_print_similar_changes(
+            service, comparator, source_change, candidates, only_automation, console
+        )
 
         # Prepare list of changes to submit (similar + source)
         source_entry: tuple[GerritChangeInfo, GerritComparisonResult | None] = (
@@ -2188,80 +2405,14 @@ def _handle_gerrit_merge(
             source_entry,
         ]
 
-        # Check permissions on the source change before proceeding
-        # Permissions are per-project in Gerrit, so we check the source change
-        # and warn if the user may not have sufficient permissions
-        permission_warnings = source_change.get_permission_warnings()
-        if permission_warnings:
-            console.print("\n⚠️ Permission warnings:")
-            for warning in permission_warnings:
-                console.print(f"   • {warning}")
-            console.print(
-                "\n   Note: Permissions vary by project. The operation may still "
-                "succeed on some changes."
-            )
+        if not _preview_gerrit_submission(
+            source_change, all_changes, no_confirm, dry_run, console
+        ):
+            return
 
-        # Preview what the run would do, then either stop (dry run),
-        # prompt for confirmation (interactive), or proceed straight to
-        # submission (--no-confirm).
-        if not no_confirm or dry_run:
-            label = "Dry run" if dry_run else "Preview"
-            console.print(
-                f"\n📊 {label}: {len(all_changes)} changes would be "
-                "reviewed and submitted"
-            )
-            if source_change.has_required_permissions():
-                console.print(
-                    "   ✅ You appear to have required permissions (+2 Code-Review, submit)"
-                )
-            else:
-                console.print(
-                    "   ⚠️ You may not have all required permissions (see warnings above)"
-                )
-            if dry_run:
-                console.print("\n🧪 Dry run: no changes were reviewed or submitted.")
-                return
-            if not _confirm_gerrit_submission(source_change, console):
-                return
-
-        console.print(f"\n🚀 Submitting {len(all_changes)} changes...")
-
-        # Live in-place progress (same protocol as the GitHub merge
-        # path): the submit manager records each change's transitory
-        # and terminal states against this tracker while the parallel
-        # submission runs, and failures are recapped afterwards by
-        # _print_gerrit_final_summary instead of interleaved lines.
-        # The tracker is created (unstarted) before the submit manager
-        # so it can be handed over, but only started inside the
-        # try/finally so it is always stopped, even when submission
-        # setup or the run itself raises.
-        progress_tracker: MergeProgressTracker | None = None
-        if show_progress:
-            progress_tracker = MergeProgressTracker(
-                parsed_url.host,
-                operation_label="Submitting changes",
-                operation_icon="▶️",
-                unit_label="changes",
-            )
-            progress_tracker.set_total_prs(len(all_changes))
-
-        submit_manager = create_submit_manager(
-            host=parsed_url.host,
-            base_path=parsed_url.base_path,
-            username=credentials.username,
-            password=credentials.password,
-            progress_tracker=progress_tracker,
+        _run_gerrit_submission(
+            parsed_url, credentials, all_changes, show_progress, console
         )
-
-        try:
-            if progress_tracker is not None:
-                progress_tracker.start()
-            results = submit_manager.submit_changes_parallel(all_changes)
-        finally:
-            if progress_tracker is not None:
-                progress_tracker.stop()
-
-        _print_gerrit_final_summary(results, all_changes, console)
 
     except typer.Exit:
         # Re-raise typer.Exit without treating it as an error

--- a/src/dependamerge/cli.py
+++ b/src/dependamerge/cli.py
@@ -2231,6 +2231,10 @@ def _handle_gerrit_merge(
         # and terminal states against this tracker while the parallel
         # submission runs, and failures are recapped afterwards by
         # _print_gerrit_final_summary instead of interleaved lines.
+        # The tracker is created (unstarted) before the submit manager
+        # so it can be handed over, but only started inside the
+        # try/finally so it is always stopped, even when submission
+        # setup or the run itself raises.
         progress_tracker: MergeProgressTracker | None = None
         if show_progress:
             progress_tracker = MergeProgressTracker(
@@ -2240,7 +2244,6 @@ def _handle_gerrit_merge(
                 unit_label="changes",
             )
             progress_tracker.set_total_prs(len(all_changes))
-            progress_tracker.start()
 
         submit_manager = create_submit_manager(
             host=parsed_url.host,
@@ -2251,6 +2254,8 @@ def _handle_gerrit_merge(
         )
 
         try:
+            if progress_tracker is not None:
+                progress_tracker.start()
             results = submit_manager.submit_changes_parallel(all_changes)
         finally:
             if progress_tracker is not None:

--- a/src/dependamerge/cli.py
+++ b/src/dependamerge/cli.py
@@ -71,11 +71,13 @@ from .progress_tracker import MergeProgressTracker, ProgressTracker
 from .resolve_conflicts import FixOptions, FixOrchestrator, PRSelection
 from .system_utils import get_default_workers
 from .url_parser import (
+    ParsedGerritTopicUrl,
     ParsedOrgUrl,
     ParsedRepoUrl,
     ParsedUrl,
     UrlParseError,
     parse_change_url,
+    parse_gerrit_topic_url,
     parse_org_url,
     parse_owner_arg,
     parse_repo_url,
@@ -1841,7 +1843,7 @@ def _execute_org_confirmed_merge(
 
 
 def _handle_gerrit_merge(
-    parsed_url: ParsedUrl,
+    parsed_url: ParsedUrl | ParsedGerritTopicUrl,
     no_confirm: bool,
     similarity_threshold: float,
     verbose: bool,
@@ -1851,12 +1853,14 @@ def _handle_gerrit_merge(
     netrc_optional: bool = True,
     dry_run: bool = False,
     override: str | None = None,
+    topic: str | None = None,
 ) -> None:
     """
-    Handle merge operation for a Gerrit change URL.
+    Handle merge operation for a Gerrit change or topic search URL.
 
     Args:
-        parsed_url: Parsed Gerrit URL with host, project, and change number.
+        parsed_url: Parsed Gerrit change URL (host, project, change
+            number) or topic search URL (host, topic).
         no_confirm: If True, skip confirmation prompt.
         similarity_threshold: Threshold for matching similar changes.
         verbose: Enable verbose output.
@@ -1867,6 +1871,9 @@ def _handle_gerrit_merge(
         dry_run: If True, preview only and never review or submit any
             change, even when ``no_confirm`` is also set.
         override: SHA hash to override non-automation change restriction.
+        topic: Explicit topic to scope the similar-change search to.
+            When omitted, the topic is taken from the search URL (if
+            given) or from the source change itself.
     """
     # Resolve Gerrit credentials from all sources using centralized function
     try:
@@ -1907,11 +1914,28 @@ def _handle_gerrit_merge(
         if not service.is_authenticated:
             console.print("⚠️ Warning: Service created but may not be authenticated")
 
-        console.print(f"📋 Fetching change {parsed_url.change_number}...")
-        source_change = service.get_change_info(parsed_url.change_number)
+        # Resolve the source change.  For a topic search URL there is no
+        # explicit change number: the first open change in the topic
+        # anchors the batch and the rest become candidates.
+        topic_changes: list[GerritChangeInfo] | None = None
+        if isinstance(parsed_url, ParsedGerritTopicUrl):
+            search_topic = topic or parsed_url.topic
+            console.print(f"📋 Fetching changes with topic '{search_topic}'...")
+            topic_changes = [
+                c for c in service.get_changes_by_topic(search_topic) if c.is_open
+            ]
+            if not topic_changes:
+                console.print(f"❌ No open changes found with topic '{search_topic}'")
+                raise typer.Exit(1)
+            # Refetch the anchor change: list queries omit the label,
+            # permission, and action detail the checks below rely on.
+            source_change = service.get_change_info(topic_changes[0].number)
+        else:
+            console.print(f"📋 Fetching change {parsed_url.change_number}...")
+            source_change = service.get_change_info(parsed_url.change_number)
 
         if source_change is None:
-            console.print(f"❌ Change {parsed_url.change_number} not found")
+            console.print("❌ Change not found")
             raise typer.Exit(1)
 
         # Display source change info using Rich table (same style as GitHub)
@@ -1978,7 +2002,7 @@ def _handle_gerrit_merge(
             if rebase_result["success"]:
                 console.print("✅ Rebase successful! Refreshing change info...")
                 # Refresh the change info after successful rebase
-                source_change = service.get_change_info(parsed_url.change_number)
+                source_change = service.get_change_info(source_change.number)
                 _display_change_info(
                     source_change,
                     console=console,
@@ -2002,11 +2026,37 @@ def _handle_gerrit_merge(
                 console.print(f"\n❌ Rebase failed: {rebase_result['error']}")
                 raise typer.Exit(1)
 
-        console.print(f"\n🔍 Searching for similar changes on {parsed_url.host}...")
+        # Prefer topic-scoped candidate discovery: an explicit --topic
+        # wins, then the topic from a search URL, then the source
+        # change's own topic.  A server-side topic query is far cheaper
+        # and more reliable than scanning every open change.
+        effective_topic = topic or source_change.topic
+        if isinstance(parsed_url, ParsedGerritTopicUrl):
+            effective_topic = topic or parsed_url.topic
+
+        candidates: list[GerritChangeInfo] | None = None
+        if effective_topic:
+            console.print(
+                f"\n🔍 Searching for changes with topic "
+                f"'{effective_topic}' on {parsed_url.host}..."
+            )
+            # topic_changes (when set) was fetched with this same topic
+            if topic_changes is not None:
+                candidates = topic_changes
+            else:
+                candidates = [
+                    c
+                    for c in service.get_changes_by_topic(effective_topic)
+                    if c.is_open
+                ]
+        else:
+            console.print(f"\n🔍 Searching for similar changes on {parsed_url.host}...")
+
         similar_changes = service.find_similar_changes(
             source_change,
             comparator,
             only_automation=only_automation,
+            candidates=candidates,
         )
 
         console.print(f"Found {len(similar_changes)} similar changes:")
@@ -2240,6 +2290,15 @@ def merge(
         "--include-human-prs",
         help="Include human-authored PRs when merging a repository (prompts for confirmation when human PRs are found)",
     ),
+    topic: str | None = typer.Option(
+        None,
+        "--topic",
+        help=(
+            "Gerrit only: scope the similar-change search to this topic. "
+            "When omitted, the topic is extracted automatically from a "
+            "Gerrit topic search URL or from the source change itself."
+        ),
+    ),
     dry_run: bool = typer.Option(
         False,
         "--dry-run",
@@ -2303,9 +2362,15 @@ def merge(
 
     1. Analyze the provided change
 
-    2. Find similar open changes on the server
+    2. Find similar open changes on the server (scoped to the change's
+       topic when it has one, or the --topic flag)
 
     3. Review (+2 Code-Review) and submit matching changes
+
+    Gerrit topic search URLs are also accepted; all open changes
+    sharing the topic form the batch:
+      https://gerrit.example.org/q/topic:some-topic
+      https://gerrit.onap.org/r/q/topic:some-topic
 
     Merges similar PRs/changes from the same automation tool.
 
@@ -2353,9 +2418,21 @@ def merge(
         )
         raise typer.Exit(1)
 
-    # Try as a specific PR/change URL first, then an owner-wide URL
-    # (bare owner / orgs/owner), then a single repository URL.
+    # Tolerate direct Python calls to ``merge`` (e.g. in tests), where
+    # Typer's ``OptionInfo`` default object is passed unresolved and
+    # would otherwise be truthy.
+    if not isinstance(topic, str):
+        topic = None
+    elif not topic.strip():
+        topic = None
+    else:
+        topic = topic.strip()
+
+    # Try as a specific PR/change URL first, then a Gerrit topic search
+    # URL, then an owner-wide URL (bare owner / orgs/owner), then a
+    # single repository URL.
     parsed_url: ParsedUrl | None = None
+    parsed_topic: ParsedGerritTopicUrl | None = None
     parsed_repo: ParsedRepoUrl | None = None
     parsed_org: ParsedOrgUrl | None = None
     change_err: UrlParseError | None = None
@@ -2363,6 +2440,13 @@ def merge(
         parsed_url = parse_change_url(pr_url)
     except UrlParseError as e:
         change_err = e
+        # Not a PR/change URL — try a Gerrit topic search URL next, so
+        # pasted dashboard URLs like /q/topic:some-topic work directly.
+        try:
+            parsed_topic = parse_gerrit_topic_url(pr_url)
+        except UrlParseError:
+            parsed_topic = None
+    if parsed_url is None and parsed_topic is None and change_err is not None:
         # Not a PR URL — try owner-wide before repository.  parse_org_url
         # is strict (only a bare owner or the canonical orgs/owner forms),
         # so a two-segment owner/repo URL falls through to parse_repo_url.
@@ -2411,9 +2495,21 @@ def merge(
                     console.print(f"❌ Invalid URL: {repo_err}")
                 raise typer.Exit(1) from None
 
-    if parsed_url is not None and parsed_url.is_gerrit:
+    if topic and not (
+        (parsed_url is not None and parsed_url.is_gerrit) or parsed_topic is not None
+    ):
+        console.print("❌ --topic is only supported for Gerrit URLs")
+        raise typer.Exit(1)
+
+    if parsed_topic is not None or (parsed_url is not None and parsed_url.is_gerrit):
+        gerrit_target: ParsedUrl | ParsedGerritTopicUrl
+        if parsed_topic is not None:
+            gerrit_target = parsed_topic
+        else:
+            assert parsed_url is not None
+            gerrit_target = parsed_url
         _handle_gerrit_merge(
-            parsed_url=parsed_url,
+            parsed_url=gerrit_target,
             no_confirm=no_confirm,
             similarity_threshold=similarity_threshold,
             verbose=verbose,
@@ -2423,6 +2519,7 @@ def merge(
             netrc_optional=netrc_optional,
             dry_run=dry_run,
             override=override,
+            topic=topic,
         )
         return
 

--- a/src/dependamerge/cli.py
+++ b/src/dependamerge/cli.py
@@ -40,6 +40,7 @@ from .gerrit import (
     GerritChangeInfo,
     GerritComparisonResult,
     GerritRestError,
+    GerritSubmitResult,
     create_gerrit_comparator,
     create_gerrit_service,
     create_submit_manager,
@@ -1902,6 +1903,51 @@ def _execute_org_confirmed_merge(
     _print_final_merge_summary(real_results)
 
 
+def _print_gerrit_final_summary(
+    results: list[GerritSubmitResult],
+    all_changes: list[tuple[GerritChangeInfo, GerritComparisonResult | None]],
+    console: Console,
+) -> None:
+    """Print the post-run 🚀 Final Results line and failure recap.
+
+    Mirrors the GitHub ``_print_final_merge_summary`` /
+    ``_print_failed_pr_details`` pair: per-change status lines are
+    not printed while the submission runs (progress is conveyed by
+    the live tracker counters), so this end-of-run report is the
+    only place failure reasons appear.
+
+    Args:
+        results: Submit results, one per attempted change.
+        all_changes: The (change, comparison) tuples that were
+            submitted; used to recover each change's web URL for the
+            failure recap (``GerritSubmitResult`` carries only the
+            project and number).
+        console: Rich console to print to.
+    """
+    submitted = sum(1 for r in results if r.submitted)
+    failed = [r for r in results if not r.success]
+    reviewed_only = sum(1 for r in results if r.reviewed and not r.submitted)
+
+    parts = [f"{submitted} submitted", f"{len(failed)} failed"]
+    if reviewed_only > 0:
+        parts.append(f"{reviewed_only} reviewed (not submitted)")
+    console.print(f"\n🚀 Final Results: {', '.join(parts)}")
+
+    if not failed:
+        return
+    url_by_key = {
+        (change.project, change.number): change.url for change, _ in all_changes
+    }
+    console.print("\n❌ Failed changes:")
+    for result in failed:
+        url = url_by_key.get((result.project, result.change_number)) or (
+            f"{result.project} #{result.change_number}"
+        )
+        reason = result.error or "no reason reported"
+        # markup=False so bracketed reasons are not eaten by Rich.
+        console.print(f"   • {url}\n     {reason}", markup=False)
+
+
 def _handle_gerrit_merge(
     parsed_url: ParsedUrl | ParsedGerritTopicUrl,
     no_confirm: bool,
@@ -1914,6 +1960,7 @@ def _handle_gerrit_merge(
     dry_run: bool = False,
     override: str | None = None,
     topic: str | None = None,
+    show_progress: bool = True,
 ) -> None:
     """
     Handle merge operation for a Gerrit change or topic search URL.
@@ -1934,6 +1981,9 @@ def _handle_gerrit_merge(
         topic: Explicit topic to scope the similar-change search to.
             When omitted, the topic is taken from the search URL (if
             given) or from the source change itself.
+        show_progress: If True, drive a live Rich progress tracker
+            during submission (in-place counters, matching the GitHub
+            merge path) instead of printing per-change status lines.
     """
     # Resolve Gerrit credentials from all sources using centralized function
     try:
@@ -2176,34 +2226,37 @@ def _handle_gerrit_merge(
 
         console.print(f"\n🚀 Submitting {len(all_changes)} changes...")
 
+        # Live in-place progress (same protocol as the GitHub merge
+        # path): the submit manager records each change's transitory
+        # and terminal states against this tracker while the parallel
+        # submission runs, and failures are recapped afterwards by
+        # _print_gerrit_final_summary instead of interleaved lines.
+        progress_tracker: MergeProgressTracker | None = None
+        if show_progress:
+            progress_tracker = MergeProgressTracker(
+                parsed_url.host,
+                operation_label="Submitting changes",
+                operation_icon="▶️",
+                unit_label="changes",
+            )
+            progress_tracker.set_total_prs(len(all_changes))
+            progress_tracker.start()
+
         submit_manager = create_submit_manager(
             host=parsed_url.host,
             base_path=parsed_url.base_path,
             username=credentials.username,
             password=credentials.password,
+            progress_tracker=progress_tracker,
         )
 
-        # Pass the tuples directly (submit_changes expects list of tuples)
-        results = submit_manager.submit_changes(all_changes)
+        try:
+            results = submit_manager.submit_changes_parallel(all_changes)
+        finally:
+            if progress_tracker is not None:
+                progress_tracker.stop()
 
-        # Display results (GerritSubmitResult has success/submitted/error fields)
-        submitted_count = sum(1 for r in results if r.submitted)
-        reviewed_count = sum(1 for r in results if r.reviewed and not r.submitted)
-        failed_count = sum(1 for r in results if not r.success)
-
-        console.print("\n📈 Results:")
-        console.print(f"   ✅ Submitted: {submitted_count}")
-        if reviewed_count > 0:
-            console.print(f"   📝 Reviewed (not submitted): {reviewed_count}")
-        if failed_count > 0:
-            console.print(f"   ❌ Failed: {failed_count}")
-
-        # Show details for failed submissions
-        for result in results:
-            if not result.success:
-                console.print(
-                    f"\n   ❌ {result.project} #{result.change_number}: {result.error}"
-                )
+        _print_gerrit_final_summary(results, all_changes, console)
 
     except typer.Exit:
         # Re-raise typer.Exit without treating it as an error
@@ -2582,6 +2635,7 @@ def merge(
             dry_run=dry_run,
             override=override,
             topic=topic,
+            show_progress=show_progress,
         )
         return
 

--- a/src/dependamerge/cli.py
+++ b/src/dependamerge/cli.py
@@ -172,6 +172,27 @@ def _generate_gerrit_override_sha(change: GerritChangeInfo) -> str:
     return sha_hash[:16]
 
 
+def _generate_gerrit_continue_sha(change: GerritChangeInfo) -> str:
+    """
+    Generate a SHA hash for continuing after a Gerrit preview.
+
+    Mirrors _generate_continue_sha for the GitHub path: the value is
+    derived from the source change so the confirmation string is unique
+    per batch and cannot be replayed against a different change.
+
+    Args:
+        change: Source Gerrit change information
+
+    Returns:
+        First 16 hex characters of a SHA256 hash string.
+    """
+    combined_data = (
+        f"continue:{change.project}#{change.number}:{change.subject.strip()}"
+    )
+    sha_hash = hashlib.sha256(combined_data.encode("utf-8")).hexdigest()
+    return sha_hash[:16]
+
+
 def _validate_override_sha(
     provided_sha: str, pr_info: PullRequestInfo, commit_message_first_line: str
 ) -> bool:
@@ -326,6 +347,45 @@ def _format_gerrit_similarity(comparison: GerritComparisonResult) -> str:
         breakdown = ""
 
     return f"{author_text}{total_score}{breakdown}"
+
+
+def _confirm_gerrit_submission(
+    source_change: GerritChangeInfo,
+    console: Console,
+) -> bool:
+    """Prompt for the continue SHA before a real Gerrit submission.
+
+    Mirrors the interactive preview-then-confirm flow of the GitHub
+    path (_handle_preview_confirmation): the user must type a SHA
+    derived from the source change to proceed.
+
+    Returns:
+        True when the user confirmed and the submission should proceed.
+    """
+    continue_sha = _generate_gerrit_continue_sha(source_change)
+    console.print()
+    console.print(f"To proceed with merging enter: {continue_sha}")
+
+    try:
+        if "pytest" in sys.modules or os.getenv("TESTING"):
+            console.print("⚠️ Test mode detected - skipping interactive prompt")
+            return False
+
+        user_input = input(
+            "Enter the string above to continue (or press Enter to cancel): "
+        ).strip()
+
+        if user_input == continue_sha:
+            return True
+        if user_input == "":
+            console.print("❌ Merge cancelled by user.")
+        else:
+            console.print("❌ Invalid input. Merge cancelled.")
+    except KeyboardInterrupt:
+        console.print("\n❌ Merge cancelled by user.")
+    except EOFError:
+        console.print("\n❌ Merge cancelled.")
+    return False
 
 
 @dataclass
@@ -2091,8 +2151,10 @@ def _handle_gerrit_merge(
                 "succeed on some changes."
             )
 
+        # Preview what the run would do, then either stop (dry run),
+        # prompt for confirmation (interactive), or proceed straight to
+        # submission (--no-confirm).
         if not no_confirm or dry_run:
-            # Preview mode - show permission status
             label = "Dry run" if dry_run else "Preview"
             console.print(
                 f"\n📊 {label}: {len(all_changes)} changes would be "
@@ -2108,9 +2170,9 @@ def _handle_gerrit_merge(
                 )
             if dry_run:
                 console.print("\n🧪 Dry run: no changes were reviewed or submitted.")
-            else:
-                console.print("\nTo proceed, run with --no-confirm flag")
-            return
+                return
+            if not _confirm_gerrit_submission(source_change, console):
+                return
 
         console.print(f"\n🚀 Submitting {len(all_changes)} changes...")
 

--- a/src/dependamerge/gerrit/models.py
+++ b/src/dependamerge/gerrit/models.py
@@ -189,7 +189,11 @@ class GerritChangeInfo(BaseModel):
     )
     actions: dict[str, dict[str, Any]] = Field(
         default_factory=dict,
-        description="Available actions the caller can perform on the change",
+        description=(
+            "Union of change-level actions (CHANGE_ACTIONS) and "
+            "current-revision actions (CURRENT_ACTIONS) the caller can "
+            "perform. Revision-level actions include 'submit'."
+        ),
     )
 
     @classmethod
@@ -255,7 +259,16 @@ class GerritChangeInfo(BaseModel):
         # Extract permitted labels (what the current user can vote on)
         permitted_labels: dict[str, list[str]] = data.get("permitted_labels", {})
 
-        actions: dict[str, dict[str, Any]] = data.get("actions", {})
+        # Gerrit splits caller actions across two locations: change-level
+        # actions (populated by the CHANGE_ACTIONS query option) and
+        # revision-level actions such as 'submit', 'rebase', and
+        # 'cherrypick' (populated by CURRENT_ACTIONS under
+        # revisions[<rev>].actions). Merge both so permission checks see
+        # the complete picture regardless of which options were requested.
+        actions: dict[str, dict[str, Any]] = dict(data.get("actions") or {})
+        if current_revision and "revisions" in data:
+            revision_data = data["revisions"].get(current_revision, {})
+            actions.update(revision_data.get("actions") or {})
 
         # Check submit requirements (Gerrit 3.x+)
         submit_requirements_met = True
@@ -401,9 +414,11 @@ class GerritChangeInfo(BaseModel):
         """
         Check if the current user has the submit action available.
 
-        This checks the actions field returned by Gerrit when
-        CURRENT_ACTIONS is requested. Gerrit only exposes the submit
-        action once a change is submittable.
+        The submit action is a revision-level action that Gerrit returns
+        under revisions[<rev>].actions when CURRENT_ACTIONS is requested
+        (merged into ``actions`` by ``from_api_response``). Gerrit only
+        exposes the submit action once a change is submittable, and only
+        to callers with submit permission.
 
         Returns:
             True if the submit action is available.

--- a/src/dependamerge/gerrit/models.py
+++ b/src/dependamerge/gerrit/models.py
@@ -143,22 +143,26 @@ class GerritChangeInfo(BaseModel):
 
     # Content
     subject: str = Field(..., description="First line of commit message")
-    message: str | None = Field(None, description="Full commit message")
-    topic: str | None = Field(None, description="Change topic (if set)")
+    message: str | None = Field(default=None, description="Full commit message")
+    topic: str | None = Field(default=None, description="Change topic (if set)")
 
     # Author/owner
     owner: str = Field(..., description="Change owner username")
-    owner_email: str | None = Field(None, description="Change owner email")
+    owner_email: str | None = Field(default=None, description="Change owner email")
 
     # Branch info
     branch: str = Field(..., description="Target branch")
-    current_revision: str = Field("", description="Current revision SHA")
+    current_revision: str = Field(default="", description="Current revision SHA")
 
     # Status
     status: str = Field(..., description="Change status (NEW, MERGED, ABANDONED)")
-    submittable: bool = Field(False, description="Whether change can be submitted")
-    mergeable: bool | None = Field(None, description="Whether change is mergeable")
-    work_in_progress: bool = Field(False, description="Whether change is WIP")
+    submittable: bool = Field(
+        default=False, description="Whether change can be submitted"
+    )
+    mergeable: bool | None = Field(
+        default=None, description="Whether change is mergeable"
+    )
+    work_in_progress: bool = Field(default=False, description="Whether change is WIP")
 
     # Files
     files_changed: list[GerritFileChange] = Field(
@@ -171,15 +175,15 @@ class GerritChangeInfo(BaseModel):
     )
 
     # URLs
-    url: str = Field("", description="Web URL for the change")
+    url: str = Field(default="", description="Web URL for the change")
 
     # Timestamps
-    created: str = Field("", description="Creation timestamp")
-    updated: str = Field("", description="Last update timestamp")
+    created: str = Field(default="", description="Creation timestamp")
+    updated: str = Field(default="", description="Last update timestamp")
 
     # Submit requirements (Gerrit 3.x+)
     submit_requirements_met: bool = Field(
-        True, description="Whether all submit requirements are satisfied"
+        default=True, description="Whether all submit requirements are satisfied"
     )
 
     # Permissions - for checking what the current user can do
@@ -506,10 +510,10 @@ class GerritSubmitResult(BaseModel):
     change_number: int = Field(..., description="The change number")
     project: str = Field(..., description="The project name")
     success: bool = Field(..., description="Whether submission succeeded")
-    reviewed: bool = Field(False, description="Whether review was applied")
-    submitted: bool = Field(False, description="Whether change was submitted")
-    error: str | None = Field(None, description="Error message if failed")
-    duration_seconds: float = Field(0.0, description="Operation duration")
+    reviewed: bool = Field(default=False, description="Whether review was applied")
+    submitted: bool = Field(default=False, description="Whether change was submitted")
+    error: str | None = Field(default=None, description="Error message if failed")
+    duration_seconds: float = Field(default=0.0, description="Operation duration")
 
     @classmethod
     def success_result(

--- a/src/dependamerge/gerrit/service.py
+++ b/src/dependamerge/gerrit/service.py
@@ -445,10 +445,19 @@ class GerritService:
         if options is None:
             options = DEFAULT_LIST_OPTIONS
 
+        # Topics containing whitespace (or quotes) must be quoted in
+        # Gerrit query syntax, otherwise the bare value splits into
+        # separate query terms and the search silently matches nothing
+        # useful.  Plain topics stay unquoted.
+        topic_term = f"topic:{topic}"
+        if '"' in topic or any(ch.isspace() for ch in topic):
+            escaped = topic.replace("\\", "\\\\").replace('"', '\\"')
+            topic_term = f'topic:"{escaped}"'
+
         if include_merged:
-            query = f"topic:{topic} (status:open OR status:merged)"
+            query = f"{topic_term} (status:open OR status:merged)"
         else:
-            query = f"topic:{topic} status:open"
+            query = f"{topic_term} status:open"
 
         return self._query_changes(query, limit, 0, options)
 

--- a/src/dependamerge/gerrit/service.py
+++ b/src/dependamerge/gerrit/service.py
@@ -44,7 +44,12 @@ DEFAULT_CHANGE_OPTIONS: list[str] = [
     "DETAILED_LABELS",
     "DETAILED_ACCOUNTS",
     "SUBMITTABLE",
-    "CURRENT_ACTIONS",  # Include available actions for permission checking
+    # Both action options are needed for permission checks: CHANGE_ACTIONS
+    # returns change-level actions, while CURRENT_ACTIONS returns
+    # revision-level actions (including 'submit') under
+    # revisions[<rev>].actions.
+    "CURRENT_ACTIONS",
+    "CHANGE_ACTIONS",
 ]
 
 # Default query options for listing changes

--- a/src/dependamerge/gerrit/service.py
+++ b/src/dependamerge/gerrit/service.py
@@ -483,19 +483,26 @@ class GerritService:
         comparator: Any,
         only_automation: bool = True,
         limit: int = 500,
+        candidates: list[GerritChangeInfo] | None = None,
     ) -> list[tuple[GerritChangeInfo, GerritComparisonResult]]:
         """
         Find changes similar to the source change.
 
-        This method fetches all open changes and uses the provided
-        comparator to identify similar changes.
+        This method uses the provided comparator to identify similar
+        changes among the candidates. When no candidate list is given,
+        it falls back to scanning all open changes on the server.
 
         Args:
             source_change: The change to find similar changes for.
             comparator: A comparator object with a compare_gerrit_changes()
                        method (or compare_pull_requests for compatibility).
             only_automation: Whether to only match automation changes.
-            limit: Maximum number of changes to scan.
+            limit: Maximum number of changes to scan when no candidate
+                   list is given.
+            candidates: Optional pre-scoped candidate changes (e.g. the
+                        open changes sharing the source change's topic).
+                        Scoping via a server-side query is far cheaper
+                        and more reliable than the whole-server scan.
 
         Returns:
             List of (change_info, comparison_result) tuples for similar
@@ -507,13 +514,14 @@ class GerritService:
             source_change.number,
         )
 
-        all_changes = self.get_all_open_changes(limit=limit)
+        if candidates is None:
+            candidates = self.get_all_open_changes(limit=limit)
 
-        log.debug("Scanning %d open changes for similarity", len(all_changes))
+        log.debug("Scanning %d open changes for similarity", len(candidates))
 
         similar_changes: list[tuple[GerritChangeInfo, GerritComparisonResult]] = []
 
-        for change in all_changes:
+        for change in candidates:
             # Skip the source change itself
             if change.number == source_change.number:
                 continue

--- a/src/dependamerge/gerrit/submit_manager.py
+++ b/src/dependamerge/gerrit/submit_manager.py
@@ -34,7 +34,7 @@ from dependamerge.gerrit.models import (
 )
 
 if TYPE_CHECKING:
-    from dependamerge.progress_tracker import ProgressTracker
+    from dependamerge.progress_tracker import MergeProgressTracker
 
 
 log = logging.getLogger("dependamerge.gerrit.submit_manager")
@@ -69,7 +69,7 @@ class GerritSubmitManager:
         password: str | None = None,
         timeout: float = 30.0,
         max_workers: int = 5,
-        progress_tracker: ProgressTracker | None = None,
+        progress_tracker: MergeProgressTracker | None = None,
     ) -> None:
         """
         Initialize the submit manager.
@@ -139,7 +139,7 @@ class GerritSubmitManager:
         results: list[GerritSubmitResult] = []
 
         for change, _comparison in changes:
-            result = self._submit_single_change(change, review_labels, dry_run)
+            result = self._submit_with_tracking(change, review_labels, dry_run)
             results.append(result)
 
         return results
@@ -171,7 +171,7 @@ class GerritSubmitManager:
         with ThreadPoolExecutor(max_workers=self._max_workers) as executor:
             futures = [
                 executor.submit(
-                    self._submit_single_change, change, review_labels, dry_run
+                    self._submit_with_tracking, change, review_labels, dry_run
                 )
                 for change, _comparison in changes
             ]
@@ -192,6 +192,41 @@ class GerritSubmitManager:
                     )
 
         return results
+
+    def _submit_with_tracking(
+        self,
+        change: GerritChangeInfo,
+        review_labels: dict[str, int],
+        dry_run: bool,
+    ) -> GerritSubmitResult:
+        """Submit a single change while driving the progress tracker.
+
+        Mirrors the GitHub merge pipeline's tracker protocol: the
+        change enters a transitory ``submitting`` display state while
+        the review + submit round-trips run, then records a terminal
+        ``merge_success`` / ``merge_failure`` outcome (which also
+        clears the transitory entry and advances completion progress).
+        No-op when no tracker was supplied.
+        """
+        tracker = self._progress_tracker
+        change_key = f"{change.project}#{change.number}"
+        if tracker is not None:
+            tracker.track_pr_state(change_key, "submitting")
+        try:
+            result = self._submit_single_change(change, review_labels, dry_run)
+        except Exception:
+            # _submit_single_change catches expected errors; anything
+            # escaping is unexpected, but the tracker entry must not
+            # be left dangling in the transitory state.
+            if tracker is not None:
+                tracker.merge_failure(change_key)
+            raise
+        if tracker is not None:
+            if result.success:
+                tracker.merge_success(change_key)
+            else:
+                tracker.merge_failure(change_key)
+        return result
 
     def _submit_single_change(
         self,
@@ -482,7 +517,7 @@ def create_submit_manager(
     username: str | None = None,
     password: str | None = None,
     max_workers: int = 5,
-    progress_tracker: ProgressTracker | None = None,
+    progress_tracker: MergeProgressTracker | None = None,
 ) -> GerritSubmitManager:
     """
     Factory function to create a GerritSubmitManager.

--- a/src/dependamerge/gerrit/submit_manager.py
+++ b/src/dependamerge/gerrit/submit_manager.py
@@ -272,11 +272,16 @@ class GerritSubmitManager:
                 change.project,
                 change.number,
             )
+            # A dry run performs no review or submit, so report the
+            # simulated success with reviewed/submitted left False.
+            # Callers gate real side effects on ``submitted`` (e.g.
+            # closing the corresponding GitHub PR after a Gerrit
+            # submit), so a dry run must never claim it submitted.
             return GerritSubmitResult.success_result(
                 change_number=change.number,
                 project=change.project,
-                reviewed=True,
-                submitted=True,
+                reviewed=False,
+                submitted=False,
                 duration=time.time() - start_time,
             )
 

--- a/src/dependamerge/gerrit/submit_manager.py
+++ b/src/dependamerge/gerrit/submit_manager.py
@@ -167,26 +167,37 @@ class GerritSubmitManager:
         if not changes:
             return []
 
-        # Use ThreadPoolExecutor for parallel execution
+        # Use ThreadPoolExecutor for parallel execution.  Keep each
+        # future paired with its change so an unexpected worker error
+        # can still be attributed to the right change in the results
+        # (and mapped back to a URL in the final failure recap).
         with ThreadPoolExecutor(max_workers=self._max_workers) as executor:
             futures = [
-                executor.submit(
-                    self._submit_with_tracking, change, review_labels, dry_run
+                (
+                    executor.submit(
+                        self._submit_with_tracking, change, review_labels, dry_run
+                    ),
+                    change,
                 )
                 for change, _comparison in changes
             ]
 
             results = []
-            for future in futures:
+            for future, change in futures:
                 try:
                     result = future.result()
                     results.append(result)
                 except Exception as exc:
-                    log.error("Unexpected error in parallel submit: %s", exc)
+                    log.error(
+                        "Unexpected error in parallel submit for %s #%d: %s",
+                        change.project,
+                        change.number,
+                        exc,
+                    )
                     results.append(
                         GerritSubmitResult.failure_result(
-                            change_number=0,
-                            project="unknown",
+                            change_number=change.number,
+                            project=change.project,
                             error=str(exc),
                         )
                     )

--- a/src/dependamerge/gerrit/submit_manager.py
+++ b/src/dependamerge/gerrit/submit_manager.py
@@ -239,6 +239,95 @@ class GerritSubmitManager:
                 tracker.merge_failure(change_key)
         return result
 
+    def _precheck_submit(
+        self,
+        change: GerritChangeInfo,
+        dry_run: bool,
+        start_time: float,
+    ) -> GerritSubmitResult | None:
+        """Return a short-circuit result, or None when submission may proceed.
+
+        Rejects changes that cannot be submitted (not open, work in
+        progress) and satisfies dry runs without any network calls.
+        """
+        if not change.is_open:
+            return GerritSubmitResult.failure_result(
+                change_number=change.number,
+                project=change.project,
+                error=f"Change is not open (status: {change.status})",
+                duration=time.time() - start_time,
+            )
+
+        if change.work_in_progress:
+            return GerritSubmitResult.failure_result(
+                change_number=change.number,
+                project=change.project,
+                error="Change is marked as Work In Progress",
+                duration=time.time() - start_time,
+            )
+
+        if dry_run:
+            log.info(
+                "[DRY RUN] Would review and submit %s #%d",
+                change.project,
+                change.number,
+            )
+            return GerritSubmitResult.success_result(
+                change_number=change.number,
+                project=change.project,
+                reviewed=True,
+                submitted=True,
+                duration=time.time() - start_time,
+            )
+
+        return None
+
+    def _submit_error_result(
+        self,
+        change: GerritChangeInfo,
+        exc: Exception,
+        reviewed: bool,
+        start_time: float,
+    ) -> GerritSubmitResult:
+        """Map an exception raised during submission to a failure result.
+
+        Classifies the exception, logs it at the matching level (auth
+        and REST errors are expected; anything else is logged with a
+        traceback), and returns a failure result.
+        """
+        if isinstance(exc, GerritAuthError):
+            log.error(
+                "Authentication error for %s #%d: %s",
+                change.project,
+                change.number,
+                exc,
+            )
+            message = f"Authentication error: {exc}"
+        elif isinstance(exc, GerritRestError):
+            log.error(
+                "REST error for %s #%d: %s",
+                change.project,
+                change.number,
+                exc,
+            )
+            message = f"REST error: {exc}"
+        else:
+            log.exception(
+                "Unexpected error for %s #%d: %s",
+                change.project,
+                change.number,
+                exc,
+            )
+            message = f"Unexpected error: {exc}"
+
+        return GerritSubmitResult.failure_result(
+            change_number=change.number,
+            project=change.project,
+            error=message,
+            reviewed=reviewed,
+            duration=time.time() - start_time,
+        )
+
     def _submit_single_change(
         self,
         change: GerritChangeInfo,
@@ -258,50 +347,14 @@ class GerritSubmitManager:
         """
         start_time = time.time()
         reviewed = False
-        submitted = False
+
+        precheck = self._precheck_submit(change, dry_run, start_time)
+        if precheck is not None:
+            return precheck
 
         try:
-            # Check if change can be submitted
-            if not change.is_open:
-                return GerritSubmitResult.failure_result(
-                    change_number=change.number,
-                    project=change.project,
-                    error=f"Change is not open (status: {change.status})",
-                    duration=time.time() - start_time,
-                )
-
-            if change.work_in_progress:
-                return GerritSubmitResult.failure_result(
-                    change_number=change.number,
-                    project=change.project,
-                    error="Change is marked as Work In Progress",
-                    duration=time.time() - start_time,
-                )
-
-            if dry_run:
-                log.info(
-                    "[DRY RUN] Would review and submit %s #%d",
-                    change.project,
-                    change.number,
-                )
-                return GerritSubmitResult.success_result(
-                    change_number=change.number,
-                    project=change.project,
-                    reviewed=True,
-                    submitted=True,
-                    duration=time.time() - start_time,
-                )
-
             review_success = self._review_change(change.number, review_labels)
-            if review_success:
-                reviewed = True
-                log.info(
-                    "Applied review to %s #%d: %s",
-                    change.project,
-                    change.number,
-                    review_labels,
-                )
-            else:
+            if not review_success:
                 return GerritSubmitResult.failure_result(
                     change_number=change.number,
                     project=change.project,
@@ -309,16 +362,16 @@ class GerritSubmitManager:
                     reviewed=False,
                     duration=time.time() - start_time,
                 )
+            reviewed = True
+            log.info(
+                "Applied review to %s #%d: %s",
+                change.project,
+                change.number,
+                review_labels,
+            )
 
             submit_success = self._submit_change(change.number)
-            if submit_success:
-                submitted = True
-                log.info(
-                    "Submitted %s #%d",
-                    change.project,
-                    change.number,
-                )
-            else:
+            if not submit_success:
                 return GerritSubmitResult.failure_result(
                     change_number=change.number,
                     project=change.project,
@@ -326,59 +379,22 @@ class GerritSubmitManager:
                     reviewed=reviewed,
                     duration=time.time() - start_time,
                 )
+            log.info(
+                "Submitted %s #%d",
+                change.project,
+                change.number,
+            )
 
             return GerritSubmitResult.success_result(
                 change_number=change.number,
                 project=change.project,
                 reviewed=reviewed,
-                submitted=submitted,
-                duration=time.time() - start_time,
-            )
-
-        except GerritAuthError as exc:
-            log.error(
-                "Authentication error for %s #%d: %s",
-                change.project,
-                change.number,
-                exc,
-            )
-            return GerritSubmitResult.failure_result(
-                change_number=change.number,
-                project=change.project,
-                error=f"Authentication error: {exc}",
-                reviewed=reviewed,
-                duration=time.time() - start_time,
-            )
-
-        except GerritRestError as exc:
-            log.error(
-                "REST error for %s #%d: %s",
-                change.project,
-                change.number,
-                exc,
-            )
-            return GerritSubmitResult.failure_result(
-                change_number=change.number,
-                project=change.project,
-                error=f"REST error: {exc}",
-                reviewed=reviewed,
+                submitted=True,
                 duration=time.time() - start_time,
             )
 
         except Exception as exc:
-            log.exception(
-                "Unexpected error for %s #%d: %s",
-                change.project,
-                change.number,
-                exc,
-            )
-            return GerritSubmitResult.failure_result(
-                change_number=change.number,
-                project=change.project,
-                error=f"Unexpected error: {exc}",
-                reviewed=reviewed,
-                duration=time.time() - start_time,
-            )
+            return self._submit_error_result(change, exc, reviewed, start_time)
 
     def _review_change(
         self,

--- a/src/dependamerge/progress_tracker.py
+++ b/src/dependamerge/progress_tracker.py
@@ -493,6 +493,7 @@ class MergeProgressTracker(ProgressTracker):
         operation_label: str | None = None,
         operation_icon: str | None = None,
         preview: bool = False,
+        unit_label: str = "PRs",
     ):
         """Initialize merge progress tracker.
 
@@ -512,6 +513,10 @@ class MergeProgressTracker(ProgressTracker):
                 "Would fail") instead of the execution labels
                 ("Merged" / "Failed") that would misstate what
                 happened.
+            unit_label: Noun used for the per-item progress fraction
+                (e.g. ``"3/9 PRs"``).  GitHub callers keep the default
+                ``"PRs"``; Gerrit callers pass ``"changes"`` so the
+                display matches the platform's terminology.
         """
         super().__init__(organization, show_pr_stats=True)
         self.similar_prs_found = 0
@@ -528,6 +533,7 @@ class MergeProgressTracker(ProgressTracker):
         self.preview = preview
         self._custom_label = operation_label
         self._custom_icon = operation_icon
+        self.unit_label = unit_label
         # PR-level progress (used for repo-scoped operations)
         self.total_prs = 0
         self.completed_prs = 0
@@ -661,7 +667,7 @@ class MergeProgressTracker(ProgressTracker):
             text.append(f"{icon} {label} in ", style="bold blue")
             text.append(f"{self.organization} ", style="bold cyan")
             text.append(
-                f"({self.completed_prs}/{self.total_prs} PRs, ",
+                f"({self.completed_prs}/{self.total_prs} {self.unit_label}, ",
                 style="dim",
             )
             text.append(f"{progress_pct:.0f}%", style="bold green")
@@ -793,6 +799,7 @@ class DummyProgressTracker(ProgressTracker):
         self.preview = False
         self._custom_label: str | None = None
         self._custom_icon: str | None = None
+        self.unit_label = "PRs"
         self.total_prs = 0
         self.completed_prs = 0
         self._pr_states: dict[str, str] = {}

--- a/src/dependamerge/progress_tracker.py
+++ b/src/dependamerge/progress_tracker.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import logging
 import sys
+import threading
 from datetime import datetime, timedelta
 from typing import Any
 
@@ -479,11 +480,14 @@ class MergeProgressTracker(ProgressTracker):
 
     # Transitory display states in pipeline order.  Each entry is
     # ``(state_key, display_label)``; only non-zero states render.
+    # ``submitting`` is recorded by the Gerrit submit manager while a
+    # change's review + submit round-trips run.
     _STATE_ORDER: tuple[tuple[str, str], ...] = (
         ("rebasing", "🔄 Rebasing"),
         ("rebased", "⬆️ Rebased"),
         ("recreating", "♻️ Recreating"),
         ("waiting", "⏳ Waiting"),
+        ("submitting", "📤 Submitting"),
     )
 
     def __init__(
@@ -540,10 +544,17 @@ class MergeProgressTracker(ProgressTracker):
         # Transitory per-PR display states: pr_key -> state key from
         # ``_STATE_ORDER``.  Terminal outcomes remove the entry.
         self._pr_states: dict[str, str] = {}
+        # Counter and state mutations may arrive from worker threads
+        # (the Gerrit submit manager records outcomes from a
+        # ThreadPoolExecutor) while Rich's refresh thread renders the
+        # display, so both mutation and the render-time snapshot are
+        # guarded by this re-entrant lock.
+        self._state_lock = threading.RLock()
 
     def found_similar_pr(self, count: int = 1) -> None:
         """Update count of similar PRs found."""
-        self.similar_prs_found += count
+        with self._state_lock:
+            self.similar_prs_found += count
         self._refresh_display()
 
     def set_total_prs(self, total: int) -> None:
@@ -552,7 +563,8 @@ class MergeProgressTracker(ProgressTracker):
         When set, the progress display switches from repo-level
         to PR-level progress (e.g. ``3/9 PRs, 33%``).
         """
-        self.total_prs = total
+        with self._state_lock:
+            self.total_prs = total
         self._refresh_display()
 
     def track_pr_state(self, pr_key: str, state: str | None) -> None:
@@ -567,16 +579,19 @@ class MergeProgressTracker(ProgressTracker):
         transitory entry when given the PR key.
         """
         if state is None:
-            self._pr_states.pop(pr_key, None)
+            with self._state_lock:
+                self._pr_states.pop(pr_key, None)
         else:
-            self._pr_states[pr_key] = state
+            with self._state_lock:
+                self._pr_states[pr_key] = state
         self._refresh_display()
 
     def _finish_pr(self, pr_key: str | None) -> None:
         """Shared terminal-outcome bookkeeping.
 
         Clears the PR's transitory state (when a key is supplied) and
-        advances PR-level completion progress.
+        advances PR-level completion progress.  Callers must hold
+        ``_state_lock``.
         """
         if pr_key is not None:
             self._pr_states.pop(pr_key, None)
@@ -585,14 +600,16 @@ class MergeProgressTracker(ProgressTracker):
 
     def merge_success(self, pr_key: str | None = None) -> None:
         """Record a successful merge."""
-        self._finish_pr(pr_key)
-        self.prs_merged += 1
+        with self._state_lock:
+            self._finish_pr(pr_key)
+            self.prs_merged += 1
         self._refresh_display()
 
     def merge_failure(self, pr_key: str | None = None) -> None:
         """Record a failed merge."""
-        self._finish_pr(pr_key)
-        self.prs_failed += 1
+        with self._state_lock:
+            self._finish_pr(pr_key)
+            self.prs_failed += 1
         self._refresh_display()
 
     def merge_skipped(self, pr_key: str | None = None) -> None:
@@ -603,14 +620,16 @@ class MergeProgressTracker(ProgressTracker):
         by us.  Tracked separately so the final summary can show
         a non-zero ⏭️ Skipped count alongside Merged / Failed.
         """
-        self._finish_pr(pr_key)
-        self.prs_skipped += 1
+        with self._state_lock:
+            self._finish_pr(pr_key)
+            self.prs_skipped += 1
         self._refresh_display()
 
     def merge_blocked(self, pr_key: str | None = None) -> None:
         """Record a PR that is blocked and cannot merge in this run."""
-        self._finish_pr(pr_key)
-        self.prs_blocked += 1
+        with self._state_lock:
+            self._finish_pr(pr_key)
+            self.prs_blocked += 1
         self._refresh_display()
 
     def merge_pending(self, pr_key: str | None = None) -> None:
@@ -620,14 +639,16 @@ class MergeProgressTracker(ProgressTracker):
         pass; from this run's perspective the PR is terminal but
         neither merged nor failed.
         """
-        self._finish_pr(pr_key)
-        self.prs_pending += 1
+        with self._state_lock:
+            self._finish_pr(pr_key)
+            self.prs_pending += 1
         self._refresh_display()
 
     def increment_closed(self, pr_key: str | None = None) -> None:
         """Record a successful close."""
-        self._finish_pr(pr_key)
-        self.prs_closed += 1
+        with self._state_lock:
+            self._finish_pr(pr_key)
+            self.prs_closed += 1
         self._refresh_display()
 
     def pr_completed(self) -> None:
@@ -639,8 +660,9 @@ class MergeProgressTracker(ProgressTracker):
         progress percentage accurate for terminal states that no
         counter method covers.
         """
-        if self.total_prs > 0:
-            self.completed_prs += 1
+        with self._state_lock:
+            if self.total_prs > 0:
+                self.completed_prs += 1
         self._refresh_display()
 
     def _generate_display_text(self) -> Any:
@@ -657,17 +679,36 @@ class MergeProgressTracker(ProgressTracker):
         )
         label = self._custom_label or default_label
 
+        # Snapshot every counter guarded by _state_lock in one
+        # acquisition (together with the per-PR states) before
+        # rendering.  This method runs on Rich's refresh thread while
+        # worker threads mutate these fields, so reading them
+        # individually could otherwise observe a mixed snapshot (or,
+        # worst case, see total_prs flip to 0 between the guard and the
+        # division and raise ZeroDivisionError).
+        with self._state_lock:
+            total_prs = self.total_prs
+            completed_prs = self.completed_prs
+            similar_prs_found = self.similar_prs_found
+            prs_merged = self.prs_merged
+            prs_pending = self.prs_pending
+            prs_closed = self.prs_closed
+            prs_failed = self.prs_failed
+            prs_skipped = self.prs_skipped
+            prs_blocked = self.prs_blocked
+            pr_states = list(self._pr_states.values())
+
         # Main progress line for merge/close operations.
         # PR-level progress takes priority over repo-level progress
         # so repo-scoped merges show "3/9 PRs" instead of "0/1 repos".
-        if self.total_prs > 0:
-            progress_pct = (self.completed_prs / self.total_prs) * 100
+        if total_prs > 0:
+            progress_pct = (completed_prs / total_prs) * 100
             default_icon = "🚪" if self.is_close_operation else "🔀"
             icon = self._custom_icon or default_icon
             text.append(f"{icon} {label} in ", style="bold blue")
             text.append(f"{self.organization} ", style="bold cyan")
             text.append(
-                f"({self.completed_prs}/{self.total_prs} {self.unit_label}, ",
+                f"({completed_prs}/{total_prs} {self.unit_label}, ",
                 style="dim",
             )
             text.append(f"{progress_pct:.0f}%", style="bold green")
@@ -695,12 +736,13 @@ class MergeProgressTracker(ProgressTracker):
             text.append(f"\n   {self.current_operation}", style="dim")
 
         # Merge stats — transitory pipeline states first (in flow
-        # order), then terminal outcomes.
+        # order), then terminal outcomes.  The per-PR states and the
+        # counters below were snapshotted under _state_lock above.
         stats_parts: list[str] = []
-        if self.similar_prs_found > 0:
-            stats_parts.append(f"🔁 Similar: {self.similar_prs_found}")
+        if similar_prs_found > 0:
+            stats_parts.append(f"🔁 Similar: {similar_prs_found}")
         state_counts: dict[str, int] = {}
-        for pr_state in self._pr_states.values():
+        for pr_state in pr_states:
             state_counts[pr_state] = state_counts.get(pr_state, 0) + 1
         for state_key, label in self._STATE_ORDER:
             count = state_counts.get(state_key, 0)
@@ -715,22 +757,22 @@ class MergeProgressTracker(ProgressTracker):
                 stats_parts.append(
                     f"{state_key.capitalize()}: {state_counts[state_key]}"
                 )
-        if self.prs_merged > 0:
+        if prs_merged > 0:
             # A preview run merges nothing — the counter records PRs
             # judged mergeable, so label it accordingly.
-            merged_label = "\u2705 Mergeable" if self.preview else "\u2705 Merged"
-            stats_parts.append(f"{merged_label}: {self.prs_merged}")
-        if self.prs_pending > 0:
-            stats_parts.append(f"\U0001f916 Pending: {self.prs_pending}")
-        if self.prs_closed > 0:
-            stats_parts.append(f"\U0001f6aa Closed: {self.prs_closed}")
-        if self.prs_failed > 0:
-            failed_label = "\u274c Would fail" if self.preview else "\u274c Failed"
-            stats_parts.append(f"{failed_label}: {self.prs_failed}")
-        if self.prs_skipped > 0:
-            stats_parts.append(f"⏭️ Skipped: {self.prs_skipped}")
-        if self.prs_blocked > 0:
-            stats_parts.append(f"🛑 Blocked: {self.prs_blocked}")
+            merged_label = "✅ Mergeable" if self.preview else "✅ Merged"
+            stats_parts.append(f"{merged_label}: {prs_merged}")
+        if prs_pending > 0:
+            stats_parts.append(f"\U0001f916 Pending: {prs_pending}")
+        if prs_closed > 0:
+            stats_parts.append(f"\U0001f6aa Closed: {prs_closed}")
+        if prs_failed > 0:
+            failed_label = "❌ Would fail" if self.preview else "❌ Failed"
+            stats_parts.append(f"{failed_label}: {prs_failed}")
+        if prs_skipped > 0:
+            stats_parts.append(f"⏭️ Skipped: {prs_skipped}")
+        if prs_blocked > 0:
+            stats_parts.append(f"🛑 Blocked: {prs_blocked}")
 
         if stats_parts:
             text.append(f"\n   {' | '.join(stats_parts)}", style="dim")

--- a/src/dependamerge/url_parser.py
+++ b/src/dependamerge/url_parser.py
@@ -16,6 +16,10 @@ GitHub:
 Gerrit:
     https://gerrit.linuxfoundation.org/infra/c/project/name/+/12345
     https://gerrit.example.org/c/project/+/67890
+
+Gerrit topic search (see parse_gerrit_topic_url):
+    https://gerrit.example.org/q/topic:some-topic
+    https://gerrit.onap.org/r/q/topic:some-topic
 """
 
 from __future__ import annotations
@@ -23,7 +27,7 @@ from __future__ import annotations
 import re
 from dataclasses import dataclass
 from enum import Enum
-from urllib.parse import urlparse
+from urllib.parse import unquote, urlparse
 
 # aislop-ignore-file ai-slop/hardcoded-url -- This module parses and builds
 # GitHub/Gerrit URLs, so URL literals here are the subject matter, not
@@ -70,6 +74,37 @@ class ParsedUrl:
     def is_github(self) -> bool:
         """Check if this URL is from GitHub."""
         return self.source == ChangeSource.GITHUB
+
+    @property
+    def is_gerrit(self) -> bool:
+        """Check if this URL is from Gerrit."""
+        return self.source == ChangeSource.GERRIT
+
+
+@dataclass(frozen=True)
+class ParsedGerritTopicUrl:
+    """
+    Parsed Gerrit topic search URL.
+
+    Represents a Gerrit query URL that scopes work to a topic, e.g.
+    ``https://gerrit.onap.org/r/q/topic:update-settings``.  Only
+    ``topic:`` queries are supported; other search operators in the
+    query are ignored for parsing purposes.
+
+    Attributes:
+        source: The code review platform (always Gerrit).
+        host: The hostname of the Gerrit server.
+        base_path: The base path for the Gerrit server (e.g., "r"),
+                   or None when the server is mounted at the root.
+        topic: The Gerrit topic name extracted from the query.
+        original_url: The original URL that was parsed.
+    """
+
+    source: ChangeSource
+    host: str
+    base_path: str | None
+    topic: str
+    original_url: str
 
     @property
     def is_gerrit(self) -> bool:
@@ -327,6 +362,96 @@ def _parse_gerrit_url(host: str, path: str, original_url: str) -> ParsedUrl:
         base_path=base_path,
         project=project,
         change_number=change_number,
+        original_url=original_url,
+    )
+
+
+def parse_gerrit_topic_url(url: str) -> ParsedGerritTopicUrl:
+    """
+    Parse a Gerrit topic search URL.
+
+    Supported formats (the optional base path, e.g. "r", precedes /q/):
+        https://gerrit.example.org/q/topic:some-topic
+        https://gerrit.onap.org/r/q/topic:some-topic
+        https://gerrit.example.org/#/q/topic:some-topic  (legacy UI)
+
+    Additional search operators in the query (separated by '+' or
+    whitespace) are tolerated; only the ``topic:`` term is extracted.
+    Quoted topics (``topic:"some topic"``) and percent-encoded
+    characters are handled.
+
+    Args:
+        url: The URL to parse.
+
+    Returns:
+        A ParsedGerritTopicUrl with the host, base path, and topic.
+
+    Raises:
+        UrlParseError: If the URL is not a Gerrit topic search URL.
+    """
+    original_url = url.strip()
+    if not original_url:
+        raise UrlParseError("URL cannot be empty")
+
+    normalized = original_url
+    if not normalized.startswith(("http://", "https://")):
+        normalized = "https://" + normalized
+
+    try:
+        parsed = urlparse(normalized)
+    except Exception as exc:
+        raise UrlParseError(f"Invalid URL format: {exc}") from exc
+
+    if not parsed.hostname:
+        raise UrlParseError("URL must include a hostname")
+
+    host = parsed.hostname.lower()
+
+    # The legacy UI keeps the query in the fragment (/#/q/...); the
+    # PolyGerrit UI keeps it in the path (/q/...).
+    path = unquote(parsed.path).rstrip("/")
+    fragment = unquote(parsed.fragment).rstrip("/")
+    if fragment.startswith("/q/"):
+        query_expr = fragment[len("/q/") :]
+        base_segments = [s for s in path.split("/") if s]
+    else:
+        segments = [s for s in path.split("/") if s]
+        if "q" not in segments:
+            raise UrlParseError(
+                f"Not a Gerrit search URL (no /q/ segment): {original_url}"
+            )
+        q_index = segments.index("q")
+        base_segments = segments[:q_index]
+        query_expr = "/".join(segments[q_index + 1 :])
+
+    if not query_expr:
+        raise UrlParseError(
+            f"Gerrit search URL contains no query expression: {original_url}"
+        )
+
+    # Gerrit search URLs separate terms with '+' (rendered as space).
+    match = re.search(
+        r'(?:^|[+\s])topic:(?:"([^"]+)"|([^+\s"]+))',
+        query_expr,
+    )
+    if not match:
+        raise UrlParseError(
+            "Only topic searches are supported for Gerrit query URLs. "
+            f"Expected: https://{host}/q/topic:some-topic "
+            f"(got query: {query_expr})"
+        )
+
+    topic = (match.group(1) or match.group(2) or "").strip()
+    if not topic:
+        raise UrlParseError("Gerrit topic cannot be empty")
+
+    base_path = "/".join(base_segments) if base_segments else None
+
+    return ParsedGerritTopicUrl(
+        source=ChangeSource.GERRIT,
+        host=host,
+        base_path=base_path,
+        topic=topic,
         original_url=original_url,
     )
 

--- a/tests/integration/test_live_gerrit.py
+++ b/tests/integration/test_live_gerrit.py
@@ -71,3 +71,57 @@ class TestGerritDryRunLive:
         assert "Dry run: no changes were reviewed or submitted" in combined_output(
             result
         )
+
+
+class TestGerritPermissionParsingLive:
+    def test_change_info_merges_change_and_revision_actions(self, gerrit_settings):
+        """Parsed change actions include both change- and revision-level actions.
+
+        Gerrit returns the 'submit' action only under
+        ``revisions[<rev>].actions`` (CURRENT_ACTIONS); change-level
+        actions come from CHANGE_ACTIONS.  The permission checks rely on
+        ``GerritChangeInfo.actions`` being the union of both, so verify
+        that invariant against a real server response.
+        """
+        from dependamerge.gerrit.models import GerritChangeInfo
+        from dependamerge.gerrit.service import (
+            DEFAULT_CHANGE_OPTIONS,
+            create_gerrit_service,
+        )
+
+        service = create_gerrit_service(
+            host=gerrit_settings["host"],
+            base_path=gerrit_settings.get("base_path") or None,
+            username=gerrit_settings["username"],
+            password=gerrit_settings["password"],
+        )
+        changes = service.get_all_open_changes(limit=25)
+        if not changes:
+            pytest.skip(
+                f"No open changes found on '{gerrit_settings['host']}'; "
+                "skipping Gerrit permission parsing integration test"
+            )
+
+        params = "&".join(f"o={opt}" for opt in DEFAULT_CHANGE_OPTIONS)
+        endpoint = f"/changes/{changes[0].number}?{params}"
+        data = service._client.get(endpoint)
+
+        change = GerritChangeInfo.from_api_response(
+            data,
+            host=gerrit_settings["host"],
+            base_path=gerrit_settings.get("base_path") or None,
+        )
+
+        change_actions = set((data.get("actions") or {}).keys())
+        revision_data = (data.get("revisions") or {}).get(
+            data.get("current_revision", ""), {}
+        )
+        revision_actions = set((revision_data.get("actions") or {}).keys())
+
+        # An authenticated caller should see at least one action; if the
+        # server returned none the invariant below is vacuous, so skip.
+        if not (change_actions | revision_actions):
+            pytest.skip("Server returned no caller actions for the probed change")
+
+        assert change_actions <= set(change.actions.keys())
+        assert revision_actions <= set(change.actions.keys())

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -19,7 +19,7 @@ from dependamerge.cli import (
     _validate_override_sha,
     app,
 )
-from dependamerge.gerrit.models import GerritChangeInfo
+from dependamerge.gerrit.models import GerritChangeInfo, GerritComparisonResult
 from dependamerge.models import PullRequestInfo
 from dependamerge.url_parser import ChangeSource, ParsedUrl
 
@@ -1046,7 +1046,7 @@ class TestCLI:
         mock_confirm.return_value = True
 
         submit_manager = Mock()
-        submit_manager.submit_changes.return_value = []
+        submit_manager.submit_changes_parallel.return_value = []
         mock_create_submit_manager.return_value = submit_manager
 
         console = Console(record=True, width=120)
@@ -1059,7 +1059,7 @@ class TestCLI:
         )
 
         mock_confirm.assert_called_once_with(change, console)
-        submit_manager.submit_changes.assert_called_once()
+        submit_manager.submit_changes_parallel.assert_called_once()
 
     @patch("dependamerge.cli.create_submit_manager")
     @patch("dependamerge.cli._confirm_gerrit_submission")
@@ -1118,6 +1118,60 @@ class TestCLI:
         output = console.export_text()
         assert _generate_gerrit_continue_sha(change) in output
         assert "Test mode detected" in output
+
+    def test_gerrit_final_summary_all_submitted(self):
+        """Test the final summary reports submitted counts inline."""
+        from dependamerge.cli import _print_gerrit_final_summary
+        from dependamerge.gerrit.models import GerritSubmitResult
+
+        changes: list[tuple[GerritChangeInfo, GerritComparisonResult | None]] = [
+            (self._automation_gerrit_change(number=1), None),
+            (self._automation_gerrit_change(number=2), None),
+        ]
+        results = [
+            GerritSubmitResult.success_result(change_number=1, project="proj"),
+            GerritSubmitResult.success_result(change_number=2, project="proj"),
+        ]
+
+        console = Console(record=True, width=120)
+        _print_gerrit_final_summary(results, changes, console)
+
+        output = console.export_text()
+        assert "Final Results: 2 submitted, 0 failed" in output
+        assert "Failed changes" not in output
+
+    def test_gerrit_final_summary_reports_failures_with_urls(self):
+        """Test failed changes are recapped with URL and reason."""
+        from dependamerge.cli import _print_gerrit_final_summary
+        from dependamerge.gerrit.models import GerritSubmitResult
+
+        ok_change = self._automation_gerrit_change(number=1)
+        bad_change = self._automation_gerrit_change(number=2)
+        bad_change.url = "https://gerrit.example.org/c/proj/+/2"
+        changes: list[tuple[GerritChangeInfo, GerritComparisonResult | None]] = [
+            (ok_change, None),
+            (bad_change, None),
+        ]
+        results = [
+            GerritSubmitResult.success_result(change_number=1, project="proj"),
+            GerritSubmitResult.failure_result(
+                change_number=2,
+                project="proj",
+                error="Failed to submit (change may not be submittable)",
+                reviewed=True,
+            ),
+        ]
+
+        console = Console(record=True, width=120)
+        _print_gerrit_final_summary(results, changes, console)
+
+        output = console.export_text()
+        assert (
+            "Final Results: 1 submitted, 1 failed, 1 reviewed (not submitted)" in output
+        )
+        assert "Failed changes:" in output
+        assert "https://gerrit.example.org/c/proj/+/2" in output
+        assert "Failed to submit (change may not be submittable)" in output
 
     @patch("dependamerge.cli.GitHubClient")
     @patch("dependamerge.cli.PRComparator")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -715,6 +715,7 @@ class TestCLI:
             change,
             comparator,
             only_automation=False,
+            candidates=None,
         )
 
     @patch("dependamerge.cli.create_gerrit_comparator")
@@ -753,6 +754,219 @@ class TestCLI:
 
         assert exc_info.value.code == 8
         service.find_similar_changes.assert_not_called()
+
+    @staticmethod
+    def _automation_gerrit_change(
+        number: int = 123,
+        project: str = "proj",
+        topic: str | None = None,
+    ) -> GerritChangeInfo:
+        return GerritChangeInfo(
+            number=number,
+            change_id=f"I{number}",
+            project=project,
+            subject="Chore: Bump actions/checkout from 4.1.0 to 4.2.0",
+            owner="dependabot",
+            branch="main",
+            status="NEW",
+            topic=topic,
+            permitted_labels={"Code-Review": ["-2", "-1", "0", "+1", "+2"]},
+        )
+
+    @patch("dependamerge.cli.create_gerrit_comparator")
+    @patch("dependamerge.cli.create_gerrit_service")
+    @patch("dependamerge.cli.resolve_gerrit_credentials")
+    def test_gerrit_merge_scopes_candidates_to_source_topic(
+        self,
+        mock_resolve_credentials,
+        mock_create_service,
+        mock_create_comparator,
+    ):
+        """Test the source change's own topic scopes the candidate search."""
+        change = self._automation_gerrit_change(topic="update-settings")
+        sibling = self._automation_gerrit_change(
+            number=124, project="other-proj", topic="update-settings"
+        )
+        credentials = Mock(is_valid=True, username="user", password="pass")
+        credentials.auth_method_display.return_value = ".netrc file"
+        mock_resolve_credentials.return_value = credentials
+
+        service = Mock(is_authenticated=True)
+        service.get_change_info.return_value = change
+        service.get_changes_by_topic.return_value = [sibling]
+        service.find_similar_changes.return_value = []
+        mock_create_service.return_value = service
+
+        comparator = Mock()
+        comparator.is_automation_change.return_value = True
+        mock_create_comparator.return_value = comparator
+
+        console = Console(record=True, width=120)
+        _handle_gerrit_merge(
+            parsed_url=self._gerrit_parsed_url(),
+            no_confirm=True,
+            similarity_threshold=0.8,
+            verbose=False,
+            console=console,
+            dry_run=True,
+        )
+
+        service.get_changes_by_topic.assert_called_once_with("update-settings")
+        service.find_similar_changes.assert_called_once_with(
+            change,
+            comparator,
+            only_automation=True,
+            candidates=[sibling],
+        )
+        output = console.export_text()
+        assert "update-settings" in output
+
+    @patch("dependamerge.cli.create_gerrit_comparator")
+    @patch("dependamerge.cli.create_gerrit_service")
+    @patch("dependamerge.cli.resolve_gerrit_credentials")
+    def test_gerrit_merge_topic_url_anchors_first_open_change(
+        self,
+        mock_resolve_credentials,
+        mock_create_service,
+        mock_create_comparator,
+    ):
+        """Test a topic search URL anchors on the first open topic change."""
+        from dependamerge.url_parser import ParsedGerritTopicUrl
+
+        anchor_listed = self._automation_gerrit_change(
+            number=200, topic="update-settings"
+        )
+        anchor_full = self._automation_gerrit_change(
+            number=200, topic="update-settings"
+        )
+        sibling = self._automation_gerrit_change(
+            number=201, project="other-proj", topic="update-settings"
+        )
+        credentials = Mock(is_valid=True, username="user", password="pass")
+        credentials.auth_method_display.return_value = ".netrc file"
+        mock_resolve_credentials.return_value = credentials
+
+        service = Mock(is_authenticated=True)
+        service.get_changes_by_topic.return_value = [anchor_listed, sibling]
+        service.get_change_info.return_value = anchor_full
+        service.find_similar_changes.return_value = []
+        mock_create_service.return_value = service
+
+        comparator = Mock()
+        comparator.is_automation_change.return_value = True
+        mock_create_comparator.return_value = comparator
+
+        parsed_topic = ParsedGerritTopicUrl(
+            source=ChangeSource.GERRIT,
+            host="gerrit.example.org",
+            base_path=None,
+            topic="update-settings",
+            original_url="https://gerrit.example.org/q/topic:update-settings",
+        )
+
+        console = Console(record=True, width=120)
+        _handle_gerrit_merge(
+            parsed_url=parsed_topic,
+            no_confirm=True,
+            similarity_threshold=0.8,
+            verbose=False,
+            console=console,
+            dry_run=True,
+        )
+
+        # The anchor change is refetched for full details
+        service.get_change_info.assert_called_once_with(200)
+        # The topic changes are reused as candidates (no second query)
+        service.get_changes_by_topic.assert_called_once_with("update-settings")
+        service.find_similar_changes.assert_called_once_with(
+            anchor_full,
+            comparator,
+            only_automation=True,
+            candidates=[anchor_listed, sibling],
+        )
+
+    @patch("dependamerge.cli.create_gerrit_comparator")
+    @patch("dependamerge.cli.create_gerrit_service")
+    @patch("dependamerge.cli.resolve_gerrit_credentials")
+    def test_gerrit_merge_topic_url_no_open_changes(
+        self,
+        mock_resolve_credentials,
+        mock_create_service,
+        mock_create_comparator,
+    ):
+        """Test a topic search URL with no open changes exits cleanly."""
+        from dependamerge.url_parser import ParsedGerritTopicUrl
+
+        credentials = Mock(is_valid=True, username="user", password="pass")
+        credentials.auth_method_display.return_value = ".netrc file"
+        mock_resolve_credentials.return_value = credentials
+
+        service = Mock(is_authenticated=True)
+        service.get_changes_by_topic.return_value = []
+        mock_create_service.return_value = service
+
+        console = Console(record=True, width=120)
+        with pytest.raises(typer.Exit) as exc_info:
+            _handle_gerrit_merge(
+                parsed_url=ParsedGerritTopicUrl(
+                    source=ChangeSource.GERRIT,
+                    host="gerrit.example.org",
+                    base_path=None,
+                    topic="empty-topic",
+                    original_url="https://gerrit.example.org/q/topic:empty-topic",
+                ),
+                no_confirm=True,
+                similarity_threshold=0.8,
+                verbose=False,
+                console=console,
+                dry_run=True,
+            )
+
+        assert exc_info.value.exit_code == 1
+        assert "No open changes found with topic 'empty-topic'" in (
+            console.export_text()
+        )
+
+    @patch("dependamerge.cli.create_gerrit_comparator")
+    @patch("dependamerge.cli.create_gerrit_service")
+    @patch("dependamerge.cli.resolve_gerrit_credentials")
+    def test_gerrit_merge_explicit_topic_flag_wins(
+        self,
+        mock_resolve_credentials,
+        mock_create_service,
+        mock_create_comparator,
+    ):
+        """Test --topic overrides the source change's own topic."""
+        change = self._automation_gerrit_change(topic="own-topic")
+        sibling = self._automation_gerrit_change(
+            number=124, project="other-proj", topic="forced-topic"
+        )
+        credentials = Mock(is_valid=True, username="user", password="pass")
+        credentials.auth_method_display.return_value = ".netrc file"
+        mock_resolve_credentials.return_value = credentials
+
+        service = Mock(is_authenticated=True)
+        service.get_change_info.return_value = change
+        service.get_changes_by_topic.return_value = [sibling]
+        service.find_similar_changes.return_value = []
+        mock_create_service.return_value = service
+
+        comparator = Mock()
+        comparator.is_automation_change.return_value = True
+        mock_create_comparator.return_value = comparator
+
+        console = Console(record=True, width=120)
+        _handle_gerrit_merge(
+            parsed_url=self._gerrit_parsed_url(),
+            no_confirm=True,
+            similarity_threshold=0.8,
+            verbose=False,
+            console=console,
+            dry_run=True,
+            topic="forced-topic",
+        )
+
+        service.get_changes_by_topic.assert_called_once_with("forced-topic")
 
     @patch("dependamerge.cli.GitHubClient")
     @patch("dependamerge.cli.PRComparator")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -968,6 +968,157 @@ class TestCLI:
 
         service.get_changes_by_topic.assert_called_once_with("forced-topic")
 
+    @patch("dependamerge.cli.create_gerrit_comparator")
+    @patch("dependamerge.cli.create_gerrit_service")
+    @patch("dependamerge.cli.resolve_gerrit_credentials")
+    def test_gerrit_merge_interactive_prompts_for_continue_sha(
+        self,
+        mock_resolve_credentials,
+        mock_create_service,
+        mock_create_comparator,
+    ):
+        """Test interactive Gerrit merges prompt with a continue SHA.
+
+        Without --no-confirm the preview must offer the same
+        SHA-confirmation flow as the GitHub path instead of telling the
+        user to re-run with --no-confirm.
+        """
+        from dependamerge.cli import _generate_gerrit_continue_sha
+
+        change = self._automation_gerrit_change()
+        credentials = Mock(is_valid=True, username="user", password="pass")
+        credentials.auth_method_display.return_value = ".netrc file"
+        mock_resolve_credentials.return_value = credentials
+
+        service = Mock(is_authenticated=True)
+        service.get_change_info.return_value = change
+        service.find_similar_changes.return_value = []
+        mock_create_service.return_value = service
+
+        comparator = Mock()
+        comparator.is_automation_change.return_value = True
+        mock_create_comparator.return_value = comparator
+
+        console = Console(record=True, width=120)
+        _handle_gerrit_merge(
+            parsed_url=self._gerrit_parsed_url(),
+            no_confirm=False,
+            similarity_threshold=0.8,
+            verbose=False,
+            console=console,
+        )
+
+        output = console.export_text()
+        expected_sha = _generate_gerrit_continue_sha(change)
+        assert f"To proceed with merging enter: {expected_sha}" in output
+        # Under pytest the interactive prompt is skipped without submitting
+        assert "Test mode detected" in output
+        assert "To proceed, run with --no-confirm" not in output
+
+    @patch("dependamerge.cli.create_submit_manager")
+    @patch("dependamerge.cli._confirm_gerrit_submission")
+    @patch("dependamerge.cli.create_gerrit_comparator")
+    @patch("dependamerge.cli.create_gerrit_service")
+    @patch("dependamerge.cli.resolve_gerrit_credentials")
+    def test_gerrit_merge_interactive_confirmed_submits(
+        self,
+        mock_resolve_credentials,
+        mock_create_service,
+        mock_create_comparator,
+        mock_confirm,
+        mock_create_submit_manager,
+    ):
+        """Test a confirmed interactive Gerrit merge proceeds to submit."""
+        change = self._automation_gerrit_change()
+        credentials = Mock(is_valid=True, username="user", password="pass")
+        credentials.auth_method_display.return_value = ".netrc file"
+        mock_resolve_credentials.return_value = credentials
+
+        service = Mock(is_authenticated=True)
+        service.get_change_info.return_value = change
+        service.find_similar_changes.return_value = []
+        mock_create_service.return_value = service
+
+        comparator = Mock()
+        comparator.is_automation_change.return_value = True
+        mock_create_comparator.return_value = comparator
+
+        mock_confirm.return_value = True
+
+        submit_manager = Mock()
+        submit_manager.submit_changes.return_value = []
+        mock_create_submit_manager.return_value = submit_manager
+
+        console = Console(record=True, width=120)
+        _handle_gerrit_merge(
+            parsed_url=self._gerrit_parsed_url(),
+            no_confirm=False,
+            similarity_threshold=0.8,
+            verbose=False,
+            console=console,
+        )
+
+        mock_confirm.assert_called_once_with(change, console)
+        submit_manager.submit_changes.assert_called_once()
+
+    @patch("dependamerge.cli.create_submit_manager")
+    @patch("dependamerge.cli._confirm_gerrit_submission")
+    @patch("dependamerge.cli.create_gerrit_comparator")
+    @patch("dependamerge.cli.create_gerrit_service")
+    @patch("dependamerge.cli.resolve_gerrit_credentials")
+    def test_gerrit_merge_interactive_declined_does_not_submit(
+        self,
+        mock_resolve_credentials,
+        mock_create_service,
+        mock_create_comparator,
+        mock_confirm,
+        mock_create_submit_manager,
+    ):
+        """Test a declined interactive Gerrit merge never submits."""
+        change = self._automation_gerrit_change()
+        credentials = Mock(is_valid=True, username="user", password="pass")
+        credentials.auth_method_display.return_value = ".netrc file"
+        mock_resolve_credentials.return_value = credentials
+
+        service = Mock(is_authenticated=True)
+        service.get_change_info.return_value = change
+        service.find_similar_changes.return_value = []
+        mock_create_service.return_value = service
+
+        comparator = Mock()
+        comparator.is_automation_change.return_value = True
+        mock_create_comparator.return_value = comparator
+
+        mock_confirm.return_value = False
+
+        console = Console(record=True, width=120)
+        _handle_gerrit_merge(
+            parsed_url=self._gerrit_parsed_url(),
+            no_confirm=False,
+            similarity_threshold=0.8,
+            verbose=False,
+            console=console,
+        )
+
+        mock_create_submit_manager.assert_not_called()
+
+    def test_confirm_gerrit_submission_test_mode_skips_prompt(self):
+        """Test _confirm_gerrit_submission never blocks under pytest."""
+        from dependamerge.cli import (
+            _confirm_gerrit_submission,
+            _generate_gerrit_continue_sha,
+        )
+
+        change = self._automation_gerrit_change()
+        console = Console(record=True, width=120)
+
+        confirmed = _confirm_gerrit_submission(change, console)
+
+        assert confirmed is False
+        output = console.export_text()
+        assert _generate_gerrit_continue_sha(change) in output
+        assert "Test mode detected" in output
+
     @patch("dependamerge.cli.GitHubClient")
     @patch("dependamerge.cli.PRComparator")
     @patch("dependamerge.github_service.GitHubService")

--- a/tests/test_gerrit_models.py
+++ b/tests/test_gerrit_models.py
@@ -566,6 +566,98 @@ class TestGerritChangeInfo:
 
         assert change.owner == "John Doe"
 
+    def test_from_api_response_merges_revision_actions(self):
+        """Test revision-level actions (CURRENT_ACTIONS) merge into actions.
+
+        Gerrit returns the 'submit' action under revisions[<rev>].actions
+        when CURRENT_ACTIONS is requested, not at the change level.
+        Shapes mirror live responses from gerrit.onap.org.
+        """
+        api_data = {
+            "_number": 146534,
+            "change_id": "I123",
+            "project": "ccsdk/apps",
+            "subject": "CI: Update maven settings in clm workflow",
+            "branch": "master",
+            "status": "NEW",
+            "owner": {"username": "kevin.sandi"},
+            "submittable": True,
+            "current_revision": "abc123",
+            "permitted_labels": {
+                "Code-Review": ["-2", "-1", " 0", "+1", "+2"],
+                "Verified": ["-1", " 0", "+1"],
+            },
+            "actions": {
+                "abandon": {"method": "POST", "enabled": True},
+                "topic": {"method": "PUT", "enabled": True},
+            },
+            "revisions": {
+                "abc123": {
+                    "actions": {
+                        "submit": {"method": "POST", "enabled": True},
+                        "rebase": {"method": "POST", "enabled": True},
+                        "cherrypick": {"method": "POST", "enabled": True},
+                    },
+                },
+            },
+        }
+
+        change = GerritChangeInfo.from_api_response(api_data)
+
+        # Change-level and revision-level actions are both present
+        assert "abandon" in change.actions
+        assert "submit" in change.actions
+        assert change.can_submit_action() is True
+        assert change.get_permission_warnings() == []
+
+    def test_from_api_response_revision_actions_only(self):
+        """Test actions populate from revision level with no change-level actions."""
+        api_data = {
+            "_number": 1,
+            "change_id": "I123",
+            "project": "proj",
+            "subject": "Test",
+            "branch": "main",
+            "status": "NEW",
+            "owner": {"username": "user"},
+            "current_revision": "abc123",
+            "revisions": {
+                "abc123": {
+                    "actions": {
+                        "submit": {"method": "POST", "enabled": True},
+                    },
+                },
+            },
+        }
+
+        change = GerritChangeInfo.from_api_response(api_data)
+
+        assert change.can_submit_action() is True
+
+    def test_from_api_response_null_actions(self):
+        """Test explicit null action values do not break parsing."""
+        api_data = {
+            "_number": 1,
+            "change_id": "I123",
+            "project": "proj",
+            "subject": "Test",
+            "branch": "main",
+            "status": "NEW",
+            "owner": {"username": "user"},
+            "current_revision": "abc123",
+            "actions": None,
+            "revisions": {
+                "abc123": {
+                    "actions": None,
+                },
+            },
+        }
+
+        change = GerritChangeInfo.from_api_response(api_data)
+
+        assert change.actions == {}
+        assert change.can_submit_action() is False
+
 
 class TestGerritComparisonResult:
     """Tests for GerritComparisonResult model."""

--- a/tests/test_gerrit_service.py
+++ b/tests/test_gerrit_service.py
@@ -476,6 +476,50 @@ class TestGerritServiceGetChangesByTopic:
         assert "topic:my-topic" in call_args
         assert "status:merged" in call_args
 
+    @patch("dependamerge.gerrit.service.build_client")
+    @patch("dependamerge.gerrit.service.create_url_builder")
+    def test_get_changes_by_topic_quotes_whitespace(
+        self,
+        mock_url_builder,
+        mock_build_client,
+        mock_client,
+        sample_change_data,
+    ):
+        """Test topics containing whitespace are quoted in the query.
+
+        parse_gerrit_topic_url() unquotes topics like topic:"some
+        topic", so the service must re-quote them or the bare value
+        splits into separate Gerrit query terms.
+        """
+        mock_build_client.return_value = mock_client
+        mock_client.get.return_value = [sample_change_data]
+
+        service = GerritService(host="gerrit.example.org")
+        service.get_changes_by_topic("some topic")
+
+        call_args = mock_client.get.call_args[0][0]
+        assert 'topic:"some topic"' in call_args
+        assert "status:open" in call_args
+
+    @patch("dependamerge.gerrit.service.build_client")
+    @patch("dependamerge.gerrit.service.create_url_builder")
+    def test_get_changes_by_topic_escapes_quotes(
+        self,
+        mock_url_builder,
+        mock_build_client,
+        mock_client,
+        sample_change_data,
+    ):
+        """Test embedded quotes in a topic are escaped when quoting."""
+        mock_build_client.return_value = mock_client
+        mock_client.get.return_value = [sample_change_data]
+
+        service = GerritService(host="gerrit.example.org")
+        service.get_changes_by_topic('odd"topic')
+
+        call_args = mock_client.get.call_args[0][0]
+        assert 'topic:"odd\\"topic"' in call_args
+
 
 class TestGerritServiceGetProjects:
     """Tests for get_projects method."""

--- a/tests/test_gerrit_service.py
+++ b/tests/test_gerrit_service.py
@@ -554,6 +554,49 @@ class TestGerritServiceFindSimilarChanges:
 
     @patch("dependamerge.gerrit.service.build_client")
     @patch("dependamerge.gerrit.service.create_url_builder")
+    def test_find_similar_changes_with_candidates_skips_server_scan(
+        self,
+        mock_url_builder,
+        mock_build_client,
+        mock_client,
+        sample_change_info,
+    ):
+        """Test that explicit candidates bypass the whole-server scan.
+
+        When candidates are provided (e.g. from a topic query), no
+        status:open query is issued and only the candidates are scored.
+        """
+        mock_build_client.return_value = mock_client
+
+        candidate = GerritChangeInfo(
+            number=99999,
+            change_id="I000",
+            project="candidate-project",
+            subject="Chore: Bump actions/checkout from 4.1.0 to 4.2.0",
+            owner="dependabot",
+            branch="main",
+            status="NEW",
+        )
+
+        mock_comparator = MagicMock()
+        mock_comparator.compare_gerrit_changes.return_value = (
+            GerritComparisonResult.similar(0.9, ["Same author"])
+        )
+
+        service = GerritService(host="gerrit.example.org")
+        similar = service.find_similar_changes(
+            sample_change_info,
+            mock_comparator,
+            candidates=[candidate],
+        )
+
+        assert len(similar) == 1
+        assert similar[0][0].number == 99999
+        # No server-wide scan should have run
+        mock_client.get.assert_not_called()
+
+    @patch("dependamerge.gerrit.service.build_client")
+    @patch("dependamerge.gerrit.service.create_url_builder")
     def test_find_similar_changes_skips_source(
         self,
         mock_url_builder,

--- a/tests/test_gerrit_service.py
+++ b/tests/test_gerrit_service.py
@@ -835,6 +835,12 @@ class TestDefaultOptions:
         assert "CURRENT_REVISION" in DEFAULT_CHANGE_OPTIONS
         assert "CURRENT_FILES" in DEFAULT_CHANGE_OPTIONS
         assert "SUBMITTABLE" in DEFAULT_CHANGE_OPTIONS
+        # Both action options are required for permission checks: the
+        # 'submit' action only appears under revision-level actions
+        # (CURRENT_ACTIONS), while change-level actions need
+        # CHANGE_ACTIONS.
+        assert "CURRENT_ACTIONS" in DEFAULT_CHANGE_OPTIONS
+        assert "CHANGE_ACTIONS" in DEFAULT_CHANGE_OPTIONS
 
     def test_default_list_options(self):
         """Test default options for list queries."""

--- a/tests/test_gerrit_submit_manager.py
+++ b/tests/test_gerrit_submit_manager.py
@@ -12,6 +12,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from dependamerge.gerrit.client import GerritRestError
 from dependamerge.gerrit.models import (
     GerritChangeInfo,
     GerritComparisonResult,
@@ -417,6 +418,117 @@ class TestSubmitChangesParallel:
         results = manager.submit_changes_parallel([])
 
         assert results == []
+
+
+class TestProgressTracking:
+    """Tests for progress tracker integration during submission.
+
+    The submit manager drives the same tracker protocol as the
+    GitHub merge pipeline: a transitory ``submitting`` state while
+    the review + submit round-trips run, then a terminal
+    ``merge_success`` / ``merge_failure`` outcome keyed by
+    ``project#number``.
+    """
+
+    @patch("dependamerge.gerrit.submit_manager.build_client")
+    def test_success_records_submitting_then_success(
+        self, mock_build_client, mock_client, sample_change
+    ):
+        """Test a successful submit drives the tracker states."""
+        mock_build_client.return_value = mock_client
+        mock_client.post.return_value = {}
+        tracker = MagicMock()
+
+        manager = GerritSubmitManager(
+            host="gerrit.example.org",
+            username="user",
+            password="pass",
+            progress_tracker=tracker,
+        )
+
+        results = manager.submit_changes([(sample_change, None)])
+
+        assert results[0].success
+        tracker.track_pr_state.assert_called_once_with("my-project#12345", "submitting")
+        tracker.merge_success.assert_called_once_with("my-project#12345")
+        tracker.merge_failure.assert_not_called()
+
+    @patch("dependamerge.gerrit.submit_manager.build_client")
+    def test_failure_records_merge_failure(
+        self, mock_build_client, mock_client, sample_change
+    ):
+        """Test a failed review drives merge_failure on the tracker."""
+        mock_build_client.return_value = mock_client
+        mock_client.post.side_effect = GerritRestError("boom")
+        tracker = MagicMock()
+
+        manager = GerritSubmitManager(
+            host="gerrit.example.org",
+            username="user",
+            password="pass",
+            progress_tracker=tracker,
+        )
+
+        results = manager.submit_changes([(sample_change, None)])
+
+        assert not results[0].success
+        tracker.merge_failure.assert_called_once_with("my-project#12345")
+        tracker.merge_success.assert_not_called()
+
+    @patch("dependamerge.gerrit.submit_manager.build_client")
+    def test_parallel_submission_drives_tracker_per_change(
+        self, mock_build_client, mock_client
+    ):
+        """Test parallel submission records one outcome per change."""
+        mock_build_client.return_value = mock_client
+        mock_client.post.return_value = {}
+        tracker = MagicMock()
+
+        manager = GerritSubmitManager(
+            host="gerrit.example.org",
+            username="user",
+            password="pass",
+            max_workers=2,
+            progress_tracker=tracker,
+        )
+
+        changes: list[tuple[GerritChangeInfo, GerritComparisonResult | None]] = [
+            (
+                GerritChangeInfo(
+                    number=i,
+                    change_id=f"I{i:040d}",
+                    project="proj",
+                    subject="Test",
+                    owner="bot",
+                    branch="main",
+                    status="NEW",
+                ),
+                None,
+            )
+            for i in range(3)
+        ]
+
+        results = manager.submit_changes_parallel(changes)
+
+        assert all(r.success for r in results)
+        assert tracker.merge_success.call_count == 3
+        assert tracker.track_pr_state.call_count == 3
+
+    @patch("dependamerge.gerrit.submit_manager.build_client")
+    def test_no_tracker_is_a_no_op(self, mock_build_client, mock_client, sample_change):
+        """Test submission works unchanged without a tracker."""
+        mock_build_client.return_value = mock_client
+        mock_client.post.return_value = {}
+
+        manager = GerritSubmitManager(
+            host="gerrit.example.org",
+            username="user",
+            password="pass",
+        )
+
+        results = manager.submit_changes([(sample_change, None)])
+
+        assert results[0].success
 
 
 class TestReviewOnly:

--- a/tests/test_gerrit_submit_manager.py
+++ b/tests/test_gerrit_submit_manager.py
@@ -308,8 +308,11 @@ class TestSubmitSingleChange:
         )
 
         assert result.success is True
-        assert result.reviewed is True
-        assert result.submitted is True
+        # A dry run performs no review or submit, so it must not claim
+        # either happened: callers gate real side effects (e.g. closing
+        # the GitHub PR after a Gerrit submit) on ``submitted``.
+        assert result.reviewed is False
+        assert result.submitted is False
         # No actual API calls should be made
         mock_client.post.assert_not_called()
 

--- a/tests/test_merge_state_tracking.py
+++ b/tests/test_merge_state_tracking.py
@@ -170,6 +170,29 @@ class TestDisplayRendering:
         assert "Blocked" not in plain
         assert "Rebasing" not in plain
 
+    def test_unit_label_defaults_to_prs(self) -> None:
+        tracker = MergeProgressTracker("org")
+        tracker.rich_available = True
+        tracker.set_total_prs(2)
+        plain = tracker._generate_display_text().plain
+        assert "(0/2 PRs, " in plain
+
+    def test_unit_label_renders_custom_noun(self) -> None:
+        """Gerrit runs label the progress fraction with 'changes'."""
+        tracker = MergeProgressTracker(
+            "gerrit.example.org",
+            operation_label="Submitting changes",
+            operation_icon="\u25b6\ufe0f",
+            unit_label="changes",
+        )
+        tracker.rich_available = True
+        tracker.set_total_prs(3)
+        tracker.merge_success("proj#1")
+        plain = tracker._generate_display_text().plain
+        assert "Submitting changes in gerrit.example.org" in plain
+        assert "(1/3 changes, " in plain
+        assert "PRs" not in plain
+
     def test_unknown_state_rendered_defensively(self) -> None:
         tracker = MergeProgressTracker("org")
         tracker.rich_available = True

--- a/tests/test_merge_state_tracking.py
+++ b/tests/test_merge_state_tracking.py
@@ -133,6 +133,36 @@ class TestTerminalCounters:
         dummy.merge_pending("org/repo#1")
         dummy.increment_closed("org/repo#1")
 
+    def test_concurrent_outcomes_lose_no_increments(self) -> None:
+        """Counter updates from worker threads are never lost.
+
+        The Gerrit submit manager records outcomes from a
+        ThreadPoolExecutor, so the tracker must serialise its
+        mutations: each thread walks a PR through a transitory state
+        and a terminal outcome, and every increment must survive.
+        """
+        from concurrent.futures import ThreadPoolExecutor
+
+        tracker = MergeProgressTracker("org")
+        total = 64
+        tracker.set_total_prs(total)
+
+        def _submit_one(index: int) -> None:
+            key = f"org/repo#{index}"
+            tracker.track_pr_state(key, "submitting")
+            if index % 2 == 0:
+                tracker.merge_success(key)
+            else:
+                tracker.merge_failure(key)
+
+        with ThreadPoolExecutor(max_workers=8) as executor:
+            list(executor.map(_submit_one, range(total)))
+
+        assert tracker.prs_merged == total // 2
+        assert tracker.prs_failed == total // 2
+        assert tracker.completed_prs == total
+        assert tracker._pr_states == {}
+
 
 class TestDisplayRendering:
     """Stats line renders transitory states then terminal counters."""
@@ -140,10 +170,11 @@ class TestDisplayRendering:
     def test_states_render_in_pipeline_order(self) -> None:
         tracker = MergeProgressTracker("org")
         tracker.rich_available = True
-        tracker.set_total_prs(6)
+        tracker.set_total_prs(7)
         tracker.track_pr_state("org/repo#1", "waiting")
         tracker.track_pr_state("org/repo#2", "rebasing")
         tracker.track_pr_state("org/repo#3", "rebased")
+        tracker.track_pr_state("org/repo#7", "submitting")
         tracker.merge_success("org/repo#4")
         tracker.merge_pending("org/repo#5")
         tracker.merge_failure("org/repo#6")
@@ -152,13 +183,15 @@ class TestDisplayRendering:
         assert "🔄 Rebasing: 1" in plain
         assert "⬆️ Rebased: 1" in plain
         assert "⏳ Waiting: 1" in plain
+        assert "📤 Submitting: 1" in plain
         assert "✅ Merged: 1" in plain
         assert "🤖 Pending: 1" in plain
         assert "❌ Failed: 1" in plain
         # Pipeline order: transitory states precede terminal counters.
         assert plain.index("Rebasing") < plain.index("Rebased")
         assert plain.index("Rebased") < plain.index("Waiting")
-        assert plain.index("Waiting") < plain.index("Merged")
+        assert plain.index("Waiting") < plain.index("Submitting")
+        assert plain.index("Submitting") < plain.index("Merged")
 
     def test_zero_counters_do_not_render(self) -> None:
         tracker = MergeProgressTracker("org")

--- a/tests/test_url_parser.py
+++ b/tests/test_url_parser.py
@@ -16,6 +16,7 @@ from dependamerge.url_parser import (
     _host_matches,
     detect_source,
     parse_change_url,
+    parse_gerrit_topic_url,
     parse_org_url,
     parse_owner_arg,
 )
@@ -234,6 +235,104 @@ class TestParseGerritUrl:
 
         assert result.source == ChangeSource.GERRIT
         assert result.host == "gerrit.example.org"
+
+
+class TestParseGerritTopicUrl:
+    """Tests for parsing Gerrit topic search URLs."""
+
+    def test_topic_url_without_base_path(self):
+        """Test parsing a topic URL on a root-mounted server."""
+        url = "https://gerrit.example.org/q/topic:update-settings"
+        result = parse_gerrit_topic_url(url)
+
+        assert result.source == ChangeSource.GERRIT
+        assert result.is_gerrit is True
+        assert result.host == "gerrit.example.org"
+        assert result.base_path is None
+        assert result.topic == "update-settings"
+        assert result.original_url == url
+
+    def test_topic_url_with_base_path(self):
+        """Test parsing a topic URL with a base path (e.g. ONAP's /r/)."""
+        url = "https://gerrit.onap.org/r/q/topic:update-settings"
+        result = parse_gerrit_topic_url(url)
+
+        assert result.host == "gerrit.onap.org"
+        assert result.base_path == "r"
+        assert result.topic == "update-settings"
+
+    def test_topic_url_legacy_fragment_form(self):
+        """Test parsing the legacy UI form with the query in the fragment."""
+        url = "https://gerrit.example.org/#/q/topic:my-topic"
+        result = parse_gerrit_topic_url(url)
+
+        assert result.base_path is None
+        assert result.topic == "my-topic"
+
+    def test_topic_url_legacy_fragment_with_base_path(self):
+        """Test the legacy fragment form behind a base path."""
+        url = "https://gerrit.example.org/r/#/q/topic:my-topic"
+        result = parse_gerrit_topic_url(url)
+
+        assert result.base_path == "r"
+        assert result.topic == "my-topic"
+
+    def test_topic_url_with_extra_terms(self):
+        """Test extracting the topic among other search operators."""
+        url = "https://gerrit.example.org/q/topic:some-topic+status:open"
+        result = parse_gerrit_topic_url(url)
+
+        assert result.topic == "some-topic"
+
+    def test_topic_url_with_leading_terms(self):
+        """Test extracting the topic when it is not the first term."""
+        url = "https://gerrit.example.org/q/status:open+topic:some-topic"
+        result = parse_gerrit_topic_url(url)
+
+        assert result.topic == "some-topic"
+
+    def test_topic_url_quoted_topic(self):
+        """Test extracting a quoted topic value."""
+        url = 'https://gerrit.example.org/q/topic:"quoted-topic"'
+        result = parse_gerrit_topic_url(url)
+
+        assert result.topic == "quoted-topic"
+
+    def test_topic_url_percent_encoded(self):
+        """Test parsing a topic URL with a percent-encoded colon."""
+        url = "https://gerrit.example.org/q/topic%3Aupdate-settings"
+        result = parse_gerrit_topic_url(url)
+
+        assert result.topic == "update-settings"
+
+    def test_topic_url_without_scheme(self):
+        """Test parsing a topic URL without https:// prefix."""
+        url = "gerrit.onap.org/r/q/topic:update-settings"
+        result = parse_gerrit_topic_url(url)
+
+        assert result.host == "gerrit.onap.org"
+        assert result.base_path == "r"
+        assert result.topic == "update-settings"
+
+    def test_non_search_url_rejected(self):
+        """Test that a Gerrit change URL is not a topic search URL."""
+        with pytest.raises(UrlParseError, match="no /q/ segment"):
+            parse_gerrit_topic_url("https://gerrit.example.org/c/project/+/123")
+
+    def test_search_url_without_topic_rejected(self):
+        """Test that a non-topic search query is rejected."""
+        with pytest.raises(UrlParseError, match="Only topic searches"):
+            parse_gerrit_topic_url("https://gerrit.example.org/q/status:open")
+
+    def test_search_url_empty_query_rejected(self):
+        """Test that a search URL with no query expression is rejected."""
+        with pytest.raises(UrlParseError, match="no query expression"):
+            parse_gerrit_topic_url("https://gerrit.example.org/q/")
+
+    def test_empty_url_rejected(self):
+        """Test that an empty URL is rejected."""
+        with pytest.raises(UrlParseError, match="URL cannot be empty"):
+            parse_gerrit_topic_url("")
 
 
 class TestInvalidUrls:


### PR DESCRIPTION
## Summary

Brings the Gerrit merge path to parity with the proven GitHub pipeline. Fixes several issues observed live against `gerrit.onap.org`:

1. **Bogus permission warnings** — `GerritChangeInfo.can_submit_action()` only read change-level `actions`, but the service requested `CURRENT_ACTIONS`, which populates the *revision-level* actions where `submit` actually lives. Every run therefore warned "You may not have permission to submit this change" even when submission succeeded. The model now merges change-level and revision-level actions, and the service requests both `CURRENT_ACTIONS` and `CHANGE_ACTIONS`.

2. **No interactive confirmation** — omitting `--no-confirm` on the Gerrit path printed "To proceed, run with --no-confirm" and exited (effectively a dry run). The path now prompts with a continue-SHA confirmation flow mirroring the GitHub path.

3. **Zero similar changes found / no topic support** — similar-change discovery now prefers topic-scoped server queries: an explicit `--topic` flag wins, then the topic from a pasted Gerrit topic search URL (`/q/topic:...`, now accepted as a merge target), then the source change's own topic. Live-verified: the ONAP `update-settings` topic URL discovers all 26 related open changes, correctly excluding 4 unrelated changes sharing the topic via similarity scoring.

4. **Output divergence** — Gerrit submissions now run in parallel and drive the same Rich `MergeProgressTracker` protocol as GitHub merges: in-place counters (`Submitting` → `Merged`/`Failed`), no interleaved per-change console lines, and a consolidated `🚀 Final Results` summary with a failure recap listing each failed change's URL and reason.

## Stacking

Stacked on #381 (`chore/aislop-findings`) — the first commit shown here belongs to that PR and this one should land after it.

## Commits

- `Fix: Parse revision-level Gerrit submit action`
- `Feat: Add Gerrit topic scoping for bulk merges`
- `Fix: Prompt for confirmation in Gerrit merges`
- `Feat: Add live progress to Gerrit submissions`

## Validation

- Full test suite: 1472 passed, 14 skipped; mypy and ruff clean
- New unit tests with live-captured ONAP API shapes; live integration tests in `tests/integration/test_live_gerrit.py`
- Live-verified against `gerrit.onap.org`: dry run of `https://gerrit.onap.org/r/q/topic:update-settings` finds all 26 open changes, reports correct permissions, and submits nothing