### PR TITLE
Fix: Judge check runs by latest run per name

### DIFF
--- a/src/dependamerge/check_runs.py
+++ b/src/dependamerge/check_runs.py
@@ -1,0 +1,131 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 The Linux Foundation
+
+"""Deduplication of check runs reported against a single commit.
+
+GitHub can attach several check runs carrying the *same name* to one
+commit.  The common cause is a superseded run: two workflow events fire
+for the same head SHA (for example a ``pull_request`` event delivered
+twice with different attributed actors), the workflow's ``concurrency``
+group cancels the first, and the cancelled run stays attached to the
+commit alongside the successful one.
+
+Treating every reported run as authoritative makes a commit look broken
+when it is not: a cancelled, superseded run sits next to a successful
+run of the same check.  GitHub's own merge protection evaluates the
+latest run per check name, and this module does the same.
+
+The helpers here are deliberately pure and transport-agnostic so the
+REST and GraphQL code paths can share one definition of "did this check
+pass".
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from datetime import datetime
+from typing import Any
+
+__all__ = [
+    "FAILING_CONCLUSIONS",
+    "failing_check_names",
+    "latest_check_run_per_name",
+]
+
+# Conclusions that mark a check run as not having succeeded.  "cancelled"
+# is included because a genuinely cancelled *latest* run should block;
+# it is only harmless when superseded, which the deduplication below
+# resolves before this set is consulted.
+FAILING_CONCLUSIONS = frozenset({"failure", "cancelled", "timed_out"})
+
+
+def _parse_timestamp(value: Any) -> datetime | None:
+    """Parse an ISO-8601 timestamp, tolerating ``Z`` and ``None``."""
+    if not isinstance(value, str) or not value:
+        return None
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def _run_timestamp(run: Mapping[str, Any]) -> datetime | None:
+    """Best available completion time for *run*.
+
+    Prefers completion over start: two runs may start in the same second
+    while their completion times still order them correctly.  Accepts
+    both REST (``completed_at``) and GraphQL (``completedAt``) spellings.
+    """
+    for key in ("completed_at", "completedAt", "started_at", "startedAt"):
+        parsed = _parse_timestamp(run.get(key))
+        if parsed is not None:
+            return parsed
+    return None
+
+
+def _is_failing(run: Mapping[str, Any]) -> bool:
+    return (run.get("conclusion") or "").strip().lower() in FAILING_CONCLUSIONS
+
+
+def _supersedes(candidate: Mapping[str, Any], incumbent: Mapping[str, Any]) -> bool:
+    """Whether *candidate* should replace *incumbent* as the latest run.
+
+    Ordering is by timestamp.  When timestamps are absent or identical --
+    which happens when the API does not expose them, or when duplicate
+    runs complete within the same second -- a successful run wins over a
+    failing one.  That tie-break is what resolves the superseded-cancel
+    race: the surviving run is the one that actually ran to completion.
+    """
+    candidate_ts = _run_timestamp(candidate)
+    incumbent_ts = _run_timestamp(incumbent)
+
+    if candidate_ts is not None and incumbent_ts is not None:
+        if candidate_ts != incumbent_ts:
+            return candidate_ts > incumbent_ts
+    elif candidate_ts is not None or incumbent_ts is not None:
+        # Only one side is timestamped.  Prefer the timestamped run: it
+        # carries strictly more information than one that reports none.
+        return candidate_ts is not None
+
+    # Indistinguishable by time; prefer a run that did not fail.
+    return _is_failing(incumbent) and not _is_failing(candidate)
+
+
+def latest_check_run_per_name(
+    runs: Iterable[Mapping[str, Any]],
+) -> dict[str, Mapping[str, Any]]:
+    """Collapse *runs* to the latest run for each check name.
+
+    Runs without a name are ignored: they cannot be matched against a
+    required-check rule, so they carry no signal here.
+    """
+    latest: dict[str, Mapping[str, Any]] = {}
+    for run in runs:
+        if not isinstance(run, Mapping):
+            continue
+        name = (run.get("name") or "").strip()
+        if not name:
+            continue
+        incumbent = latest.get(name)
+        if incumbent is None or _supersedes(run, incumbent):
+            latest[name] = run
+    return latest
+
+
+def failing_check_names(runs: Iterable[Mapping[str, Any]]) -> list[str]:
+    """Names whose *latest* run did not succeed, in first-seen order.
+
+    A name is reported at most once even when several runs carry it.
+    """
+    materialised = [run for run in runs if isinstance(run, Mapping)]
+    latest = latest_check_run_per_name(materialised)
+
+    ordered: list[str] = []
+    seen: set[str] = set()
+    for run in materialised:
+        name = (run.get("name") or "").strip()
+        if name and name not in seen:
+            seen.add(name)
+            ordered.append(name)
+
+    return [name for name in ordered if _is_failing(latest[name])]

--- a/src/dependamerge/check_runs.py
+++ b/src/dependamerge/check_runs.py
@@ -23,7 +23,7 @@ pass".
 from __future__ import annotations
 
 from collections.abc import Iterable, Mapping
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any
 
 __all__ = [
@@ -40,13 +40,22 @@ FAILING_CONCLUSIONS = frozenset({"failure", "cancelled", "timed_out"})
 
 
 def _parse_timestamp(value: Any) -> datetime | None:
-    """Parse an ISO-8601 timestamp, tolerating ``Z`` and ``None``."""
+    """Parse an ISO-8601 timestamp, tolerating ``Z`` and ``None``.
+
+    A parsed value is always timezone-aware.  GitHub reports UTC, and a
+    payload that omits the offset is assumed to mean the same, so an
+    aware and a naive value can never meet in a comparison and raise
+    ``TypeError``.
+    """
     if not isinstance(value, str) or not value:
         return None
     try:
-        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
     except ValueError:
         return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=timezone.utc)
+    return parsed
 
 
 def _run_timestamp(run: Mapping[str, Any]) -> datetime | None:
@@ -70,24 +79,26 @@ def _is_failing(run: Mapping[str, Any]) -> bool:
 def _supersedes(candidate: Mapping[str, Any], incumbent: Mapping[str, Any]) -> bool:
     """Whether *candidate* should replace *incumbent* as the latest run.
 
-    Ordering is by timestamp.  When timestamps are absent or identical --
-    which happens when the API does not expose them, or when duplicate
-    runs complete within the same second -- a successful run wins over a
-    failing one.  That tie-break is what resolves the superseded-cancel
-    race: the surviving run is the one that actually ran to completion.
+    Ordering is by timestamp whenever both runs carry one and they
+    differ.  Otherwise the order cannot be established -- the timestamps
+    are absent, only one side reports them, or they are identical, which
+    happens readily when duplicate runs complete within the same second.
+
+    When order is indeterminate a successful run wins over a failing one.
+    Two runs sharing a name are overwhelmingly a supersede race, and a
+    genuine lone failure has no successful sibling to beat it, so this
+    resolves the phantom failure without masking real breakage.
     """
     candidate_ts = _run_timestamp(candidate)
     incumbent_ts = _run_timestamp(incumbent)
 
-    if candidate_ts is not None and incumbent_ts is not None:
-        if candidate_ts != incumbent_ts:
-            return candidate_ts > incumbent_ts
-    elif candidate_ts is not None or incumbent_ts is not None:
-        # Only one side is timestamped.  Prefer the timestamped run: it
-        # carries strictly more information than one that reports none.
-        return candidate_ts is not None
+    if (
+        candidate_ts is not None
+        and incumbent_ts is not None
+        and candidate_ts != incumbent_ts
+    ):
+        return candidate_ts > incumbent_ts
 
-    # Indistinguishable by time; prefer a run that did not fail.
     return _is_failing(incumbent) and not _is_failing(candidate)
 
 

--- a/src/dependamerge/cli.py
+++ b/src/dependamerge/cli.py
@@ -739,13 +739,21 @@ def _maybe_check_merge_permissions(ctx: _MergeContext) -> None:
 
 
 def _validate_automation_author(ctx: _MergeContext) -> None:
-    """Verify the source PR author is from automation or has a valid override.
+    """Gate a human-authored source PR behind an explicit opt-in.
 
-    May print usage guidance and return early (via ``return`` in
-    the caller) or exit on validation failure.
+    Automation-authored sources pass straight through.  A human-authored
+    source needs either ``--include-human-prs`` (the documented opt-in,
+    which also governs which similar PRs are acted on) or a matching
+    ``--override`` SHA, retained so existing invocations keep working.
+
+    With neither, fail fast.  Previously this printed override guidance
+    and exited *successfully*, which is indistinguishable from "nothing
+    to merge" when scripted, and meant ``--include-human-prs`` appeared
+    to do nothing when pointed at a human-authored PR.
 
     Raises:
-        typer.Exit: On invalid override SHA.
+        SystemExit: When the source is human-authored and unauthorised,
+            or when a supplied override SHA does not match.
     """
     assert ctx.github_client is not None
     assert ctx.source_pr is not None
@@ -759,27 +767,49 @@ def _validate_automation_author(ctx: _MergeContext) -> None:
     first_commit_line = commit_messages[0].split("\n")[0] if commit_messages else ""
     expected_sha = _generate_override_sha(ctx.source_pr, first_commit_line)
 
-    if not ctx.override:
-        console.print("Source PR is not from a recognized automation tool.")
-        console.print(
-            f"To merge this and similar PRs, run again with: --override {expected_sha}"
-        )
-        console.print(
-            f"This SHA is based on the author "
-            f"'{ctx.source_pr.author}' and commit message "
-            f"'{first_commit_line[:50]}...'",
-            style="dim",
-        )
-        raise typer.Exit(0)
-
-    if not _validate_override_sha(ctx.override, ctx.source_pr, first_commit_line):
+    # A supplied override must match whichever gate ultimately authorises
+    # the run.  A wrong SHA means the operator is looking at a different
+    # PR than they think, and that is worth stopping for even when
+    # --include-human-prs would otherwise have been sufficient.
+    if ctx.override and not _validate_override_sha(
+        ctx.override, ctx.source_pr, first_commit_line
+    ):
         exit_with_error(
             ExitCode.VALIDATION_ERROR,
             message="❌ Invalid override SHA provided",
             details=(f"Expected SHA for this PR and author: --override {expected_sha}"),
         )
 
-    console.print("Override SHA validated. Proceeding with non-automation PR merge.")
+    if ctx.include_human_prs:
+        console.print(
+            f"👤 Source PR is human-authored (by {ctx.source_pr.author}); "
+            "proceeding because --include-human-prs was supplied."
+        )
+        return
+
+    if ctx.override:
+        console.print("Override SHA validated. Proceeding with non-automation PR merge.")
+        console.print(
+            "ℹ️ --include-human-prs is the documented way to authorise "
+            "human-authored PRs; --override remains supported.",
+            style="dim",
+        )
+        return
+
+    exit_with_error(
+        ExitCode.VALIDATION_ERROR,
+        message=(
+            f"❌ Source PR is human-authored (by {ctx.source_pr.author}), "
+            "not from a recognised automation tool"
+        ),
+        details=(
+            "dependamerge acts on automation PRs by default.\n"
+            "To include human-authored PRs, run again with: --include-human-prs\n"
+            f"To authorise only this PR instead: --override {expected_sha}\n"
+            f"That SHA derives from the author '{ctx.source_pr.author}' and "
+            f"commit message '{first_commit_line[:50]}...'"
+        ),
+    )
 
 
 def _scan_and_find_similar(ctx: _MergeContext) -> None:
@@ -2077,7 +2107,7 @@ def _resolve_gerrit_only_automation(
         True when only automation changes should be matched.
 
     Raises:
-        typer.Exit: When the source is a non-automation change without a
+        SystemExit: When the source is a non-automation change without a
             valid override SHA.
     """
     if comparator.is_automation_change(source_change):
@@ -2456,7 +2486,10 @@ def merge(
     override: str | None = typer.Option(
         None,
         "--override",
-        help="SHA hash to override non-automation PR/change restriction",
+        help=(
+            "SHA hash authorising a single non-automation PR/change. "
+            "Prefer --include-human-prs; this remains supported"
+        ),
     ),
     no_fix: bool = typer.Option(
         False,
@@ -2559,7 +2592,11 @@ def merge(
     include_human_prs: bool = typer.Option(
         False,
         "--include-human-prs",
-        help="Include human-authored PRs when merging a repository (prompts for confirmation when human PRs are found)",
+        help=(
+            "Authorise human-authored PRs. Required when the source PR is "
+            "human-authored, and includes human-authored PRs in the similar-PR "
+            "set (prompting for confirmation unless --no-confirm)"
+        ),
     ),
     topic: str | None = typer.Option(
         None,

--- a/src/dependamerge/cli.py
+++ b/src/dependamerge/cli.py
@@ -752,7 +752,7 @@ def _validate_automation_author(ctx: _MergeContext) -> None:
     to do nothing when pointed at a human-authored PR.
 
     Raises:
-        SystemExit: When the source is human-authored and unauthorised,
+        SystemExit: When the source is human-authored and unauthorized,
             or when a supplied override SHA does not match.
     """
     assert ctx.github_client is not None
@@ -761,13 +761,26 @@ def _validate_automation_author(ctx: _MergeContext) -> None:
     if ctx.github_client.is_automation_author(ctx.source_pr.author):
         return
 
+    human_source_notice = (
+        f"👤 Source PR is human-authored (by {ctx.source_pr.author}); "
+        "proceeding because --include-human-prs was supplied."
+    )
+
+    # Deriving the override SHA costs an extra API call per pull request.
+    # Skip it when --include-human-prs alone already authorizes the run
+    # and there is no supplied override to check it against; at
+    # organisation scale that latency and rate-limit pressure adds up.
+    if ctx.include_human_prs and not ctx.override:
+        console.print(human_source_notice)
+        return
+
     commit_messages = ctx.github_client.get_pull_request_commits(
         ctx.owner, ctx.repo_name, ctx.pr_number
     )
     first_commit_line = commit_messages[0].split("\n")[0] if commit_messages else ""
     expected_sha = _generate_override_sha(ctx.source_pr, first_commit_line)
 
-    # A supplied override must match whichever gate ultimately authorises
+    # A supplied override must match whichever gate ultimately authorizes
     # the run.  A wrong SHA means the operator is looking at a different
     # PR than they think, and that is worth stopping for even when
     # --include-human-prs would otherwise have been sufficient.
@@ -781,16 +794,13 @@ def _validate_automation_author(ctx: _MergeContext) -> None:
         )
 
     if ctx.include_human_prs:
-        console.print(
-            f"👤 Source PR is human-authored (by {ctx.source_pr.author}); "
-            "proceeding because --include-human-prs was supplied."
-        )
+        console.print(human_source_notice)
         return
 
     if ctx.override:
         console.print("Override SHA validated. Proceeding with non-automation PR merge.")
         console.print(
-            "ℹ️ --include-human-prs is the documented way to authorise "
+            "ℹ️ --include-human-prs is the documented way to authorize "
             "human-authored PRs; --override remains supported.",
             style="dim",
         )
@@ -800,12 +810,12 @@ def _validate_automation_author(ctx: _MergeContext) -> None:
         ExitCode.VALIDATION_ERROR,
         message=(
             f"❌ Source PR is human-authored (by {ctx.source_pr.author}), "
-            "not from a recognised automation tool"
+            "not from a recognized automation tool"
         ),
         details=(
             "dependamerge acts on automation PRs by default.\n"
             "To include human-authored PRs, run again with: --include-human-prs\n"
-            f"To authorise only this PR instead: --override {expected_sha}\n"
+            f"To authorize only this PR instead: --override {expected_sha}\n"
             f"That SHA derives from the author '{ctx.source_pr.author}' and "
             f"commit message '{first_commit_line[:50]}...'"
         ),
@@ -2487,7 +2497,7 @@ def merge(
         None,
         "--override",
         help=(
-            "SHA hash authorising a single non-automation PR/change. "
+            "SHA hash authorizing a single non-automation PR/change. "
             "Prefer --include-human-prs; this remains supported"
         ),
     ),
@@ -2593,7 +2603,7 @@ def merge(
         False,
         "--include-human-prs",
         help=(
-            "Authorise human-authored PRs. Required when the source PR is "
+            "Authorize human-authored PRs. Required when the source PR is "
             "human-authored, and includes human-authored PRs in the similar-PR "
             "set (prompting for confirmation unless --no-confirm)"
         ),

--- a/src/dependamerge/github_async.py
+++ b/src/dependamerge/github_async.py
@@ -2320,7 +2320,14 @@ class GitHubAsync:
                 # a completed run and a fresh in_progress re-run is still
                 # pending, and must not be collapsed away here.
                 for run in raw_runs:
-                    name = run.get("name", "unknown")
+                    name = (run.get("name") or "").strip()
+                    if not name:
+                        # An unnamed run cannot be matched against a
+                        # required-check rule.  Recording it produces
+                        # only misleading output such as "Blocked by
+                        # failing check: unknown", so drop it here just
+                        # as the deduplication helper does.
+                        continue
                     status = run.get("status")
                     reported_check_names.add(name)
                     if status == "completed":

--- a/src/dependamerge/github_async.py
+++ b/src/dependamerge/github_async.py
@@ -26,6 +26,7 @@ from tenacity import (
 )
 
 from .bot_identity import is_copilot
+from .check_runs import failing_check_names
 
 __all__ = [
     "GitHubAsync",
@@ -2309,19 +2310,29 @@ class GitHubAsync:
                 f"/repos/{owner}/{repo}/commits/{head_sha}/check-runs"
             )
             if isinstance(runs, dict):
-                for run in runs.get("check_runs") or []:
-                    if not isinstance(run, dict):
-                        continue
+                raw_runs = [
+                    run
+                    for run in (runs.get("check_runs") or [])
+                    if isinstance(run, dict)
+                ]
+                # Status classification deliberately considers *every*
+                # reported run, not just the latest: a name carrying both
+                # a completed run and a fresh in_progress re-run is still
+                # pending, and must not be collapsed away here.
+                for run in raw_runs:
                     name = run.get("name", "unknown")
                     status = run.get("status")
-                    conclusion = run.get("conclusion")
                     reported_check_names.add(name)
                     if status == "completed":
                         completed_check_names.add(name)
                     elif status in ("queued", "in_progress"):
                         pending_check_names.add(name)
-                    if conclusion in ["failure", "cancelled", "timed_out"]:
-                        failing_checks.append(name)
+                # Failure, by contrast, is decided by the latest run per
+                # name.  A commit can carry several runs under one name
+                # when a duplicate workflow event causes ``concurrency``
+                # to cancel a superseded run; that cancelled run must not
+                # mask the successful one that replaced it.
+                failing_checks.extend(failing_check_names(raw_runs))
         except Exception:
             # Check-runs API may be unavailable; proceed with whatever
             # checks were collected so far.

--- a/src/dependamerge/github_graphql.py
+++ b/src/dependamerge/github_graphql.py
@@ -157,6 +157,8 @@ query($org: String!, $reposCursor: String) {
                           name
                           status
                           conclusion
+                          startedAt
+                          completedAt
                         }
                         ... on StatusContext {
                           context
@@ -247,6 +249,8 @@ query($owner: String!, $name: String!, $prsCursor: String, $prsPageSize: Int!, $
                       name
                       status
                       conclusion
+                      startedAt
+                      completedAt
                     }
                     ... on StatusContext {
                       context

--- a/src/dependamerge/github_service.py
+++ b/src/dependamerge/github_service.py
@@ -11,6 +11,7 @@ from datetime import datetime
 from typing import Any
 
 from .bot_identity import canonical_bot_login, is_automation_author
+from .check_runs import failing_check_names
 from .github_async import (
     GitHubAsync,
     GraphQLError,
@@ -1334,9 +1335,15 @@ class GitHubService:
                 )
         return result
 
-    def _extract_failing_checks(self, pr: dict[str, Any]) -> list[str]:
+    @staticmethod
+    def _extract_failing_checks(pr: dict[str, Any]) -> list[str]:
         """
         Extract failing checks from the statusCheckRollup on the latest commit.
+
+        A commit can carry several check runs sharing one name, typically
+        when a duplicate workflow event causes ``concurrency`` to cancel a
+        superseded run.  Only the latest run per name decides the outcome,
+        matching GitHub's own merge protection; see ``check_runs``.
         """
         failing: list[str] = []
 
@@ -1348,23 +1355,23 @@ class GitHubService:
         rollup = commit.get("statusCheckRollup") or {}
         contexts = (rollup.get("contexts") or {}).get("nodes", []) or []
 
+        check_runs: list[dict[str, Any]] = []
+
         for ctx in contexts:
             typ = ctx.get("__typename")
             if typ == "CheckRun":
-                # Consider failure, cancelled, or timed_out as failing
-                conclusion = (ctx.get("conclusion") or "").lower()
-                if conclusion in ("failure", "cancelled", "timed_out"):
-                    name = ctx.get("name") or ""
-                    if name:
-                        failing.append(name)
+                # Collected for deduplication rather than judged here.
+                check_runs.append(ctx)
             elif typ == "StatusContext":
+                # Commit statuses are already latest-per-context: GitHub
+                # collapses repeated posts to the same context itself.
                 state = (ctx.get("state") or "").upper()
                 if state in ("FAILURE", "ERROR"):
                     name = ctx.get("context") or ""
                     if name:
                         failing.append(name)
 
-        return failing
+        return failing_check_names(check_runs) + failing
 
     async def gather_organization_status(self, org: str) -> OrganizationStatus:
         """

--- a/tests/test_check_run_dedup.py
+++ b/tests/test_check_run_dedup.py
@@ -101,6 +101,32 @@ class TestSupersededRuns:
         ]
         assert failing_check_names(runs) == []
 
+    def test_success_wins_when_only_the_failure_is_timestamped(self):
+        # Partial timestamps leave the order genuinely unknown.  An
+        # earlier revision preferred whichever run carried a timestamp,
+        # which let a superseded cancel beat the success that replaced
+        # it and reintroduced the phantom failure.
+        runs = [
+            _run("Build", "success"),
+            _run("Build", "cancelled", "2026-07-30T14:43:37Z"),
+        ]
+        assert failing_check_names(runs) == []
+
+    def test_success_wins_when_only_the_success_is_timestamped(self):
+        runs = [
+            _run("Build", "cancelled"),
+            _run("Build", "success", "2026-07-30T14:44:05Z"),
+        ]
+        assert failing_check_names(runs) == []
+
+    def test_identical_timestamps_resolve_to_success(self):
+        # Duplicate runs readily complete within the same second.
+        runs = [
+            _run("Build", "cancelled", "2026-07-30T14:43:37Z"),
+            _run("Build", "success", "2026-07-30T14:43:37Z"),
+        ]
+        assert failing_check_names(runs) == []
+
 
 class TestGenuineFailures:
     """Deduplication must not mask real problems."""
@@ -161,6 +187,24 @@ class TestMalformedInput:
         ]
         # Both timestamps unusable, so the success tie-break applies.
         assert failing_check_names(runs) == []
+
+    def test_naive_and_aware_timestamps_do_not_raise(self):
+        # Comparing an offset-naive datetime with an offset-aware one
+        # raises TypeError in Python.  A payload that omits the offset
+        # must not crash a run; GitHub reports UTC, so naive values are
+        # read as UTC.
+        runs = [
+            _run("A", "cancelled", "2026-07-30T14:43:37"),
+            _run("A", "success", "2026-07-30T14:44:05Z"),
+        ]
+        assert failing_check_names(runs) == []
+
+    def test_naive_timestamps_still_order_correctly(self):
+        runs = [
+            _run("A", "success", "2026-07-30T10:00:00"),
+            _run("A", "failure", "2026-07-30T11:00:00Z"),
+        ]
+        assert failing_check_names(runs) == ["A"]
 
     def test_missing_conclusion_treated_as_not_failing(self):
         # An in-progress run has no conclusion yet; pending is handled
@@ -308,3 +352,23 @@ class TestRestCheckRunPath:
             result = await api.analyze_block_reason("owner", "repo", 123, "abc123")
 
         assert result is not None and "Audit Workflows" in result
+
+    @pytest.mark.asyncio
+    async def test_unnamed_failing_run_is_not_surfaced(self) -> None:
+        # An unnamed run cannot be matched against a required-check
+        # rule.  Reporting it produced output naming a check called
+        # "unknown", which tells the operator nothing actionable.
+        async with GitHubAsync(token="t") as api:
+            api.get = AsyncMock(  # type: ignore[method-assign]
+                side_effect=_rest_router(
+                    check_runs=[
+                        {"status": "completed", "conclusion": "failure"},
+                        {"name": None, "status": "completed", "conclusion": "failure"},
+                    ]
+                )
+            )
+            api.get_required_status_checks = AsyncMock(return_value=[])  # type: ignore[method-assign]
+
+            result = await api.analyze_block_reason("owner", "repo", 123, "abc123")
+
+        assert result is None or "unknown" not in result

--- a/tests/test_check_run_dedup.py
+++ b/tests/test_check_run_dedup.py
@@ -1,0 +1,310 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 The Linux Foundation
+
+"""Tests for check-run deduplication.
+
+The motivating defect: GitHub can attach two runs of the same check to a
+single commit when a duplicate workflow event causes ``concurrency`` to
+cancel a superseded run.  Reading every run as authoritative made a
+healthy commit look broken, which blocked automerge until someone forced
+a rebase -- retrying never helped, because the cancelled run stays
+attached to that SHA permanently.
+"""
+
+from collections.abc import Mapping
+from typing import Any, cast
+from unittest.mock import AsyncMock
+
+import pytest
+
+from dependamerge.check_runs import (
+    failing_check_names,
+    latest_check_run_per_name,
+)
+from dependamerge.github_async import GitHubAsync
+from dependamerge.github_service import GitHubService
+
+
+def _rest_router(*, check_runs):
+    """Route ``analyze_block_reason``'s GETs with an approved PR.
+
+    Everything except the check runs is benign, so any block reason the
+    method returns comes from the check-run handling under test.
+    """
+
+    async def _get(url: str):
+        if url.endswith("/reviews"):
+            return [{"state": "APPROVED", "user": {}}]
+        if url.endswith("/comments"):
+            return []
+        if "/check-runs" in url:
+            return {"check_runs": check_runs}
+        if url.endswith("/status"):
+            return {"statuses": []}
+        if url == "/repos/owner/repo":
+            return {"default_branch": "main"}
+        if url.endswith("/pulls/123"):
+            return {"base": {"ref": "main"}}
+        return {}
+
+    return _get
+
+
+def _run(name, conclusion, completed_at=None, status="completed"):
+    run = {"name": name, "conclusion": conclusion, "status": status}
+    if completed_at is not None:
+        run["completed_at"] = completed_at
+    return run
+
+
+class TestSupersededRuns:
+    """A cancelled run superseded by a successful one must not block."""
+
+    def test_cancelled_then_success_is_not_failing(self):
+        # Observed on lfreleng-actions/harden-runner-block-action#36:
+        # both runs on head 06e8015, one second apart.
+        runs = [
+            _run("Audit changes", "cancelled", "2026-07-30T14:43:37Z"),
+            _run("Audit changes", "success", "2026-07-30T14:44:05Z"),
+        ]
+        assert failing_check_names(runs) == []
+
+    def test_order_in_payload_does_not_matter(self):
+        runs = [
+            _run("Audit changes", "success", "2026-07-30T14:44:05Z"),
+            _run("Audit changes", "cancelled", "2026-07-30T14:43:37Z"),
+        ]
+        assert failing_check_names(runs) == []
+
+    def test_success_wins_when_timestamps_absent(self):
+        # The GraphQL rollup historically exposed no timestamps; the
+        # tie-break must still resolve the supersede race.
+        runs = [
+            _run("Zizmor Scan", "cancelled"),
+            _run("Zizmor Scan", "success"),
+        ]
+        assert failing_check_names(runs) == []
+
+    def test_newest_run_wins_even_when_it_failed(self):
+        # A re-run that fails must still block: newest wins, not
+        # "any success anywhere".
+        runs = [
+            _run("Python Tests", "success", "2026-07-30T10:00:00Z"),
+            _run("Python Tests", "failure", "2026-07-30T11:00:00Z"),
+        ]
+        assert failing_check_names(runs) == ["Python Tests"]
+
+    def test_timestamped_run_preferred_over_untimestamped(self):
+        runs = [
+            _run("Build", "cancelled"),
+            _run("Build", "success", "2026-07-30T11:00:00Z"),
+        ]
+        assert failing_check_names(runs) == []
+
+
+class TestGenuineFailures:
+    """Deduplication must not mask real problems."""
+
+    def test_single_failure_still_reported(self):
+        assert failing_check_names([_run("Lint", "failure")]) == ["Lint"]
+
+    def test_lone_cancelled_run_still_blocks(self):
+        # Nothing superseded it, so it is the latest word on that check.
+        assert failing_check_names([_run("Lint", "cancelled")]) == ["Lint"]
+
+    def test_timed_out_still_blocks(self):
+        assert failing_check_names([_run("Slow", "timed_out")]) == ["Slow"]
+
+    def test_names_are_independent(self):
+        runs = [
+            _run("A", "cancelled", "2026-07-30T10:00:00Z"),
+            _run("A", "success", "2026-07-30T10:00:05Z"),
+            _run("B", "failure", "2026-07-30T10:00:00Z"),
+        ]
+        assert failing_check_names(runs) == ["B"]
+
+    def test_each_name_reported_at_most_once(self):
+        runs = [
+            _run("Flaky", "failure", "2026-07-30T10:00:00Z"),
+            _run("Flaky", "failure", "2026-07-30T10:00:05Z"),
+        ]
+        assert failing_check_names(runs) == ["Flaky"]
+
+    def test_reporting_order_follows_first_appearance(self):
+        runs = [
+            _run("Second", "failure"),
+            _run("First", "failure"),
+        ]
+        assert failing_check_names(runs) == ["Second", "First"]
+
+
+class TestMalformedInput:
+    """Hostile or incomplete payloads must not raise."""
+
+    def test_unnamed_runs_ignored(self):
+        assert (
+            failing_check_names([_run("", "failure"), {"conclusion": "failure"}]) == []
+        )
+
+    def test_non_mapping_entries_ignored(self):
+        # API payloads are untrusted; the guard is deliberate, so the
+        # cast documents that this input is hostile by design.
+        hostile = cast(
+            "list[Mapping[str, Any]]", [None, "nonsense", _run("A", "failure")]
+        )
+        assert failing_check_names(hostile) == ["A"]
+
+    def test_unparseable_timestamp_does_not_raise(self):
+        runs = [
+            _run("A", "cancelled", "not-a-date"),
+            _run("A", "success", "also-not-a-date"),
+        ]
+        # Both timestamps unusable, so the success tie-break applies.
+        assert failing_check_names(runs) == []
+
+    def test_missing_conclusion_treated_as_not_failing(self):
+        # An in-progress run has no conclusion yet; pending is handled
+        # elsewhere and must not be reported as a failure here.
+        assert failing_check_names([_run("A", None, status="in_progress")]) == []
+
+    def test_latest_helper_returns_one_entry_per_name(self):
+        runs = [
+            _run("A", "cancelled", "2026-07-30T10:00:00Z"),
+            _run("A", "success", "2026-07-30T10:00:05Z"),
+        ]
+        latest = latest_check_run_per_name(runs)
+        assert set(latest) == {"A"}
+        assert latest["A"]["conclusion"] == "success"
+
+
+class TestGraphQLRollupExtraction:
+    """The GraphQL path must apply the same rule."""
+
+    @staticmethod
+    def _pr(context_nodes):
+        return {
+            "commits": {
+                "nodes": [
+                    {
+                        "commit": {
+                            "statusCheckRollup": {"contexts": {"nodes": context_nodes}}
+                        }
+                    }
+                ]
+            }
+        }
+
+    def test_superseded_check_run_not_reported(self):
+        pr = self._pr(
+            [
+                {
+                    "__typename": "CheckRun",
+                    "name": "Audit Workflows",
+                    "conclusion": "CANCELLED",
+                    "completedAt": "2026-07-30T14:43:37Z",
+                },
+                {
+                    "__typename": "CheckRun",
+                    "name": "Audit Workflows",
+                    "conclusion": "SUCCESS",
+                    "completedAt": "2026-07-30T14:44:04Z",
+                },
+            ]
+        )
+        assert GitHubService._extract_failing_checks(pr) == []
+
+    def test_status_contexts_still_reported(self):
+        # Commit statuses are already latest-per-context, so they bypass
+        # deduplication and must survive it unchanged.
+        pr = self._pr(
+            [
+                {
+                    "__typename": "StatusContext",
+                    "context": "pre-commit.ci - pr",
+                    "state": "FAILURE",
+                }
+            ]
+        )
+        assert GitHubService._extract_failing_checks(pr) == ["pre-commit.ci - pr"]
+
+    def test_mixed_superseded_run_and_failing_status(self):
+        pr = self._pr(
+            [
+                {
+                    "__typename": "CheckRun",
+                    "name": "Audit changes",
+                    "conclusion": "CANCELLED",
+                    "completedAt": "2026-07-30T14:43:37Z",
+                },
+                {
+                    "__typename": "CheckRun",
+                    "name": "Audit changes",
+                    "conclusion": "SUCCESS",
+                    "completedAt": "2026-07-30T14:44:05Z",
+                },
+                {
+                    "__typename": "StatusContext",
+                    "context": "pre-commit.ci - pr",
+                    "state": "FAILURE",
+                },
+            ]
+        )
+        assert GitHubService._extract_failing_checks(pr) == ["pre-commit.ci - pr"]
+
+    def test_no_commits_returns_empty(self):
+        assert GitHubService._extract_failing_checks({}) == []
+
+
+class TestRestCheckRunPath:
+    """The REST path is what produced the reports seen in the field."""
+
+    @pytest.mark.asyncio
+    async def test_superseded_cancelled_run_does_not_block(self) -> None:
+        # Reproduces lfreleng-actions/nexus-staging-action#52, reported
+        # as "Required workflows failed - Package Hardening Audit" while
+        # a successful run of that very check sat on the same commit.
+        async with GitHubAsync(token="t") as api:
+            api.get = AsyncMock(  # type: ignore[method-assign]
+                side_effect=_rest_router(
+                    check_runs=[
+                        {
+                            "name": "Audit package manager hardening",
+                            "status": "completed",
+                            "conclusion": "cancelled",
+                            "completed_at": "2026-07-30T13:38:44Z",
+                        },
+                        {
+                            "name": "Audit package manager hardening",
+                            "status": "completed",
+                            "conclusion": "success",
+                            "completed_at": "2026-07-30T13:39:03Z",
+                        },
+                    ]
+                )
+            )
+            api.get_required_status_checks = AsyncMock(return_value=[])  # type: ignore[method-assign]
+
+            result = await api.analyze_block_reason("owner", "repo", 123, "abc123")
+
+        assert result is None or "Audit package manager hardening" not in result
+
+    @pytest.mark.asyncio
+    async def test_unsuperseded_failure_still_blocks(self) -> None:
+        async with GitHubAsync(token="t") as api:
+            api.get = AsyncMock(  # type: ignore[method-assign]
+                side_effect=_rest_router(
+                    check_runs=[
+                        {
+                            "name": "Audit Workflows",
+                            "status": "completed",
+                            "conclusion": "failure",
+                            "completed_at": "2026-07-30T13:39:03Z",
+                        },
+                    ]
+                )
+            )
+            api.get_required_status_checks = AsyncMock(return_value=[])  # type: ignore[method-assign]
+
+            result = await api.analyze_block_reason("owner", "repo", 123, "abc123")
+
+        assert result is not None and "Audit Workflows" in result

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -410,13 +410,54 @@ class TestCLI:
         assert "--include-human-prs" in result.stdout
 
     @patch("dependamerge.cli.GitHubClient")
-    def test_merge_command_human_pr_with_include_flag(self, mock_client_class):
-        """--include-human-prs authorises the source without --override."""
+    @patch("dependamerge.cli.PRComparator")
+    @patch("dependamerge.github_service.GitHubService")
+    @patch("dependamerge.merge_manager.GitHubAsync")
+    def test_merge_command_human_pr_with_include_flag(
+        self,
+        mock_async_class,
+        mock_service_class,
+        mock_comparator_class,
+        mock_client_class,
+    ):
+        """--include-human-prs authorizes a human-authored source PR.
+
+        Driven all the way to a successful merge rather than merely past
+        the gate: asserting only that the run avoided VALIDATION_ERROR
+        would also pass if it failed later for an unrelated reason.
+
+        Combined with --no-confirm, this also pins that an authorized
+        human-authored source proceeds unattended, with no prompt.
+        """
         mock_client = Mock()
         mock_client_class.return_value = mock_client
 
+        mock_comparator = Mock()
+        mock_comparator_class.return_value = mock_comparator
+
+        mock_service = Mock()
+        mock_service_class.return_value = mock_service
+
+        mock_async = AsyncMock()
+        mock_async.approve_pull_request = AsyncMock()
+        mock_async.merge_pull_request = AsyncMock(return_value=True)
+        mock_async.update_branch = AsyncMock()
+
+        mock_async_instance = AsyncMock()
+        mock_async_instance.__aenter__ = AsyncMock(return_value=mock_async)
+        mock_async_instance.__aexit__ = AsyncMock(return_value=None)
+        mock_async_class.return_value = mock_async_instance
+
         mock_client.parse_pr_url.return_value = ("owner", "repo", 22)
+        # The point of the test: a human author, not automation.
         mock_client.is_automation_author.return_value = False
+
+        mock_repo = Mock()
+        mock_repo.full_name = "owner/other-repo"
+        mock_repo.owner.login = "owner"
+        mock_repo.name = "other-repo"
+        mock_client.get_organization_repositories.return_value = [mock_repo]
+        mock_client.get_open_pull_requests.return_value = []
 
         mock_pr = PullRequestInfo(
             number=22,
@@ -435,25 +476,41 @@ class TestCLI:
             html_url="https://github.com/owner/repo/pull/22",
         )
         mock_client.get_pull_request_info.return_value = mock_pr
+        mock_client.get_pr_status_details.return_value = "Ready to merge"
         mock_client.get_pull_request_commits.return_value = [
             "Fix bug\n\nDetailed description"
         ]
-        mock_client.get_pr_status_details.return_value = "Ready to merge"
+        mock_client.approve_pull_request.return_value = True
+        mock_client.merge_pull_request.return_value = True
+        mock_client.fix_out_of_date_pr.return_value = True
 
-        result = self.runner.invoke(
-            app,
-            [
-                "merge",
-                "https://github.com/owner/repo/pull/22",
-                "--token",
-                "test_token",
-                "--include-human-prs",
-            ],
-        )
+        async def mock_find_similar_prs(*args, **kwargs):
+            return []
 
-        # The gate is cleared; the run proceeds past it rather than
-        # stopping with a validation error.
-        assert result.exit_code != ExitCode.VALIDATION_ERROR
+        async def mock_close():
+            return None
+
+        mock_service.find_similar_prs = mock_find_similar_prs
+        mock_service.close = mock_close
+
+        with patch(
+            "dependamerge.merge_manager.AsyncMergeManager._check_merge_requirements",
+            new_callable=AsyncMock,
+            return_value=(True, "Ready to merge"),
+        ):
+            result = self.runner.invoke(
+                app,
+                [
+                    "merge",
+                    "https://github.com/owner/repo/pull/22",
+                    "--no-confirm",
+                    "--token",
+                    "test_token",
+                    "--include-human-prs",
+                ],
+            )
+
+        assert result.exit_code == ExitCode.SUCCESS
         assert "--include-human-prs was supplied" in result.stdout
 
     @patch("dependamerge.cli.GitHubClient")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -19,6 +19,7 @@ from dependamerge.cli import (
     _validate_override_sha,
     app,
 )
+from dependamerge.error_codes import ExitCode
 from dependamerge.gerrit.models import GerritChangeInfo, GerritComparisonResult
 from dependamerge.models import PullRequestInfo
 from dependamerge.url_parser import ChangeSource, ParsedUrl
@@ -233,8 +234,9 @@ class TestCLI:
             ["merge", "https://github.com/owner/repo/pull/22", "--token", "test_token"],
         )
 
-        assert result.exit_code == 0
-        assert "not from a recognized automation tool" in result.stdout
+        assert result.exit_code == ExitCode.VALIDATION_ERROR
+        assert "human-authored" in result.stdout
+        assert "--include-human-prs" in result.stdout
 
     @patch("dependamerge.cli.GitHubClient")
     @patch("dependamerge.cli.PRComparator")
@@ -400,10 +402,59 @@ class TestCLI:
             ["merge", "https://github.com/owner/repo/pull/22", "--token", "test_token"],
         )
 
-        assert result.exit_code == 0
-        assert "not from a recognized automation tool" in result.stdout
-        assert "--override" in result.stdout
-        assert "human-user" in result.stdout
+        # A human-authored source with neither --include-human-prs nor
+        # --override now fails fast.  It previously exited 0, which a
+        # scripted caller could not tell apart from "nothing to merge".
+        assert result.exit_code == ExitCode.VALIDATION_ERROR
+        assert "human-authored" in result.stdout
+        assert "--include-human-prs" in result.stdout
+
+    @patch("dependamerge.cli.GitHubClient")
+    def test_merge_command_human_pr_with_include_flag(self, mock_client_class):
+        """--include-human-prs authorises the source without --override."""
+        mock_client = Mock()
+        mock_client_class.return_value = mock_client
+
+        mock_client.parse_pr_url.return_value = ("owner", "repo", 22)
+        mock_client.is_automation_author.return_value = False
+
+        mock_pr = PullRequestInfo(
+            number=22,
+            title="Fix bug",
+            body="Test body",
+            author="human-user",
+            head_sha="abc123",
+            base_branch="main",
+            head_branch="fix-bug",
+            state="open",
+            mergeable=True,
+            mergeable_state="clean",
+            behind_by=0,
+            files_changed=[],
+            repository_full_name="owner/repo",
+            html_url="https://github.com/owner/repo/pull/22",
+        )
+        mock_client.get_pull_request_info.return_value = mock_pr
+        mock_client.get_pull_request_commits.return_value = [
+            "Fix bug\n\nDetailed description"
+        ]
+        mock_client.get_pr_status_details.return_value = "Ready to merge"
+
+        result = self.runner.invoke(
+            app,
+            [
+                "merge",
+                "https://github.com/owner/repo/pull/22",
+                "--token",
+                "test_token",
+                "--include-human-prs",
+            ],
+        )
+
+        # The gate is cleared; the run proceeds past it rather than
+        # stopping with a validation error.
+        assert result.exit_code != ExitCode.VALIDATION_ERROR
+        assert "--include-human-prs was supplied" in result.stdout
 
     @patch("dependamerge.cli.GitHubClient")
     def test_merge_command_non_automation_pr_invalid_override(self, mock_client_class):

--- a/tests/test_human_pr_gate.py
+++ b/tests/test_human_pr_gate.py
@@ -1,0 +1,153 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 The Linux Foundation
+
+"""Tests for the human-authored source PR gate.
+
+Regression cover for lfreleng-actions/dependamerge#395: --include-human-prs
+had no bearing on the source PR check, so pointing dependamerge at a
+human-authored PR demanded an --override SHA whether or not the flag was
+given, and then exited 0 -- a silent no-op indistinguishable from
+"nothing to merge" when scripted.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+import typer
+
+from dependamerge.cli import _generate_override_sha, _validate_automation_author
+from dependamerge.error_codes import ExitCode
+
+FIRST_COMMIT_LINE = "Fix: Env-mediate job status in run block"
+
+
+def _ctx(*, author, include_human_prs=False, override=None):
+    """A merge context whose source PR is authored by *author*."""
+    source_pr = MagicMock()
+    source_pr.author = author
+    source_pr.title = "Fix: Env-mediate job status in run block"
+    source_pr.body = "body"
+
+    github_client = MagicMock()
+    github_client.is_automation_author.side_effect = lambda a: a.endswith("[bot]")
+    github_client.get_pull_request_commits.return_value = [FIRST_COMMIT_LINE]
+
+    ctx = MagicMock()
+    ctx.github_client = github_client
+    ctx.source_pr = source_pr
+    ctx.owner = "lfreleng-actions"
+    ctx.repo_name = "tailscale-openstack-bastion-action"
+    ctx.pr_number = 63
+    ctx.include_human_prs = include_human_prs
+    ctx.override = override
+    return ctx
+
+
+def _expected_sha(ctx):
+    return _generate_override_sha(ctx.source_pr, FIRST_COMMIT_LINE)
+
+
+class TestAutomationSource:
+    """Automation PRs are unaffected by the gate."""
+
+    def test_bot_author_passes_without_flags(self):
+        _validate_automation_author(_ctx(author="pre-commit-ci[bot]"))
+
+    def test_bot_author_does_not_consult_commits(self):
+        # The gate should short-circuit before fetching commit messages;
+        # an extra API call per PR is wasteful at organisation scale.
+        ctx = _ctx(author="dependabot[bot]")
+        _validate_automation_author(ctx)
+        ctx.github_client.get_pull_request_commits.assert_not_called()
+
+
+class TestHumanSourceWithoutAuthorisation:
+    """The defect in #395: neither flag given must fail fast."""
+
+    def test_exits_non_zero(self):
+        ctx = _ctx(author="ModeSevenIndustrialSolutions")
+        with pytest.raises(SystemExit) as excinfo:
+            _validate_automation_author(ctx)
+        # Previously this exited 0, so a scripted run could not tell
+        # refusal apart from success.
+        assert excinfo.value.code == ExitCode.VALIDATION_ERROR
+        assert excinfo.value.code != 0
+
+    def test_failure_names_the_flag(self, capsys):
+        ctx = _ctx(author="ModeSevenIndustrialSolutions")
+        with pytest.raises(SystemExit):
+            _validate_automation_author(ctx)
+        output = capsys.readouterr().out
+        assert "--include-human-prs" in output
+
+    def test_failure_still_offers_the_override_sha(self, capsys):
+        ctx = _ctx(author="ModeSevenIndustrialSolutions")
+        with pytest.raises(SystemExit):
+            _validate_automation_author(ctx)
+        assert _expected_sha(ctx) in capsys.readouterr().out
+
+
+class TestHumanSourceWithIncludeHumanPrs:
+    """--include-human-prs alone authorises a human-authored source."""
+
+    def test_proceeds_without_override(self):
+        _validate_automation_author(
+            _ctx(author="ModeSevenIndustrialSolutions", include_human_prs=True)
+        )
+
+    def test_says_why_it_proceeded(self, capsys):
+        ctx = _ctx(author="ModeSevenIndustrialSolutions", include_human_prs=True)
+        _validate_automation_author(ctx)
+        output = capsys.readouterr().out
+        assert "--include-human-prs" in output
+        assert "ModeSevenIndustrialSolutions" in output
+
+    def test_no_prompt_is_issued(self, monkeypatch):
+        # The gate must never block on input: with --no-confirm the run
+        # has to proceed unattended.  Any prompt here would hang CI.
+        def _explode(*args, **kwargs):
+            raise AssertionError("the author gate must not prompt")
+
+        monkeypatch.setattr(typer, "prompt", _explode)
+        monkeypatch.setattr(typer, "confirm", _explode)
+        _validate_automation_author(
+            _ctx(author="ModeSevenIndustrialSolutions", include_human_prs=True)
+        )
+
+    def test_invalid_override_still_rejected(self):
+        # --include-human-prs authorises the class of PR; it does not
+        # excuse a SHA that points at a different PR entirely.
+        ctx = _ctx(
+            author="ModeSevenIndustrialSolutions",
+            include_human_prs=True,
+            override="0000000000000000",
+        )
+        with pytest.raises(SystemExit) as excinfo:
+            _validate_automation_author(ctx)
+        assert excinfo.value.code == ExitCode.VALIDATION_ERROR
+
+    def test_matching_override_is_accepted(self):
+        ctx = _ctx(author="ModeSevenIndustrialSolutions", include_human_prs=True)
+        ctx.override = _expected_sha(ctx)
+        _validate_automation_author(ctx)
+
+
+class TestHumanSourceWithOverrideOnly:
+    """--override keeps working on its own, for existing invocations."""
+
+    def test_matching_override_proceeds(self):
+        ctx = _ctx(author="ModeSevenIndustrialSolutions")
+        ctx.override = _expected_sha(ctx)
+        _validate_automation_author(ctx)
+
+    def test_matching_override_points_at_the_flag(self, capsys):
+        ctx = _ctx(author="ModeSevenIndustrialSolutions")
+        ctx.override = _expected_sha(ctx)
+        _validate_automation_author(ctx)
+        assert "--include-human-prs" in capsys.readouterr().out
+
+    def test_mismatched_override_exits_validation_error(self):
+        ctx = _ctx(author="ModeSevenIndustrialSolutions", override="deadbeefdeadbeef")
+        with pytest.raises(SystemExit) as excinfo:
+            _validate_automation_author(ctx)
+        assert excinfo.value.code == ExitCode.VALIDATION_ERROR

--- a/tests/test_human_pr_gate.py
+++ b/tests/test_human_pr_gate.py
@@ -95,6 +95,21 @@ class TestHumanSourceWithIncludeHumanPrs:
             _ctx(author="ModeSevenIndustrialSolutions", include_human_prs=True)
         )
 
+    def test_does_not_fetch_commits_when_no_override_to_check(self):
+        # Deriving the override SHA costs an API call per pull request.
+        # With --include-human-prs and no override there is nothing to
+        # check it against, so the call is pure waste at org scale.
+        ctx = _ctx(author="ModeSevenIndustrialSolutions", include_human_prs=True)
+        _validate_automation_author(ctx)
+        ctx.github_client.get_pull_request_commits.assert_not_called()
+
+    def test_still_fetches_commits_when_an_override_needs_checking(self):
+        ctx = _ctx(author="ModeSevenIndustrialSolutions", include_human_prs=True)
+        ctx.override = _expected_sha(ctx)
+        ctx.github_client.get_pull_request_commits.reset_mock()
+        _validate_automation_author(ctx)
+        ctx.github_client.get_pull_request_commits.assert_called_once()
+
     def test_says_why_it_proceeded(self, capsys):
         ctx = _ctx(author="ModeSevenIndustrialSolutions", include_human_prs=True)
         _validate_automation_author(ctx)


### PR DESCRIPTION
Two independent fixes, one per commit, plus a third commit carrying review feedback.

---

## 1. `Fix: Judge check runs by latest run per name`

### Why

A commit can carry **several check runs sharing one name**. The usual cause is a superseded run: two workflow events fire for the same head SHA, the workflow's `concurrency` group cancels the first, and that cancelled run stays attached to the commit next to the successful one that replaced it.

Both transports treated *every* reported run as authoritative:

```python
# github_service.py  (GraphQL statusCheckRollup)
if conclusion in ("failure", "cancelled", "timed_out"):
    failing.append(name)

# github_async.py  (REST /commits/{sha}/check-runs)
if conclusion in ["failure", "cancelled", "timed_out"]:
    failing_checks.append(name)
```

Neither deduplicates by name, so a cancelled run made a check look failed while a successful run of that same check sat beside it.

### Observed in the field

On `lfreleng-actions/harden-runner-block-action#36`, head `06e8015` — both runs `event=pull_request`, same SHA, one second apart, differing only in attributed actor (`pre-commit-ci[bot]` vs the pusher):

```
Audit changes                                 cancelled   14:43:37
Audit changes                                 success     14:44:05
Audit package manager hardening / ...         cancelled
Audit package manager hardening / ...         success
Check SHA pinned actions / Pinned Versions    cancelled
Check SHA pinned actions / Pinned Versions    success
```

dependamerge reported *"Required workflows failed — Package Hardening Audit"* on `nexus-staging-action#52`, whose Package Hardening Audit had in fact passed.

**Retrying never helped.** The cancelled run stays attached to that SHA permanently, so the only remedy was a fresh commit — which meant rebasing bot branches by hand to clear a phantom failure.

### What

New `src/dependamerge/check_runs.py`: a pure, transport-agnostic helper that collapses runs to the **latest per name** before deciding failure, matching GitHub's own merge protection. Both call sites now use it.

Ordering is by timestamp whenever both runs carry one and they differ, preferring **completion** over start time since duplicates frequently start within the same second. Otherwise the order cannot be established — absent, partial, or identical timestamps — and **a successful run wins over a failing one**. Two runs sharing a name are overwhelmingly a supersede race, and a genuine lone failure has no successful sibling to beat it.

The GraphQL `CheckRun` fragments now request `startedAt`/`completedAt` so both transports order on the same evidence.

### Deliberately *not* changed

Status classification still considers **every** run. A name carrying both a `completed` run and a fresh `in_progress` re-run is genuinely still pending, and collapsing that to the latest run alone would misreport it as settled. My first attempt got this wrong and `test_rerun_completed_and_in_progress_reads_as_pending` caught it — only the *failure* decision is deduplicated.

`_extract_failing_checks` becomes a `staticmethod`; it reads no instance state, which also lets it be exercised directly.

### Note on the root cause

This does not paper over a workflow misconfiguration. The concurrency groups (`${{ github.workflow }}-${{ github.ref }}`, `cancel-in-progress: true`) are already correctly scoped — on a `pull_request` event `github.ref` is `refs/pull/N/merge`, unique per workflow per PR — and cancellation is doing exactly its job. The bug was consuming a superseded run as though it were the verdict.

---

## 2. `Fix: Honour --include-human-prs for the source PR` — closes #395

### Why

`--include-human-prs` governed only which similar PRs were acted on during fan-out (`only_automation = not ctx.include_human_prs`). The **source PR gate never consulted it**, so pointing dependamerge at a human-authored PR demanded an `--override` SHA whether or not the flag was given — exactly as the issue reports.

Worse, the refusal did `raise typer.Exit(0)`. A scripted caller could not tell *"refused to touch a human PR"* from *"ran fine, nothing to merge"*, so a mistargeted invocation looked like success.

### What

| Source author | `--include-human-prs` | `--override` | Result |
| --- | --- | --- | --- |
| automation | — | — | proceeds (unchanged) |
| human | ✅ | — | **proceeds** |
| human | — | valid | proceeds (compat) |
| human | ✅ | valid | proceeds |
| human | ✅ | *invalid* | exits `VALIDATION_ERROR` |
| human | — | *invalid* | exits `VALIDATION_ERROR` |
| human | — | — | **exits `VALIDATION_ERROR`** (was exit 0) |

`--override` keeps working on its own: it predates the flag and appears in existing invocations, so requiring both would break callers for no safety gain. The message points at `--include-human-prs` as the way forward.

An override that does not match is rejected **even when `--include-human-prs` alone would have sufficed** — a wrong SHA means the operator is looking at a different PR than they think, which is worth stopping for.

The gate never prompts, so `--include-human-prs` with `--no-confirm` proceeds unattended. The separate confirmation covering human PRs found during *fan-out* already honours `--no-confirm` (`needs_human_confirm = bool(human_prs) and not ctx.no_confirm and not ctx.dry_run`) and is unchanged.

Option help text updated for both flags.

### Behaviour change worth calling out

The refusal exit code moves **0 → 8**. That is the point of the issue, but anyone treating a refusal as success will now see a failure.

---

## 3. `Fix: Address Copilot review feedback`

Five defects found in review, each reproduced before fixing. Three were raised as inline comments (all resolved), two were suppressed as low-confidence but were nonetheless correct:

| # | Defect | Evidence |
| --- | --- | --- |
| 1 | `_supersedes` preferred a *timestamped* run regardless of conclusion, so a timestamped cancel beat an untimestamped success — reintroducing the phantom failure | returned `['A']`, now `[]` |
| 2 | `_parse_timestamp` could mix naive and aware datetimes | raised `TypeError`, now `[]` |
| 3 | Unnamed runs recorded as literal `"unknown"`, able to surface *"Blocked by failing check: unknown"* | now skipped, as the helper already did |
| 4 | Commit messages fetched to derive an override SHA even when `--include-human-prs` alone authorized the run and no override existed to check | avoidable API call per PR, now conditional |
| 5 | `"recognised"` where both sibling gates print `"recognized"` | user-facing strings aligned; the five `authoris*` spellings this branch introduced move to `authoriz*` |

---

## Validation

- **1536 passed, 14 skipped** — full suite, no regressions
- 28 tests in `tests/test_check_run_dedup.py`, encoding the real incidents (`harden-runner-block-action#36` head `06e8015`; `nexus-staging-action#52`), the full timestamp matrix, and malformed-payload tolerance
- 16 tests in `tests/test_human_pr_gate.py` covering the authorization matrix above, that the gate never prompts, and that the commit fetch happens only when its result is used
- Two existing tests in `tests/test_cli.py` updated: they asserted the exit-0 refusal, which is the defect being removed
- `pre-commit run --all-files` green, including `basedpyright`

Happy to split this into two PRs if you'd rather review the fixes independently.
