### PR TITLE
Feat(progress): Add cumulative rebase/retrigger totals

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,13 @@ or user account in one command.
 - **Resilient Enumeration**: The run reports and skips a transient
   failure scanning one repository, then continues with the repositories
   it scanned
+- **Cumulative Activity Counters**: The live progress line reports
+  `⬆️ Rebased` (rebase operations triggered — local force-push, REST
+  `update-branch`, or the `@dependabot rebase` macro) and
+  `📣 Retriggered` (comment macros posted: `@dependabot rebase`,
+  `@dependabot recreate`, `pre-commit.ci run`). Both are running totals
+  of *operations*, so they keep reporting what the run did after the PRs
+  themselves have landed in `✅ Merged` / `❌ Failed`
 - **Grouped Preview**: The preview lists candidate PRs grouped by repository
   for readability, then prompts for a confirmation token before merging
 - **Human PR Safety**: The run excludes human-authored PRs by default;

--- a/src/dependamerge/merge_manager.py
+++ b/src/dependamerge/merge_manager.py
@@ -680,6 +680,34 @@ class AsyncMergeManager:
         pr_key = f"{pr_info.repository_full_name}#{pr_info.number}"
         tracker.track_pr_state(pr_key, state)
 
+    def _record_rebase(self) -> None:
+        """Count one rebase operation on the progress tracker.
+
+        Called wherever the run actually moves a branch onto its base:
+        the ``@dependabot rebase`` macro, the local ``git rebase`` +
+        force-push, and the REST ``update-branch`` path.  The counter
+        is cumulative, so the live display keeps reporting how many
+        rebases the run triggered after the PRs have reached their
+        terminal outcomes.
+        """
+        tracker = self.progress_tracker
+        if not tracker:
+            return
+        tracker.record_rebase()
+
+    def _record_retrigger(self) -> None:
+        """Count one comment macro on the progress tracker.
+
+        Called after successfully posting ``@dependabot rebase``,
+        ``@dependabot recreate`` or ``pre-commit.ci run``.  New macros
+        should call this too so the ``Retriggered`` total stays a
+        complete record of what the run poked.
+        """
+        tracker = self.progress_tracker
+        if not tracker:
+            return
+        tracker.record_retrigger()
+
     def _pr_status(self, message: str, *, level: str = "info") -> None:
         """Emit a per-PR status line to the log.
 
@@ -1490,6 +1518,7 @@ class AsyncMergeManager:
                     rebased_prs=self._rebased_prs,
                     enable_auto_merge=self._enable_auto_merge_with_approval,
                     track_pr_state=self._track_pr_state,
+                    record_rebase=self._record_rebase,
                     request_dependabot_rebase=self._request_dependabot_rebase,
                 )
                 outcome = await rebase.perform_step5_rebase(
@@ -3501,6 +3530,7 @@ class AsyncMergeManager:
             await self._github_client.post_issue_comment(
                 repo_owner, repo_name, pr_info.number, "pre-commit.ci run"
             )
+            self._record_retrigger()
         except Exception as e:
             self.log.warning(
                 f"Failed to post pre-commit.ci trigger comment on "
@@ -3916,6 +3946,7 @@ class AsyncMergeManager:
             await self._github_client.post_issue_comment(
                 repo_owner, repo_name, pr_info.number, "@dependabot recreate"
             )
+            self._record_retrigger()
         except Exception as e:
             self.log.warning(
                 "Failed to post @dependabot recreate comment on %s#%s: %s",
@@ -5223,6 +5254,11 @@ class AsyncMergeManager:
             await self._github_client.post_issue_comment(
                 owner, repo, pr_info.number, "@dependabot rebase"
             )
+            # One macro comment and one rebase request: both totals
+            # move.  The duplicate-guard path above deliberately does
+            # not count — that rebase was requested by an earlier run.
+            self._record_retrigger()
+            self._record_rebase()
             return True
         except Exception as exc:
             self.log.warning(
@@ -5459,7 +5495,12 @@ class AsyncMergeManager:
             )
         else:
             continue_states = ("blocked", "behind", "unstable", "unknown", "")
-        self._track_pr_state(pr_info, "rebased")
+        # The rebase landed; what remains is a wait on required checks.
+        # No counting here: ``_request_dependabot_rebase`` above owns
+        # the cumulative "Rebased" total, and deliberately counts
+        # nothing when its duplicate guard finds a macro an earlier run
+        # already posted.
+        self._track_pr_state(pr_info, "waiting")
         try:
             closed, merged = await self._wait_for_auto_merge(
                 pr_info,
@@ -5802,6 +5843,7 @@ class AsyncMergeManager:
                     f"PR {owner}/{repo}#{pr_info.number} is behind - updating branch"
                 )
                 await self._github_client.update_branch(owner, repo, pr_info.number)
+                self._record_rebase()
                 # Wait a moment for GitHub to process the update
                 await asyncio.sleep(min(2.0, self._merge_recheck_interval))
                 return True

--- a/src/dependamerge/progress_tracker.py
+++ b/src/dependamerge/progress_tracker.py
@@ -469,22 +469,34 @@ class ProgressTracker:
 class MergeProgressTracker(ProgressTracker):
     """Extended progress tracker with merge-specific metrics.
 
-    In addition to the terminal counters (merged / failed / skipped /
-    blocked / pending / closed), PRs move through **transitory**
-    display states while the merge pipeline operates on them
-    (``rebasing`` → ``rebased`` → ``waiting`` → terminal).  Transitory
-    states are keyed by PR so a PR occupies at most one state at a
-    time; recording a terminal outcome removes the PR from whatever
-    transitory state it was in.
+    Three families of counter feed the live display:
+
+    - **Transitory states** — where each PR is *right now* (one of
+      the keys in :attr:`_STATE_ORDER`).  Keyed by PR, so a PR
+      occupies at most one state at a time and recording a terminal
+      outcome removes it from whatever state it was in.
+    - **Activity counters** (``rebases_triggered``,
+      ``retriggers_issued``) — monotonic totals of *operations* the
+      run performed.  Unlike transitory states these never decrease
+      when a PR moves on, so the display keeps showing how many
+      rebases and comment macros the run issued even after every PR
+      has reached ``Merged`` / ``Failed``.
+    - **Terminal counters** (merged / failed / skipped / blocked /
+      pending / closed) — one per PR, recorded exactly once.
     """
 
     # Transitory display states in pipeline order.  Each entry is
     # ``(state_key, display_label)``; only non-zero states render.
     # ``submitting`` is recorded by the Gerrit submit manager while a
     # change's review + submit round-trips run.
+    #
+    # NOTE: there is deliberately no ``rebased`` state here.  "A rebase
+    # happened" is a completed operation, not a place a PR sits, and
+    # keying it per PR made the count vanish the moment the PR moved
+    # on; it is tracked by the cumulative ``rebases_triggered`` counter
+    # instead.  Post-rebase waiting is reported as ``waiting``.
     _STATE_ORDER: tuple[tuple[str, str], ...] = (
         ("rebasing", "🔄 Rebasing"),
-        ("rebased", "⬆️ Rebased"),
         ("recreating", "♻️ Recreating"),
         ("waiting", "⏳ Waiting"),
         ("submitting", "📤 Submitting"),
@@ -533,6 +545,15 @@ class MergeProgressTracker(ProgressTracker):
         self.prs_pending = 0
         # PRs that are blocked and cannot be merged by this run.
         self.prs_blocked = 0
+        # Cumulative activity counters.  These count *operations*, not
+        # PRs: a single PR can contribute more than one (e.g. a
+        # ``@dependabot rebase`` macro counts as both a rebase and a
+        # re-trigger, and a PR rebased twice counts twice).  They are
+        # monotonic and survive the PR's transition to a terminal
+        # outcome, so the operator can still see what the run did after
+        # every PR has landed in Merged / Failed.
+        self.rebases_triggered = 0
+        self.retriggers_issued = 0
         self.is_close_operation = is_close_operation
         self.preview = preview
         self._custom_label = operation_label
@@ -567,16 +588,58 @@ class MergeProgressTracker(ProgressTracker):
             self.total_prs = total
         self._refresh_display()
 
+    def record_rebase(self, count: int = 1) -> None:
+        """Count a rebase operation triggered against a PR branch.
+
+        Covers every mechanism that brings a branch up to date: a
+        local ``git rebase`` + force-push, the REST ``update-branch``
+        call, and the ``@dependabot rebase`` comment macro.  The
+        counter is cumulative and never cleared — it records what the
+        run *did*, independently of where each PR ended up.
+
+        ``count`` must be positive; a zero or negative value is
+        ignored so the monotonic contract holds no matter what a
+        caller passes.  A display counter must never abort a merge
+        run, so a bad argument is dropped rather than raised.
+        """
+        if count <= 0:
+            return
+        with self._state_lock:
+            self.rebases_triggered += count
+        self._refresh_display()
+
+    def record_retrigger(self, count: int = 1) -> None:
+        """Count a comment macro posted to re-trigger external tooling.
+
+        Covers ``@dependabot rebase``, ``@dependabot recreate``,
+        ``pre-commit.ci run`` and any macro added later.  Like
+        :meth:`record_rebase` this is cumulative and never cleared.
+
+        A ``@dependabot rebase`` deliberately increments *both*
+        counters: it is one comment macro and one rebase request, and
+        the two counters answer different questions ("how many
+        branches did we move?" vs "how many times did we poke an
+        external bot?").
+
+        ``count`` is validated exactly as in :meth:`record_rebase`:
+        zero and negative values are ignored.
+        """
+        if count <= 0:
+            return
+        with self._state_lock:
+            self.retriggers_issued += count
+        self._refresh_display()
+
     def track_pr_state(self, pr_key: str, state: str | None) -> None:
         """Move a PR between transitory display states.
 
         ``state`` is one of the keys in ``_STATE_ORDER`` (e.g.
-        ``"rebasing"``, ``"rebased"``, ``"waiting"``) or ``None`` to
-        clear the PR's entry when an operation finishes without
-        reaching a terminal outcome.  Terminal outcomes are recorded
-        via ``merge_success`` / ``merge_failure`` / ``merge_skipped``
-        / ``merge_blocked`` / ``merge_pending``, which also clear the
-        transitory entry when given the PR key.
+        ``"rebasing"``, ``"waiting"``) or ``None`` to clear the PR's
+        entry when an operation finishes without reaching a terminal
+        outcome.  Terminal outcomes are recorded via ``merge_success``
+        / ``merge_failure`` / ``merge_skipped`` / ``merge_blocked`` /
+        ``merge_pending``, which also clear the transitory entry when
+        given the PR key.
         """
         if state is None:
             with self._state_lock:
@@ -696,6 +759,8 @@ class MergeProgressTracker(ProgressTracker):
             prs_failed = self.prs_failed
             prs_skipped = self.prs_skipped
             prs_blocked = self.prs_blocked
+            rebases_triggered = self.rebases_triggered
+            retriggers_issued = self.retriggers_issued
             pr_states = list(self._pr_states.values())
 
         # Main progress line for merge/close operations.
@@ -736,8 +801,9 @@ class MergeProgressTracker(ProgressTracker):
             text.append(f"\n   {self.current_operation}", style="dim")
 
         # Merge stats — transitory pipeline states first (in flow
-        # order), then terminal outcomes.  The per-PR states and the
-        # counters below were snapshotted under _state_lock above.
+        # order), then the cumulative activity totals, then terminal
+        # outcomes.  The per-PR states and the counters below were
+        # snapshotted under _state_lock above.
         stats_parts: list[str] = []
         if similar_prs_found > 0:
             stats_parts.append(f"🔁 Similar: {similar_prs_found}")
@@ -757,6 +823,14 @@ class MergeProgressTracker(ProgressTracker):
                 stats_parts.append(
                     f"{state_key.capitalize()}: {state_counts[state_key]}"
                 )
+        # Cumulative activity totals.  Rendered between the transitory
+        # states and the terminal outcomes so the line reads in
+        # pipeline order, and kept visible for the rest of the run
+        # once non-zero.
+        if rebases_triggered > 0:
+            stats_parts.append(f"⬆️ Rebased: {rebases_triggered}")
+        if retriggers_issued > 0:
+            stats_parts.append(f"📣 Retriggered: {retriggers_issued}")
         if prs_merged > 0:
             # A preview run merges nothing — the counter records PRs
             # judged mergeable, so label it accordingly.
@@ -812,6 +886,8 @@ class MergeProgressTracker(ProgressTracker):
                 "prs_blocked": self.prs_blocked,
                 "prs_pending": self.prs_pending,
                 "prs_closed": self.prs_closed,
+                "rebases_triggered": self.rebases_triggered,
+                "retriggers_issued": self.retriggers_issued,
                 "total_prs": self.total_prs,
                 "completed_prs": self.completed_prs,
             }
@@ -837,6 +913,8 @@ class DummyProgressTracker(ProgressTracker):
         self.prs_blocked = 0
         self.prs_pending = 0
         self.prs_closed = 0
+        self.rebases_triggered = 0
+        self.retriggers_issued = 0
         self.is_close_operation = False
         self.preview = False
         self._custom_label: str | None = None
@@ -886,6 +964,12 @@ class DummyProgressTracker(ProgressTracker):
         pass
 
     def track_pr_state(self, pr_key: str, state: str | None) -> None:
+        pass
+
+    def record_rebase(self, count: int = 1) -> None:
+        pass
+
+    def record_retrigger(self, count: int = 1) -> None:
         pass
 
     def merge_success(self, pr_key: str | None = None) -> None:

--- a/src/dependamerge/rebase.py
+++ b/src/dependamerge/rebase.py
@@ -103,10 +103,18 @@ class RebaseContext:
     enable_auto_merge: Callable[[PullRequestInfo, str, str], Awaitable[bool]]
     # Optional callback (``manager._track_pr_state``) that moves the PR
     # between transitory states on the Rich progress tracker
-    # ("rebasing", "rebased", "waiting", or ``None`` to clear).
+    # ("rebasing", "waiting", or ``None`` to clear).
     # Default ``None`` keeps existing test constructions working and
     # makes the tracker strictly optional for isolated use.
     track_pr_state: Callable[[PullRequestInfo, str | None], None] | None = None
+    # Optional callback (``manager._record_rebase``) that increments the
+    # tracker's cumulative "Rebased" total.  Called once per rebase this
+    # module performs itself — the local force-push path and the REST
+    # ``update-branch`` path.  The ``@dependabot rebase`` macro path is
+    # *not* counted here: ``request_dependabot_rebase`` owns the
+    # accounting for the macro (including its duplicate guard, which
+    # counts nothing), and counting again would double it.
+    record_rebase: Callable[[], None] | None = None
     # Optional async callable equivalent to
     # ``manager._request_dependabot_rebase``: posts ``@dependabot
     # rebase`` on the PR (idempotent — the manager implementation
@@ -659,6 +667,18 @@ def _set_tracker_state(
         ctx.track_pr_state(pr_info, state)
 
 
+def _record_rebase(ctx: RebaseContext) -> None:
+    """Count one rebase operation on the progress tracker.
+
+    No-op when the context was constructed without a ``record_rebase``
+    callback (isolated tests).  Preview runs never reach here at all:
+    :func:`perform_step5_rebase` returns before dispatching to any
+    rebase path.
+    """
+    if ctx.record_rebase is not None:
+        ctx.record_rebase()
+
+
 async def _run_local_path(
     *,
     ctx: RebaseContext,
@@ -732,9 +752,18 @@ async def _run_local_path(
     if auto_merge_ok:
         ctx.rebased_prs.add(f"{owner}/{repo}#{pr_info.number}")
 
+    # Either way the rebase attempt is over, so clear the "rebasing"
+    # state ``perform_step5_rebase`` set before dispatch.  Leaving it
+    # set on the failure branch would strand the PR displaying as
+    # "Rebasing" for the rest of the run, since this path defers to
+    # auto-merge rather than reaching a terminal outcome that would
+    # clear it.
+    _set_tracker_state(ctx, pr_info, None)
     if local_rebase_ok:
         ctx.log.debug("Rebased (local): %s", pr_info.html_url)
-        _set_tracker_state(ctx, pr_info, "rebased")
+        # The cumulative "Rebased" total is what keeps a record of the
+        # rebase from here on.
+        _record_rebase(ctx)
     else:
         ctx.log.debug(
             "Local rebase failed; deferring to auto-merge: %s",
@@ -807,7 +836,12 @@ async def _run_dependabot_macro_path(
         ctx.rebased_prs.add(f"{owner}/{repo}#{pr_info.number}")
 
     ctx.log.debug("Rebase requested (dependabot macro): %s", pr_info.html_url)
-    _set_tracker_state(ctx, pr_info, "rebased")
+    # No counting here: ``ctx.request_dependabot_rebase`` owns the
+    # cumulative totals and records them only when it actually posts
+    # the macro (its duplicate guard returns True without posting when
+    # an earlier run already requested the rebase).  Counting again
+    # here would double the posted case and invent the guarded one.
+    _set_tracker_state(ctx, pr_info, None)
     return True
 
 
@@ -837,6 +871,7 @@ async def _run_rest_path(
 
     try:
         await client.update_branch(owner, repo, pr_info.number)
+        _record_rebase(ctx)
 
         # Enable auto-merge so the PR merges even if we time out
         # waiting for status checks.
@@ -897,7 +932,7 @@ async def _run_rest_path(
         # in ``blocked`` or ``behind`` state.
         ctx.rebased_prs.add(f"{owner}/{repo}#{pr_info.number}")
 
-        _set_tracker_state(ctx, pr_info, "rebased")
+        _set_tracker_state(ctx, pr_info, None)
         _log_post_rebase_status(ctx=ctx, pr_info=pr_info)
         return Step5Outcome()
 

--- a/tests/test_merge_state_tracking.py
+++ b/tests/test_merge_state_tracking.py
@@ -4,20 +4,24 @@
 """Tests for merge progress tracker state transitions and counters.
 
 The live merge display moved from per-PR console lines to counter-based
-reporting: PRs travel through transitory states (rebasing → rebased →
-waiting) rendered live on the stats line, then land in exactly one
-terminal counter (merged / pending / closed / failed / skipped /
-blocked).  ``AsyncMergeManager._record_terminal_outcome`` is the single
-accounting point mapping ``MergeStatus`` onto those counters.
+reporting.  Three families of counter feed it: transitory per-PR states
+(rebasing → waiting) rendered live on the stats line, cumulative
+activity totals (rebases triggered, comment macros issued) that survive
+the PR reaching a terminal outcome, and the terminal counters themselves
+(merged / pending / closed / failed / skipped / blocked).
+``AsyncMergeManager._record_terminal_outcome`` is the single accounting
+point mapping ``MergeStatus`` onto the terminal counters.
 """
 
 from __future__ import annotations
 
+import logging
 from typing import Any
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from dependamerge import rebase as rebase_module
 from dependamerge.merge_manager import MergeStatus
 from dependamerge.models import PullRequestInfo
 from dependamerge.progress_tracker import (
@@ -57,8 +61,8 @@ class TestTransitoryStates:
         assert tracker._pr_states == {"org/repo#1": "rebasing"}
 
         # Transition: the PR occupies exactly one state at a time.
-        tracker.track_pr_state("org/repo#1", "rebased")
-        assert tracker._pr_states == {"org/repo#1": "rebased"}
+        tracker.track_pr_state("org/repo#1", "recreating")
+        assert tracker._pr_states == {"org/repo#1": "recreating"}
 
         tracker.track_pr_state("org/repo#1", "waiting")
         assert tracker._pr_states == {"org/repo#1": "waiting"}
@@ -132,6 +136,8 @@ class TestTerminalCounters:
         dummy.merge_blocked("org/repo#1")
         dummy.merge_pending("org/repo#1")
         dummy.increment_closed("org/repo#1")
+        dummy.record_rebase()
+        dummy.record_retrigger()
 
     def test_concurrent_outcomes_lose_no_increments(self) -> None:
         """Counter updates from worker threads are never lost.
@@ -164,6 +170,94 @@ class TestTerminalCounters:
         assert tracker._pr_states == {}
 
 
+class TestActivityCounters:
+    """Cumulative rebase / re-trigger totals outlive the PRs they came from."""
+
+    def test_record_rebase_accumulates(self) -> None:
+        tracker = MergeProgressTracker("org")
+        tracker.record_rebase()
+        tracker.record_rebase()
+        assert tracker.rebases_triggered == 2
+
+    def test_record_retrigger_accumulates(self) -> None:
+        tracker = MergeProgressTracker("org")
+        tracker.record_retrigger()
+        tracker.record_retrigger(2)
+        assert tracker.retriggers_issued == 3
+
+    def test_non_positive_counts_are_ignored(self) -> None:
+        """The totals are monotonic whatever a caller passes.
+
+        A display counter must never abort a merge run, so a bad
+        argument is dropped rather than raised — but it must also
+        never walk the total backwards.
+        """
+        tracker = MergeProgressTracker("org")
+        tracker.record_rebase(3)
+        tracker.record_retrigger(3)
+
+        tracker.record_rebase(0)
+        tracker.record_rebase(-5)
+        tracker.record_retrigger(0)
+        tracker.record_retrigger(-5)
+
+        assert tracker.rebases_triggered == 3
+        assert tracker.retriggers_issued == 3
+
+    def test_totals_survive_terminal_outcomes(self) -> None:
+        """The whole point: the counts stay put once the PR lands.
+
+        Previously "rebased" was a per-PR transitory state, so the
+        moment a rebased PR merged or failed the display lost all
+        trace that a rebase had ever been requested.
+        """
+        tracker = MergeProgressTracker("org")
+        tracker.rich_available = True
+        tracker.set_total_prs(2)
+
+        tracker.track_pr_state("org/repo#1", "rebasing")
+        tracker.record_rebase()
+        tracker.record_retrigger()
+        tracker.merge_success("org/repo#1")
+
+        tracker.track_pr_state("org/repo#2", "rebasing")
+        tracker.record_rebase()
+        tracker.record_retrigger()
+        tracker.merge_failure("org/repo#2")
+
+        assert tracker._pr_states == {}
+        assert tracker.rebases_triggered == 2
+        assert tracker.retriggers_issued == 2
+        plain = tracker._generate_display_text().plain
+        assert "⬆️ Rebased: 2" in plain
+        assert "📣 Retriggered: 2" in plain
+        assert "✅ Merged: 1" in plain
+        assert "❌ Failed: 1" in plain
+
+    def test_summary_includes_activity_counters(self) -> None:
+        tracker = MergeProgressTracker("org")
+        tracker.record_rebase()
+        tracker.record_retrigger()
+        summary = tracker.get_summary()
+        assert summary["rebases_triggered"] == 1
+        assert summary["retriggers_issued"] == 1
+
+    def test_concurrent_activity_increments_are_serialised(self) -> None:
+        from concurrent.futures import ThreadPoolExecutor
+
+        tracker = MergeProgressTracker("org")
+
+        def _record(_index: int) -> None:
+            tracker.record_rebase()
+            tracker.record_retrigger()
+
+        with ThreadPoolExecutor(max_workers=8) as executor:
+            list(executor.map(_record, range(64)))
+
+        assert tracker.rebases_triggered == 64
+        assert tracker.retriggers_issued == 64
+
+
 class TestDisplayRendering:
     """Stats line renders transitory states then terminal counters."""
 
@@ -173,25 +267,32 @@ class TestDisplayRendering:
         tracker.set_total_prs(7)
         tracker.track_pr_state("org/repo#1", "waiting")
         tracker.track_pr_state("org/repo#2", "rebasing")
-        tracker.track_pr_state("org/repo#3", "rebased")
+        tracker.track_pr_state("org/repo#3", "recreating")
         tracker.track_pr_state("org/repo#7", "submitting")
+        tracker.record_rebase()
+        tracker.record_retrigger()
         tracker.merge_success("org/repo#4")
         tracker.merge_pending("org/repo#5")
         tracker.merge_failure("org/repo#6")
 
         plain = tracker._generate_display_text().plain
         assert "🔄 Rebasing: 1" in plain
-        assert "⬆️ Rebased: 1" in plain
+        assert "♻️ Recreating: 1" in plain
         assert "⏳ Waiting: 1" in plain
         assert "📤 Submitting: 1" in plain
+        assert "⬆️ Rebased: 1" in plain
+        assert "📣 Retriggered: 1" in plain
         assert "✅ Merged: 1" in plain
         assert "🤖 Pending: 1" in plain
         assert "❌ Failed: 1" in plain
-        # Pipeline order: transitory states precede terminal counters.
-        assert plain.index("Rebasing") < plain.index("Rebased")
-        assert plain.index("Rebased") < plain.index("Waiting")
+        # Pipeline order: transitory states, then cumulative activity
+        # totals, then terminal counters.
+        assert plain.index("Rebasing") < plain.index("Recreating")
+        assert plain.index("Recreating") < plain.index("Waiting")
         assert plain.index("Waiting") < plain.index("Submitting")
-        assert plain.index("Submitting") < plain.index("Merged")
+        assert plain.index("Submitting") < plain.index("Rebased")
+        assert plain.index("Rebased") < plain.index("Retriggered")
+        assert plain.index("Retriggered") < plain.index("Merged")
 
     def test_zero_counters_do_not_render(self) -> None:
         tracker = MergeProgressTracker("org")
@@ -202,6 +303,8 @@ class TestDisplayRendering:
         assert "Pending" not in plain
         assert "Blocked" not in plain
         assert "Rebasing" not in plain
+        assert "Rebased" not in plain
+        assert "Retriggered" not in plain
 
     def test_unit_label_defaults_to_prs(self) -> None:
         tracker = MergeProgressTracker("org")
@@ -343,3 +446,184 @@ class TestRecordTerminalOutcome:
         tracker.track_pr_state.reset_mock()
         mgr._track_pr_state(pr, None)
         tracker.track_pr_state.assert_called_once_with("org/repo#7", None)
+
+    def test_record_helpers_delegate_to_tracker(self) -> None:
+        tracker = MagicMock()
+        mgr, _client = make_merge_manager(progress_tracker=tracker)
+
+        mgr._record_rebase()
+        mgr._record_retrigger()
+
+        tracker.record_rebase.assert_called_once_with()
+        tracker.record_retrigger.assert_called_once_with()
+
+    def test_record_helpers_without_tracker_are_noops(self) -> None:
+        mgr, _client = make_merge_manager(progress_tracker=None)
+        # Must not raise.
+        mgr._record_rebase()
+        mgr._record_retrigger()
+
+
+class TestMacroSitesRecordActivity:
+    """Every comment macro and rebase feeds the cumulative counters."""
+
+    @pytest.mark.asyncio
+    async def test_dependabot_rebase_counts_rebase_and_retrigger(self) -> None:
+        """``@dependabot rebase`` is one macro *and* one rebase."""
+        tracker = MagicMock()
+        mgr, client = make_merge_manager(progress_tracker=tracker)
+        client.get = AsyncMock(return_value=[])
+        client.post_issue_comment = AsyncMock()
+
+        assert await mgr._request_dependabot_rebase(_make_pr(), "org", "repo")
+
+        tracker.record_rebase.assert_called_once_with()
+        tracker.record_retrigger.assert_called_once_with()
+
+    @pytest.mark.asyncio
+    async def test_existing_rebase_comment_counts_nothing(self) -> None:
+        """A rebase requested by an earlier run is not ours to claim."""
+        tracker = MagicMock()
+        mgr, client = make_merge_manager(progress_tracker=tracker)
+        client.get = AsyncMock(return_value=[{"body": "@dependabot rebase"}])
+        client.post_issue_comment = AsyncMock()
+
+        assert await mgr._request_dependabot_rebase(_make_pr(), "org", "repo")
+
+        tracker.record_rebase.assert_not_called()
+        tracker.record_retrigger.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_failed_post_counts_nothing(self) -> None:
+        tracker = MagicMock()
+        mgr, client = make_merge_manager(progress_tracker=tracker)
+        client.get = AsyncMock(return_value=[])
+        client.post_issue_comment = AsyncMock(side_effect=RuntimeError("nope"))
+
+        assert not await mgr._request_dependabot_rebase(_make_pr(), "org", "repo")
+
+        tracker.record_rebase.assert_not_called()
+        tracker.record_retrigger.assert_not_called()
+
+
+class TestRebaseModuleRecordsRebases:
+    """The rebase orchestrator counts the rebases it performs itself."""
+
+    def _make_ctx(
+        self, client: Any, record: Any, track: Any = None
+    ) -> rebase_module.RebaseContext:
+        return rebase_module.RebaseContext(
+            github_client=client,
+            token="t",
+            rebase_local=False,
+            preview_mode=False,
+            merge_recheck_interval=0.0,
+            merge_poll_max_attempts=1,
+            log=logging.getLogger("test"),
+            console=MagicMock(),
+            rebased_prs=set(),
+            enable_auto_merge=AsyncMock(return_value=True),
+            track_pr_state=track,
+            record_rebase=record,
+        )
+
+    @pytest.mark.asyncio
+    async def test_local_path_counts_successful_rebase(self) -> None:
+        record = MagicMock()
+        ctx = self._make_ctx(AsyncMock(), record)
+
+        with patch.object(
+            rebase_module, "local_rebase_pr", new=AsyncMock(return_value=True)
+        ):
+            await rebase_module._run_local_path(
+                ctx=ctx,
+                pr_info=_make_pr(),
+                owner="org",
+                repo="repo",
+                local_reason="signatures required",
+            )
+
+        record.assert_called_once_with()
+
+    @pytest.mark.asyncio
+    async def test_local_path_failure_counts_nothing(self) -> None:
+        record = MagicMock()
+        ctx = self._make_ctx(AsyncMock(), record)
+
+        with patch.object(
+            rebase_module, "local_rebase_pr", new=AsyncMock(return_value=False)
+        ):
+            await rebase_module._run_local_path(
+                ctx=ctx,
+                pr_info=_make_pr(),
+                owner="org",
+                repo="repo",
+                local_reason="signatures required",
+            )
+
+        record.assert_not_called()
+
+    @pytest.mark.parametrize("rebase_ok", [True, False])
+    @pytest.mark.asyncio
+    async def test_local_path_always_clears_rebasing_state(
+        self, rebase_ok: bool
+    ) -> None:
+        """A failed local rebase must not strand the PR in "Rebasing".
+
+        ``perform_step5_rebase`` sets "rebasing" before dispatch, and
+        this path defers to auto-merge rather than reaching a terminal
+        outcome, so nothing else would clear it.
+        """
+        track = MagicMock()
+        ctx = self._make_ctx(AsyncMock(), MagicMock(), track)
+        pr = _make_pr()
+
+        with patch.object(
+            rebase_module, "local_rebase_pr", new=AsyncMock(return_value=rebase_ok)
+        ):
+            await rebase_module._run_local_path(
+                ctx=ctx,
+                pr_info=pr,
+                owner="org",
+                repo="repo",
+                local_reason="signatures required",
+            )
+
+        track.assert_called_once_with(pr, None)
+
+    @pytest.mark.asyncio
+    async def test_rest_path_counts_update_branch(self) -> None:
+        record = MagicMock()
+        client = AsyncMock()
+        client.update_branch = AsyncMock()
+        ctx = self._make_ctx(client, record)
+
+        with patch.object(
+            rebase_module,
+            "_poll_post_rebase",
+            new=AsyncMock(return_value=(True, "clean")),
+        ):
+            outcome = await rebase_module._run_rest_path(
+                ctx=ctx, pr_info=_make_pr(), owner="org", repo="repo"
+            )
+
+        assert not outcome.failed
+        record.assert_called_once_with()
+
+    @pytest.mark.asyncio
+    async def test_dependabot_macro_path_does_not_double_count(self) -> None:
+        """The macro path delegates to the manager, which already counts."""
+        record = MagicMock()
+        ctx = self._make_ctx(AsyncMock(), record)
+        ctx.request_dependabot_rebase = AsyncMock(return_value=True)
+
+        handled = await rebase_module._run_dependabot_macro_path(
+            ctx=ctx,
+            pr_info=_make_pr(),
+            owner="org",
+            repo="repo",
+            local_reason="signatures required",
+        )
+
+        assert handled is True
+        record.assert_not_called()


### PR DESCRIPTION
## Summary

The live merge display only ever showed where each PR was *right now*. `Rebased` was a transitory per-PR state, so the moment a rebased PR reached `Merged` or `Failed` the display lost every trace that a rebase had been requested. Comment macros (`@dependabot recreate`, `pre-commit.ci run`) were never surfaced at all.

On the 159-PR org-wide run that prompted this, the progress line finished as:

```
✅ Merged: 142 | ❌ Failed: 17
```

…with no way to tell how much recovery work the run actually performed.

This adds two **cumulative activity counters** that track *operations* rather than PRs:

```
🔄 Rebasing: 2 | ⏳ Waiting: 5 | ⬆️ Rebased: 12 | 📣 Retriggered: 4 | ✅ Merged: 142 | ❌ Failed: 17
```

- **`⬆️ Rebased`** — every mechanism that moves a branch onto its base: the local `git rebase` + force-push, the REST `update-branch` call, and the `@dependabot rebase` macro.
- **`📣 Retriggered`** — every comment macro posted: `@dependabot rebase`, `@dependabot recreate`, `pre-commit.ci run`, and any macro added later.

Both are monotonic and survive the PR's transition to a terminal outcome.

## Design notes

**A `@dependabot rebase` increments both counters.** It is one comment macro *and* one rebase request, and the two counters answer different questions ("how many branches did we move?" vs "how many times did we poke an external bot?"). This is documented on `record_retrigger`.

**The duplicate-comment guard counts neither.** When `_request_dependabot_rebase` finds an existing `@dependabot rebase` comment it returns `True` without posting — that rebase belongs to an earlier run, so claiming it would inflate this run's totals.

**`rebased` is no longer a transitory state.** "A rebase happened" is a completed operation, not a place a PR sits; keying it per PR is exactly what made the count vanish. `_STATE_ORDER` drops it, and the call sites that previously parked a PR in `rebased` while polling now report `waiting`, which is what the PR is actually doing. The defensive unknown-state rendering in `_generate_display_text` still catches any stray caller.

**Counting happens at request time, not landing time.** A `@dependabot rebase` that is posted but never lands (the PR times out still `dirty`) is still a rebase this run triggered, and the operator wants to see it.

## Changes

| File | Change |
| --- | --- |
| `src/dependamerge/progress_tracker.py` | `rebases_triggered` / `retriggers_issued` counters, `record_rebase()` / `record_retrigger()` (lock-guarded like the existing counters), render + `get_summary()` + `DummyProgressTracker` surface; `rebased` removed from `_STATE_ORDER` |
| `src/dependamerge/merge_manager.py` | `_record_rebase()` / `_record_retrigger()` helpers; wired into `_request_dependabot_rebase`, `_trigger_dependabot_recreate`, `_trigger_stale_precommit_ci`, and the `update_branch` call in `_handle_merge_failure`; conflict handler's post-rebase wait now reports `waiting` |
| `src/dependamerge/rebase.py` | New optional `RebaseContext.record_rebase` callback; counted in the local force-push path and after REST `update_branch`. The `@dependabot rebase` macro path deliberately does **not** count — `request_dependabot_rebase` already records it on the manager |
| `tests/test_merge_state_tracking.py` | New `TestActivityCounters`, `TestMacroSitesRecordActivity`, `TestRebaseModuleRecordsRebases`; existing state/render tests updated |
| `README.md` | Feature bullet describing both counters |

## Validation

- `uv run pytest tests/ -q` → **1489 passed, 14 skipped** (was 1480; +9 new tests), coverage 70.26%
- `uv run mypy` on the three changed modules → clean
- Full `pre-commit` gate ran on commit (ruff, ruff-format, mypy, basedpyright, reuse, markdownlint, codespell, gitlint, pytest) → all passed

## Out of scope

The end-of-run `📈 Final Results:` line is computed from `MergeResult` objects rather than the tracker, so it does not yet show these totals. Plumbing the tracker summary into `_print_final_merge_summary` / `_display_merge_results` would be a natural follow-up if the totals are wanted in the post-run recap too.
