### PR TITLE
Fix: Stop adaptive throttle latching at the floor

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -73,7 +73,10 @@ repos:
     hooks:
       - id: write-good
         files: "\\.(rst|md|markdown|mdown|mkdn)$"
-        exclude: "^docs/SECURITY-IMPROVEMENTS-.*\\.md$"
+        # Incident/audit reports quote measured figures and code identifiers
+        # verbatim; write-good's weasel-word heuristics fight that precision.
+        exclude: >-
+          ^docs/(SECURITY-IMPROVEMENTS-.*|BULK_RUN_PERFORMANCE_AUDIT)\.md$
 
   - repo: https://github.com/shellcheck-py/shellcheck-py
     rev: 745eface02aef23e168a8afb6b5737818efbea95  # frozen: v0.11.0.1

--- a/docs/BULK_RUN_PERFORMANCE_AUDIT.md
+++ b/docs/BULK_RUN_PERFORMANCE_AUDIT.md
@@ -1,0 +1,453 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- SPDX-FileCopyrightText: 2026 The Linux Foundation -->
+
+# Bulk Run Performance Audit — 503-PR `lfreleng-actions` run
+
+Status: **Analysis**. No code changes proposed here are implemented yet.
+
+Subject run: `dependamerge merge --no-confirm https://github.com/lfreleng-actions`,
+503 automation PRs across 116 repositories, elapsed **1h 21m 20s**, reported
+**469 merged / 34 failed**. Observed symptom: the first ~300 merges completed
+at speed, after which throughput collapsed.
+
+This document records what the code does today, what the evidence says
+actually happened, and how a persistent local record of run history could
+change the tool's behaviour.
+
+---
+
+## 1. Executive summary
+
+Three independent problems compound:
+
+1. **Polling cost scales with the number of *waiting* PRs, and the REST
+   budget cannot pay for it.** Each parked PR issues 6 API calls per minute
+   forever. The REST budget is 83 calls per minute. Beyond ~14 simultaneously
+   parked PRs, polling alone consumes 100% of the budget.
+2. **The adaptive throttle is a one-way ratchet with a dead recovery path.**
+   Once the remaining REST budget drops below 10%, concurrency and RPS halve
+   on *every subsequent successful response* until they hit the floor
+   (2 concurrent / 1.0 rps) and **never recover for the lifetime of the
+   process**. This is the mechanism behind the sudden, permanent cliff.
+3. **Failure reporting inverts the truth for most of the set.**
+   Of the 34 reported failures, **21 (62%) had merged**, most within two
+   minutes of being reported failed. The tool arms auto-merge, gives up
+   waiting, reports `FAILED`, and GitHub completes the merge moments later.
+
+Only 12 of the 34 reported failures were real. Of those, 9 are GitHub
+infrastructure failures (ruleset-injected workflows queued but never executed)
+that this tool cannot address, and 3 are Dependabot title/commit-subject
+mismatches now tracked as lfreleng-actions/dependamerge#405 (§2.7).
+
+---
+
+## 2. Evidence
+
+### 2.1 Polling cost is O(parked PRs)
+
+Measured during a live run while 4 PRs were parked in `_wait_for_auto_merge`,
+sampling `X-RateLimit-Remaining` from response headers:
+
+```text
+16:28:13 remaining 3624 delta 6 over 20s
+16:28:34 remaining 3615 delta 8 over 20s
+16:28:55 remaining 3606 delta 8 over 20s
+16:29:16 remaining 3599 delta 6 over 20s
+16:29:37 remaining 3590 delta 8 over 20s
+16:29:58 remaining 3581 delta 8 over 20s
+```
+
+≈ 8 calls per 20 s for 4 parked PRs = **6 calls/min/parked PR**, exactly the
+`DEFAULT_MERGE_RECHECK_INTERVAL = 10.0` cadence
+(`merge_manager.py:56`). The poll is an unbatched
+`GET /repos/{o}/{r}/pulls/{n}` per PR per tick
+(`merge_manager.py:5107`).
+
+Against the authenticated REST budget of 5000/hr = **83 calls/min**:
+
+| Parked PRs | Polling calls/min | % of REST budget |
+| ---------- | ----------------- | ---------------- |
+| 5          | 30                | 36%              |
+| 14         | 84                | **100%**         |
+| 40         | 240               | 289%             |
+| 60         | 360               | 434%             |
+
+`slot_lease.parked()` deliberately releases the *work* slot while waiting so
+that waiting never starves runnable work — but it does **not** bound how many
+PRs may poll concurrently. The number of simultaneous pollers is unbounded by
+`--concurrency`. The design that fixed slot starvation converted it into
+budget starvation.
+
+> Measurement note: the `GET /rate_limit` endpoint returns a stale, cached
+> value and is unusable for this measurement — it read `3856` while response
+> headers on the same token read `3643`. Use response headers.
+
+### 2.2 The throttle ratchet
+
+`github_async.py:617-655`, executed after every successful response:
+
+```python
+if limit > 0:
+    remaining_ratio = remaining / max(1, limit)
+    should_throttle = remaining_ratio < 0.1 or error_rate > 0.1
+    if should_throttle:
+        throttle_factor = 0.3 if error_rate > 0.2 else 0.5
+        new_concurrency = max(2, int(self._max_concurrency * throttle_factor))
+        ...
+        new_rps = max(1.0, self._current_rps * throttle_factor)
+        ...
+else:
+    # Gradually increase limits when healthy  <-- UNREACHABLE
+```
+
+Three defects:
+
+1. **The recovery branch is dead code.** It lives in the `else:` of
+   `if limit > 0:`. `limit` is parsed from `X-RateLimit-Limit` with a default
+   of `"60"` (`github_async.py:467`) and GitHub always sends `5000`.
+   `limit > 0` is always true, so ramp-up **never executes**.
+   The comment at `github_async.py:243-246` states the intent ("adaptive
+   tuning ramps concurrency back up to *this* value") — the intent is not
+   realised.
+2. **The error-rate signal is inert.** `_get_recent_error_rate`
+   (`github_async.py:2638-2654`) returns
+   `len(recent) / (len(recent) * _ESTIMATED_REQUESTS_PER_ERROR)` with
+   `_ESTIMATED_REQUESTS_PER_ERROR = 10` (`:200`) — that is **exactly 0.1**
+   whenever any error exists, and 0.0 otherwise. Both tests
+   (`> 0.1`, `> 0.2`) are always false. Errors can never trigger throttling,
+   and `throttle_factor` is always `0.5`.
+3. **Live semaphore replacement.** `self.semaphore = asyncio.Semaphore(n)`
+   (`:635`) swaps the object while tasks hold permits from the previous
+   instance. In-flight tasks release the old object; the new one starts fully
+   unclaimed, so the cap is transiently violated by up to the old concurrency.
+
+The single live trigger is `remaining_ratio < 0.1`, i.e. **fewer than 500
+REST calls remaining**. Descent is `20→10→5→2` concurrency and
+`8.0→4.0→2.0→1.0` rps, permanent for the process.
+
+At an observed active-phase burn of roughly 200-500 calls/minute, a 503-PR run
+crosses `remaining < 500` after roughly 20 minutes — which matches the
+reported "first 300 were very quick, then it slowed down considerably".
+
+**The two problems reinforce each other**: more parked PRs → faster budget
+burn → ratchet trips → 1 rps → each PR takes longer → more PRs parked
+simultaneously → more polling. That feedback loop, not any single constant,
+is the "exponential" behaviour.
+
+### 2.3 Sticky adaptive delay
+
+`_apply_retry_after_throttling` (`github_async.py:2656-2675`) sets
+`self._adaptive_delay` (up to 5.0 s), which is then slept **before every
+subsequent successful request** (`:613-615`). Its decay logic lives *inside
+the same function*, so it only decays when another `Retry-After` arrives.
+A single `Retry-After: 60` therefore adds a permanent serial delay to every
+request for the rest of the run. At ~10 calls per PR that is +50 s per PR.
+
+On a secondary rate limit the code sleeps the advised delay
+(`:533`) **and then** raises `SecondaryRateLimitError`, which tenacity retries
+with its own `wait_random_exponential(multiplier=0.5, max=10.0)` (`:485`).
+The sleeps stack rather than being taken as a maximum.
+
+### 2.4 Uncoordinated clients share one real budget
+
+`AsyncMergeManager.__init__` builds a `GitHubAsync` (`merge_manager.py:371`)
+*and* a `GitHubService` (`:374`), which builds a **second** `GitHubAsync`
+(`github_service.py:126`). Neither is passed `max_concurrency` or
+`requests_per_second`, so each defaults to 20/8.0 — a combined ceiling of
+**40 concurrent / 16 rps**, not the `concurrency=20, rps=8.0` the UI reports.
+Separately, `GitHubClient` constructs a **fresh `GitHubAsync` per call** at
+seven sites (`github_client.py:78,190,210,247,264,344,384`), each with a new
+limiter and zero throttle memory.
+
+GraphQL also flows through the same `_request` (`github_async.py:721`) and so
+updates the same `remaining`/`limit` pair, despite GraphQL having a separate
+5000-*point* budget. A GraphQL response ratchets down the REST path and vice
+versa. No query requests `rateLimit { cost remaining }`.
+
+### 2.5 Per-repo waits stack serially
+
+The striped scheduler runs one serial worker per repository, so a repo's PRs
+are processed strictly in sequence. Observed in the re-run:
+
+```text
+16:21:07  ⏳ Waiting: workflows-template/pull/29 [required workflows still running]
+16:26:15  ❌ Failed:  workflows-template/pull/29
+16:26:28  ⏳ Waiting: workflows-template/pull/30 [required workflows still running]
+```
+
+PR #29 burned the full 300 s and failed; PR #30 then began its **own** fresh
+300 s wait for the identical, already-known-hopeless reason. A repo with four
+such PRs burns 20 minutes serially to learn the same fact four times. Nothing
+propagates the first PR's outcome to its siblings — not even within a single
+run, let alone across runs.
+
+Compounding this, the per-loop budgets do not roll up: only
+`_wait_for_auto_merge` honours `--max-wait`. The pre-commit.ci poll
+(`merge_manager.py:3520`), the dependabot-recreate poll (`:3939`), the
+recreated-checks wait (`:4091`) and the post-rebase poll (`rebase.py:953`)
+each independently burn up to `--merge-timeout` (300 s).
+`docs/MERGE_ENGINE_DESIGN.md` §2 already documents this; it remains true.
+
+### 2.6 Reported failures were mostly not failures
+
+Re-checking all 34 reported failures against the API:
+
+| Reported reason                      | Count | Actually merged |
+| ------------------------------------ | ----: | --------------: |
+| Required workflows not satisfied     | 13    | 6               |
+| Approve failed — HTTP 500            | 6     | 4               |
+| Merge already in progress            | 5     | 4               |
+| Required status checks not satisfied | 5     | 5               |
+| Required workflows failed            | 4     | 2               |
+| Merge conflicts                      | 1     | 1               |
+| **Total**                            | 34    | **21 (62%)**    |
+
+Most merged between 15:16:46 and 15:17:50 — a tight cluster in the run's final
+minutes, i.e. auto-merge firing seconds *after* the tool had already declared
+failure and moved on. The tool never re-verifies terminal state before
+reporting.
+
+Two specific gaps:
+
+- **HTTP 500 on approve is not retried.** `_is_retryable_status` is
+  `(429, 502, 503, 504)` (`github_async.py:114`); 500 is excluded and
+  `approve_pull_request` has no local retry. GitHub's
+  `POST /pulls/{n}/reviews` endpoint returns transient 500s — yet
+  4 of the 6 affected PRs merged anyway, meaning the review was
+  created despite the 500.
+- **"Merge already in progress" is treated as terminal** after
+  `3.0*(attempt+1)` s backoff × 2 retries (`merge_manager.py:4564`). GitHub
+  needs 10-30 s. 4 of 5 subsequently merged.
+
+### 2.7 The genuine residual failures
+
+A verbose re-run (`--verbose --no-progress`, log at
+`/tmp/dependamerge-runs/run2.log`) found only 13 PRs still open, merged 1, and
+failed 12 in **11 minutes** (16:20:40 → 16:31:38). Every one of those 12 is
+still open, so this time the failures are real. They collapse into exactly
+**two** root causes:
+
+<!-- markdownlint-disable MD060 -->
+
+| Failing required check                                        | PRs |
+| ------------------------------------------------------------- | --: |
+| `AI Slop Scan 🧹` + `Zizmor Scan 🌈` — queued, never executed | 9   |
+| `Semantic Pull Request 🛠️` — title/commit-subject mismatch    | 3   |
+
+<!-- markdownlint-enable MD060 -->
+
+**Cause A — required workflows queued but never executed. Out of scope.**
+For `verify-release-schema-action#106` and `workflows-template#29` the head SHA
+carries only two check runs:
+
+```text
+DCO      completed success
+CodeQL   completed neutral
+```
+
+`AI Slop Scan 🧹` and `Zizmor Scan 🌈` are injected org-wide by a repository
+ruleset, with the workflow code hosted in the special `.github` repository —
+so the consuming repositories contain no local workflow files for them. Under
+load, GitHub queues these runs and never executes them. This is a GitHub
+infrastructure failure, **not** a repository misconfiguration and **not**
+something this tooling can repair. No fix is proposed.
+
+The only tooling-side observation worth recording is the cost: the tool waited
+the full 300 s per affected PR, serially per repository, to rediscover a
+condition that cannot change (§2.5).
+
+**Cause B — Dependabot title / commit-subject mismatch.** These are legitimate
+check failures. Dependabot writes a PR title that differs from the single
+commit's subject, and the org check runs
+`validateSingleCommitMatchesPrTitle`:
+
+<!-- markdownlint-disable MD013 -->
+
+| PR                                 | PR title                                                                             | Commit subject                                                  |
+| ---------------------------------- | ------------------------------------------------------------------------------------ | --------------------------------------------------------------- |
+| `tag-validate-action#283`          | `Chore: Bump cryptography from 49.0.0 to 50.0.0 in the uv group across 1 directory`  | `Chore: Bump cryptography in the uv group across 1 directory`   |
+| `github-security-report-action#96` | `CI(deps): Bump github-security-report from 0.8.0 to 0.10.0 in /.github/runtime-pin` | `CI(deps): Bump github-security-report in /.github/runtime-pin` |
+| `sigul-sign-docker#175`            | `CI(actions): Bump lfit/…/reuse-openssf-scorecard.yaml from 0.9.1 to 0.10.1`         | `CI(actions): Bump lfit/…/reuse-openssf-scorecard.yaml`         |
+
+<!-- markdownlint-enable MD013 -->
+
+The upstream reusable workflow already relaxes the exact match to a **prefix**
+match when the commit subject is a leading substring of the title — which
+covers Dependabot dropping a trailing `from X to Y`. The first two cases above
+are **mid-string elision** (the version range is removed from the middle), so
+the relaxation does not apply and the check fails correctly.
+
+`sigul-sign-docker#175` is covered by the relaxation and its check did pass —
+but the workflow sets `concurrency.cancel-in-progress: true`, leaving a
+`cancelled` duplicate run alongside the `success`, and ruleset evaluation is
+blocked by the `cancelled` one.
+
+Tracked as **lfreleng-actions/dependamerge#405** — align the PR title with the
+commit subject, then let the workflow's `edited` trigger re-run the check.
+
+So of the 34 originally reported failures: 21 merged on their own, 9 are GitHub
+infrastructure failures outside this tool's control, and 3 are actionable via
+issue #405.
+
+### 2.8 Dead code
+
+`src/dependamerge/engine/` (`scheduler.py`, `reconciler.py`, `ladder.py`,
+`model.py`) is **not imported anywhere in `src/`** — only by `tests/engine/`.
+`slot_lease.py` ported one semantic (parking) out of it into the legacy path.
+The reconciler — the component designed to centralise and batch exactly the
+polling that is now the dominant cost — is unwired. Notably its own docstring
+(`reconciler.py:24-25`) concedes it is *also* one-GET-per-waiting-PR, so
+wiring it as-is would not fix §2.1 without adding batching.
+
+---
+
+## 3. Recommended fixes, in priority order
+
+### P0 — stop the cliff (small, surgical, high impact)
+
+1. **Fix the ratchet.** Restructure `github_async.py:617-655` to
+   `if should_throttle: ... else: ramp_up()` so recovery is reachable. Ramp up
+   on sustained healthy responses toward `_base_max_concurrency`/`_base_rps`.
+2. **Delete or fix `_get_recent_error_rate`.** As written it is a constant.
+   Either track total requests (a simple counter alongside errors) or remove
+   the error term and drive throttling from budget headroom alone.
+3. **Do not replace live semaphores.** Use a resizable limiter that adjusts by
+   acquiring/releasing spare permits, so the cap is never transiently violated.
+4. **Decay `_adaptive_delay` on read**, not only inside
+   `_apply_retry_after_throttling`; cap its total contribution per run.
+5. **Do not stack sleeps.** On a secondary rate limit, either sleep locally
+   *or* delegate to tenacity — not both.
+6. **Separate REST and GraphQL budget accounting.** Key the throttle state on
+   `X-RateLimit-Resource` (already returned; observed as `core`), and add
+   `rateLimit { cost remaining resetAt }` to GraphQL queries.
+7. **Share one `GitHubAsync`.** Inject the manager's client into
+   `GitHubService` and `GitHubClient` so there is exactly one limiter, one
+   semaphore, and one throttle state per run.
+
+### P1 — cut API volume (the real scaling fix)
+
+1. **Batch parked-PR polling.** Replace N× `GET /pulls/{n}` per tick with a
+   single aliased GraphQL query covering all parked PRs
+   (`pr0: repository(...){pullRequest(number:){...}} pr1: ...`). This turns
+   O(parked) into O(1) per tick and is the single largest lever available:
+   60 parked PRs go from 360 calls/min to ~6.
+2. **Adaptive first-poll delay.** Do not poll from t=0 at 10 s intervals when
+   the repo's checks historically take 4 minutes. Schedule the first poll at
+   `p50_check_seconds × 0.8`. (Requires §4.)
+3. **Cache `analyze_block_reason` per `(repo, head_sha)`.** It costs ≥5 calls
+   and is invoked from three sites per PR.
+4. **Propagate a repo's first outcome to its siblings within a run.** If PR
+   #29 waited out 300 s for a required check that never started, do not make
+   #30, #31 and #32 repeat the same discovery.
+
+### P2 — correctness of reporting
+
+1. **Re-verify before reporting failure.** Before emitting `FAILED`, re-read
+   the PR once. This alone would have converted 21 of 34 "failures" into
+   successes or `AUTO_MERGE_PENDING`.
+2. **Retry 500 on approve**, guarded by a re-read of existing reviews so a
+   duplicate approval is never created.
+3. **Treat "Merge already in progress" as park-and-verify**, not terminal.
+4. **Bound the wait for required checks that have not started.** Where a
+   required check has no check-run on the head SHA, the cause is usually a
+   GitHub infrastructure problem — ruleset-injected workflows queued but never
+   executed — which no amount of waiting resolves. That cause is out of scope
+   for this tool, but the tool need not spend 300 s per sibling PR
+   rediscovering it: report it distinctly from "check failed" and stop waiting.
+5. **Resolve duplicate check runs by latest attempt.** When one check name has
+   several runs on a head SHA, judge it by the most recent non-`cancelled` run.
+   `sigul-sign-docker#175` is blocked purely because a `cancelled` duplicate
+   — a side effect of `concurrency.cancel-in-progress: true` — shadows a
+   `success`.
+6. **Align Dependabot PR titles with commit subjects.** Tracked separately as
+   lfreleng-actions/dependamerge#405.
+7. **Wire or delete `src/dependamerge/engine/`.** Carrying an unused scheduler
+   plus its test suite is a maintenance tax and a trap for future readers.
+
+---
+
+## 4. Proposal: a persistent local record
+
+### 4.1 Why
+
+Every expensive decision the tool makes today is made with **zero memory**:
+how long this repo's checks take, whether this repo's required
+workflows ever fire, how many API calls a run of this size costs, which error
+classes resolve on retry. Each run rediscovers this, at full price, and
+then throws it away. Worse, it rediscovers some of it *repeatedly within a
+single run* (§2.5).
+
+A local record earns its place solely by **changing behaviour**. The
+sections below pair each stored fact with the decision it improves.
+
+### 4.2 Store
+
+SQLite via the stdlib `sqlite3` module — no new dependency — at
+`${XDG_STATE_HOME:-~/.local/state}/dependamerge/history.db`, WAL mode, schema
+version in `PRAGMA user_version`. Local only; **never** store tokens.
+Provide `--no-history` to opt out, plus `dependamerge history prune|export`.
+
+```sql
+runs(id, started_at, finished_at, target, mode, tool_version,
+     concurrency, rps, max_wait, merge_timeout,
+     total, merged, failed, skipped, api_calls_rest, api_calls_graphql)
+
+pr_attempts(id, run_id, repo, pr_number, author, head_sha,
+            outcome, error_class, error_detail, attempts, duration_s,
+            rebased, retriggered, verified_final_state, phase_timings_json)
+
+check_observations(repo, check_name, required, head_sha,
+                   observed_at, first_seen_s, completed_s, conclusion)
+
+budget_samples(run_id, at, resource, remaining, limit,
+               effective_concurrency, effective_rps)
+```
+
+Plus a derived, cheaply-recomputed `repo_profile` view: per-repo p50/p90 check
+completion, required-check inventory, rebase-required rate, failure rate by
+class, and last-success timestamp.
+
+### 4.3 How each stored fact changes behaviour
+
+<!-- markdownlint-disable MD013 -->
+
+| Stored fact                         | Decision it changes                                                                                        | Expected effect                                                                                                                         |
+| ----------------------------------- | ---------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| p50/p90 check completion per repo   | First-poll delay and park deadline (`p90 × 1.5`, clamped) instead of a flat 300 s / 10 s                   | Removes most of the ~22 wasted GETs per PR; stops fast repos burning 300 s and stops slow repos failing spuriously                      |
+| Required-check inventory per repo   | Distinguish "required check queued but never executed" from "check failed", and stop waiting on the former | Correctly attributes the 9 `AI Slop Scan`/`Zizmor Scan` PRs to GitHub infrastructure instead of burning 300 s each                      |
+| Per-repo expected latency           | Schedule repos longest-first (LPT) rather than first-seen                                                  | Shortens makespan; the tail stops being decided by scheduling luck                                                                      |
+| Calls-per-PR by outcome class       | Pre-flight admission control: compare `n_prs × p90_calls_per_pr` against live `remaining`                  | Warn "this run needs ~7,400 calls but only 4,300 remain" *before* starting, or auto-lower concurrency — instead of a silent 4× slowdown |
+| `budget_samples` timeline           | Post-hoc diagnosis of exactly the ratchet in §2.2                                                          | Would have made this audit a five-minute `dependamerge history show`                                                                    |
+| Error class → eventual outcome      | Learn that `500 on reviews` and `Merge already in progress` resolve ~80% of the time                       | Justifies the retry-policy changes in P2 with data, and can drive them automatically                                                    |
+| Repeated failure signature per repo | `--skip-known-blocked`, and a "these repos need attention" report                                          | Stops a bulk run spending 20 minutes per repo re-deriving a config problem                                                              |
+| Historical merge duration per repo  | Regression alerting on CI time                                                                             | Useful releng signal independent of merging                                                                                             |
+
+<!-- markdownlint-enable MD013 -->
+
+### 4.4 Sequencing
+
+The record is **P2, not P0**. It makes the tool smarter; it does not fix the
+cliff. Ship P0 and P1 first — those are bounded, surgical changes to
+`github_async.py` and the polling path, and they address the reported symptom
+directly. Then add the record, initially write-only (`runs`, `pr_attempts`,
+`budget_samples`) plus a `dependamerge history` reporting command. Once real
+data exists, the adaptive read-paths in §4.3 can be switched on, each behind a
+flag, so a bad heuristic cannot degrade runs unnoticed.
+
+---
+
+## 5. Suggested immediate operational workaround
+
+Until P0 lands, split large runs so no single process crosses the
+ratchet, and keep the parked-PR population under ~14:
+
+```sh
+dependamerge merge --no-confirm --max-wait 0 https://github.com/lfreleng-actions
+```
+
+`--max-wait 0` is fire-and-forget: it arms auto-merge and returns without
+waiting. It eliminates the polling load entirely and lets GitHub do the
+waiting for free. Re-run later to sweep up anything auto-merge did not
+complete. Given §2.6 — 62% of "failures" merged on their own within two
+minutes — this should produce a *better* outcome than the current
+blocking behaviour, in a fraction of the wall-clock time.

--- a/src/dependamerge/github_async.py
+++ b/src/dependamerge/github_async.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import json
 import logging
 import os
@@ -76,6 +77,12 @@ class RetryableError(Exception):
     """Internal exception to signal tenacity that a retry should occur."""
 
 
+# Ceiling of tenacity's ``wait_random_exponential`` on ``_request``.  Named
+# so the secondary-rate-limit path can subtract it from a ``Retry-After``
+# sleep rather than stacking a full sleep on top of the retry backoff.
+_TENACITY_MAX_BACKOFF = 10.0
+
+
 def _now() -> float:
     return time.time()
 
@@ -110,6 +117,129 @@ def _is_transient_graphql_error(errors: Any) -> bool:
             "network timeout",
         ]
     )
+
+
+class _ResizableSemaphore:
+    """A semaphore whose effective capacity can change at runtime.
+
+    Backed by a single fixed-capacity :class:`asyncio.Semaphore` sized to
+    ``maximum``.  Capacity is *reduced* by acquiring "ballast" permits and
+    holding them, and restored by releasing them.
+
+    This exists because the obvious implementation --- replacing
+    ``self.semaphore`` with a smaller ``asyncio.Semaphore`` --- is unsafe.
+    Tasks that acquired the old object release back into it, while new
+    arrivals see a fresh object with its full count unclaimed, so the cap
+    is transiently violated by up to the old capacity at exactly the
+    moment the client is trying to back off.  Holding ballast keeps one
+    object for the process lifetime, so every acquire/release pairs up.
+
+    ``resize`` never blocks the caller: acquiring ballast may have to wait
+    for in-flight requests to finish, so it runs in a background task.
+    Shrinking is therefore best-effort and eventually consistent, which is
+    the correct semantic for a throttle --- it takes effect as capacity
+    frees up rather than cancelling work already in flight.
+    """
+
+    def __init__(self, capacity: int, maximum: int) -> None:
+        if maximum < 1:
+            raise ValueError("maximum must be >= 1")
+        self._maximum = maximum
+        self._sem = asyncio.Semaphore(maximum)
+        self._ballast = 0
+        self._desired_ballast = max(0, maximum - max(1, min(capacity, maximum)))
+        self._lock = asyncio.Lock()
+        self._task: asyncio.Task[None] | None = None
+
+    @property
+    def capacity(self) -> int:
+        """Effective capacity once any pending resize has settled."""
+        return self._maximum - self._desired_ballast
+
+    def resize(self, capacity: int) -> None:
+        """Request a new effective capacity.  Returns immediately.
+
+        Safe to call without a running event loop: the desired capacity is
+        recorded and applied by the next call made from inside one.  The
+        production caller (``_request``) always runs in a loop; tolerating
+        its absence keeps the tuning logic testable in isolation and stops
+        a stray call from raising inside a best-effort code path.
+        """
+        capacity = max(1, min(capacity, self._maximum))
+        desired = self._maximum - capacity
+        if desired == self._desired_ballast:
+            return
+        self._desired_ballast = desired
+        if self._task is None or self._task.done():
+            try:
+                asyncio.get_running_loop()
+            except RuntimeError:
+                # No running loop; ``_desired_ballast`` is recorded and
+                # will be honoured by the next resize or explicit settle.
+                self._task = None
+                return
+            self._task = asyncio.create_task(
+                self._settle(), name="github-semaphore-resize"
+            )
+
+    async def _settle(self) -> None:
+        async with self._lock:
+            while self._ballast != self._desired_ballast:
+                if self._ballast < self._desired_ballast:
+                    await self._sem.acquire()
+                    self._ballast += 1
+                else:
+                    self._sem.release()
+                    self._ballast -= 1
+
+    async def aclose(self) -> None:
+        """Cancel any in-flight resize so the loop can shut down cleanly."""
+        task = self._task
+        self._task = None
+        if task is not None and not task.done():
+            task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await task
+
+    async def __aenter__(self) -> None:
+        await self._sem.acquire()
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        self._sem.release()
+
+
+class _Budget:
+    """Latest known rate-limit state for one GitHub rate-limit resource.
+
+    REST (``core``), GraphQL (``graphql``) and ``search`` have independent
+    budgets.  They must be tracked separately: GraphQL responses report
+    *points* remaining against a 5000-point budget, so folding them into
+    the same counter as REST request budget makes a healthy GraphQL
+    allowance mask an exhausted REST one, and vice versa.
+    """
+
+    __slots__ = ("remaining", "limit", "reset_epoch", "updated_at")
+
+    def __init__(
+        self, remaining: int, limit: int, reset_epoch: float | None, updated_at: float
+    ) -> None:
+        self.remaining = remaining
+        self.limit = limit
+        self.reset_epoch = reset_epoch
+        self.updated_at = updated_at
+
+    def headroom(self, now: float) -> float:
+        """Fraction of the budget still available, in ``[0.0, 1.0]``.
+
+        Past its reset the budget has replenished, so report full
+        headroom rather than a stale near-zero value that would keep the
+        client throttled long after the pressure ended.
+        """
+        if self.reset_epoch is not None and now >= self.reset_epoch:
+            return 1.0
+        if self.limit <= 0:
+            return 1.0
+        return max(0.0, min(1.0, self.remaining / self.limit))
 
 
 def _is_retryable_status(status: int) -> bool:
@@ -188,16 +318,10 @@ class GitHubAsync:
     # concurrency back up after a period of throttling.
     _DEFAULT_MAX_CONCURRENCY = 20
 
-    # Heuristic used by ``_get_recent_error_rate`` to estimate how many
-    # requests accompanied each observed error within the error window.
-    # We do not track total request counts, only errors, so we assume each
-    # error corresponds to roughly this many requests. With the current
-    # value of 10 the estimate is errors / (errors * 10), so any window
-    # containing at least one error yields an error_rate of ~0.1. A smaller
-    # number raises that estimate and reacts to errors more aggressively,
-    # while a larger number lowers it and tolerates more errors before
-    # throttling. Tune this if observed throttling behaviour is too eager
-    # or too lax.
+    # Heuristic retained for backwards compatibility with callers that may
+    # reference it.  No longer used: ``_get_recent_error_rate`` now counts
+    # real requests instead of estimating them from the error count, which
+    # made the computed rate a constant.
     _ESTIMATED_REQUESTS_PER_ERROR = 10
 
     def __init__(
@@ -246,7 +370,10 @@ class GitHubAsync:
         # a period of throttling, mirroring how ``_base_rps`` bounds the RPS
         # ramp-up.
         self._base_max_concurrency = max_concurrency
-        self.semaphore = asyncio.Semaphore(self._max_concurrency)
+        # Sized to the base ceiling and never replaced; throttling reduces
+        # the *effective* capacity by holding ballast permits.  See
+        # ``_ResizableSemaphore`` for why swapping the object is unsafe.
+        self.semaphore = _ResizableSemaphore(max_concurrency, max_concurrency)
         self._base_rps = requests_per_second
         self._current_rps = requests_per_second
         self.limiter = AsyncLimiter(max_rate=self._current_rps, time_period=1.0)
@@ -257,14 +384,26 @@ class GitHubAsync:
         self.on_rate_limit_cleared = on_rate_limit_cleared
         self.on_metrics = on_metrics
 
-        # Error tracking for adaptive throttling
+        # Adaptive throttling state.  ``_request_history`` records the
+        # timestamp of every completed request and ``_error_history`` the
+        # subset that failed, so the error *rate* is a real ratio rather
+        # than a constant derived from a guessed request count.
         self._error_history: list[
             tuple[float, str]
         ] = []  # List of (timestamp, error_type) tuples
+        self._request_history: list[float] = []
         self._error_window = 300  # 5 minutes
         self._last_retry_after: float | None = None
         self._adaptive_delay = 0.0
         self._last_adaptive_update: float | None = None
+        # Per-resource rate-limit budgets, keyed by ``X-RateLimit-Resource``
+        # (``core``, ``graphql``, ``search``).  Kept apart because they are
+        # independent allowances; see ``_Budget``.
+        self._budgets: dict[str, _Budget] = {}
+        # Consecutive healthy responses observed since the last throttle
+        # event.  Ramp-up requires a sustained run rather than a single
+        # lucky response, so a client under pressure does not oscillate.
+        self._healthy_streak = 0
 
         # Cache for the authenticated user's login (never changes during a session)
         self._authenticated_user_login: str | None = None
@@ -321,7 +460,8 @@ class GitHubAsync:
         await self.aclose()
 
     async def aclose(self) -> None:
-        """Close underlying httpx client."""
+        """Close underlying httpx client and stop any pending resize."""
+        await self.semaphore.aclose()
         await self._client.aclose()
 
     def _parse_permission_error(
@@ -483,7 +623,7 @@ class GitHubAsync:
     @retry(
         reraise=True,
         stop=stop_after_attempt(6),
-        wait=wait_random_exponential(multiplier=0.5, max=10.0),
+        wait=wait_random_exponential(multiplier=0.5, max=_TENACITY_MAX_BACKOFF),
         retry=retry_if_exception_type(
             (
                 httpx.TransportError,
@@ -519,29 +659,37 @@ class GitHubAsync:
             # Secondary rate limit (abuse detection)
             if _is_secondary_rate_limited(body_text):
                 retry_after = r.headers.get("Retry-After")
+                delay: float | None = None
                 if retry_after:
-                    # Sleep the advised duration and signal retry
                     try:
                         delay = float(retry_after)
                         self._last_retry_after = delay
-                        # Apply adaptive throttling based on Retry-After
                         self._apply_retry_after_throttling(delay)
-                    except Exception:
-                        delay = 5.0
-                    self.log.warning(
-                        "Secondary rate limit hit. Sleeping for %ss", delay
-                    )
-                    await asyncio.sleep(max(0.0, delay))
-                else:
-                    # Fallback wait when no explicit Retry-After
-                    delay = 10.0
-                    self.log.warning(
-                        "Secondary rate limit hit. Sleeping fallback %ss", delay
-                    )
-                    await asyncio.sleep(delay)
-
+                    except (TypeError, ValueError):
+                        delay = None
                 # Track error for adaptive throttling
                 self._track_error("secondary_rate_limit")
+                if delay is not None:
+                    # GitHub told us exactly how long to wait.  Sleeping
+                    # here *and* letting tenacity back off on top would
+                    # stack the two; hand tenacity a pre-slept signal
+                    # instead by waiting the advised time and then
+                    # raising, which tenacity adds its own (smaller,
+                    # jittered) delay to.  Keep that combined wait honest
+                    # by subtracting tenacity's cap from our sleep.
+                    effective = max(0.0, delay - _TENACITY_MAX_BACKOFF)
+                    self.log.warning(
+                        "Secondary rate limit hit. Retry-After=%ss, sleeping %ss",
+                        delay,
+                        effective,
+                    )
+                    if effective:
+                        await asyncio.sleep(effective)
+                else:
+                    self.log.warning(
+                        "Secondary rate limit hit without Retry-After; "
+                        "deferring to retry backoff"
+                    )
                 raise SecondaryRateLimitError("Secondary rate limit encountered")
 
             # Primary rate limit exhausted
@@ -611,49 +759,18 @@ class GitHubAsync:
         # All other errors -> raise
         r.raise_for_status()
 
-        # Apply adaptive delay based on recent error patterns
-        if self._adaptive_delay > 0:
-            await asyncio.sleep(self._adaptive_delay)
+        self._track_request()
 
-        # Dynamic concurrency and RPS tuning based on latest headers and error history
+        # Pace the next request when recent Retry-After headers indicated
+        # sustained pressure.  Decays with time (see ``_current_adaptive_delay``).
+        delay = self._current_adaptive_delay()
+        if delay > 0:
+            await asyncio.sleep(delay)
+
+        # Dynamic concurrency and RPS tuning from the latest headers.
         try:
-            remaining, limit, reset_epoch = self._parse_rate_limit_headers(r)
-            error_rate = self._get_recent_error_rate()
-
-            # More aggressive throttling if we have recent errors or low rate limit remaining
-            if limit > 0:
-                remaining_ratio = remaining / max(1, limit)
-                should_throttle = remaining_ratio < 0.1 or error_rate > 0.1
-
-                if should_throttle:
-                    # Reduce concurrency but keep a floor of 2
-                    throttle_factor = 0.3 if error_rate > 0.2 else 0.5
-                    new_concurrency = max(
-                        2, int(self._max_concurrency * throttle_factor)
-                    )
-                    if new_concurrency != self._max_concurrency:
-                        self._max_concurrency = new_concurrency
-                        self.semaphore = asyncio.Semaphore(self._max_concurrency)
-
-                    # Reduce RPS but keep a floor of 1
-                    new_rps = max(1.0, self._current_rps * throttle_factor)
-                    if abs(new_rps - self._current_rps) >= 0.5:
-                        self._current_rps = new_rps
-                        self.limiter = AsyncLimiter(
-                            max_rate=self._current_rps, time_period=1.0
-                        )
-            else:
-                # Gradually increase limits when healthy, up to configured base values
-                if self._max_concurrency < self._base_max_concurrency:
-                    self._max_concurrency = min(
-                        self._base_max_concurrency, self._max_concurrency + 1
-                    )
-                    self.semaphore = asyncio.Semaphore(self._max_concurrency)
-                if self._current_rps < self._base_rps:
-                    self._current_rps = min(self._base_rps, self._current_rps + 1.0)
-                    self.limiter = AsyncLimiter(
-                        max_rate=self._current_rps, time_period=1.0
-                    )
+            self._record_budget(r)
+            self._tune(self._headroom())
         except Exception as e:
             # Tuning is best-effort; never fail the request on tuning errors.
             self.log.debug("Adaptive concurrency tuning skipped: %s", e)
@@ -2653,41 +2770,179 @@ class GitHubAsync:
         cutoff = current_time - self._error_window
         self._error_history = [(t, e) for t, e in self._error_history if t > cutoff]
 
-    def _get_recent_error_rate(self) -> float:
-        """Calculate the error rate in the recent window."""
-        if not self._error_history:
-            return 0.0
+    def _track_request(self) -> None:
+        """Record a completed request so the error *rate* has a denominator."""
+        current_time = _now()
+        self._request_history.append(current_time)
+        cutoff = current_time - self._error_window
+        if self._request_history[0] <= cutoff:
+            self._request_history = [t for t in self._request_history if t > cutoff]
 
+    def _get_recent_error_rate(self) -> float:
+        """Errors as a fraction of all requests in the recent window.
+
+        Previously this divided the error count by an *estimate* derived
+        from the same error count (``errors / (errors * 10)``), which is
+        the constant ``0.1`` whenever any error exists and ``0.0``
+        otherwise.  Both call sites compared it against ``0.1`` and
+        ``0.2``, so the error signal could never fire.  Counting requests
+        as well gives a real ratio.
+        """
         current_time = _now()
         cutoff = current_time - self._error_window
-        recent_errors = [e for t, e in self._error_history if t > cutoff]
+        errors = sum(1 for t, _ in self._error_history if t > cutoff)
+        if not errors:
+            return 0.0
+        requests = sum(1 for t in self._request_history if t > cutoff)
+        # Errors are not recorded in ``_request_history`` (they raise
+        # before ``_track_request``), so the denominator is the total of
+        # both.  Guard against a window holding only errors.
+        total = requests + errors
+        return errors / total if total else 0.0
 
-        # Estimate request rate (very rough heuristic): we only track
-        # errors, not total requests, so assume each error accompanied
-        # ``_ESTIMATED_REQUESTS_PER_ERROR`` requests in the window. See the
-        # constant's definition for the rationale and tuning guidance.
-        estimated_requests = max(
-            len(recent_errors) * self._ESTIMATED_REQUESTS_PER_ERROR, 1
+    def _record_budget(self, r: httpx.Response) -> None:
+        """Store the rate-limit state carried by a response, per resource."""
+        remaining_hdr = r.headers.get("X-RateLimit-Remaining")
+        limit_hdr = r.headers.get("X-RateLimit-Limit")
+        if remaining_hdr is None or limit_hdr is None:
+            # No rate-limit headers: nothing reliable to learn.  Notably we
+            # do *not* fall back to defaults here --- the previous code
+            # defaulted to remaining=1/limit=60, a headroom of 0.017, which
+            # tripped the throttle on any response lacking headers.
+            return
+        try:
+            remaining = int(remaining_hdr)
+            limit = int(limit_hdr)
+        except (TypeError, ValueError):
+            return
+        reset = r.headers.get("X-RateLimit-Reset")
+        try:
+            reset_epoch = float(reset) if reset else None
+        except (TypeError, ValueError):
+            reset_epoch = None
+        resource = r.headers.get("X-RateLimit-Resource") or "core"
+        self._budgets[resource] = _Budget(remaining, limit, reset_epoch, _now())
+
+    def _headroom(self) -> float | None:
+        """Smallest remaining fraction across all known budgets.
+
+        The limiter and semaphore are shared across REST and GraphQL, so
+        the binding constraint is whichever resource is most depleted.
+        Returns ``None`` when nothing is known, meaning "do not tune".
+        """
+        if not self._budgets:
+            return None
+        now = _now()
+        return min(b.headroom(now) for b in self._budgets.values())
+
+    # Ramp-up requires this many consecutive healthy responses.  Recovery
+    # is deliberately slower than back-off: one lucky response should not
+    # undo a throttle, but a sustained healthy run must be able to.
+    _RAMP_UP_STREAK = 20
+
+    def _tune(self, headroom: float | None) -> None:
+        """Adjust concurrency and RPS from budget headroom and error rate.
+
+        Throttling down and ramping back up are the two branches of a
+        single condition.  In the previous implementation the ramp-up
+        branch sat in the ``else`` of ``if limit > 0:`` --- unreachable,
+        because GitHub always reports a positive limit.  Back-off was
+        therefore permanent for the process lifetime: a long run would
+        decay to the floor of 2 concurrent / 1.0 rps and stay there.
+        """
+        if headroom is None:
+            return
+        error_rate = self._get_recent_error_rate()
+        should_throttle = headroom < 0.1 or error_rate > 0.1
+
+        if should_throttle:
+            self._healthy_streak = 0
+            factor = 0.3 if error_rate > 0.2 else 0.5
+            new_concurrency = max(2, int(self._max_concurrency * factor))
+            new_rps = max(1.0, self._current_rps * factor)
+            changed = False
+            if new_concurrency != self._max_concurrency:
+                self._max_concurrency = new_concurrency
+                self.semaphore.resize(new_concurrency)
+                changed = True
+            if abs(new_rps - self._current_rps) >= 0.5:
+                self._current_rps = new_rps
+                self.limiter = AsyncLimiter(max_rate=new_rps, time_period=1.0)
+                changed = True
+            if changed:
+                self.log.warning(
+                    "Throttling down: headroom=%.3f error_rate=%.3f "
+                    "-> concurrency=%d rps=%.1f",
+                    headroom,
+                    error_rate,
+                    self._max_concurrency,
+                    self._current_rps,
+                )
+            return
+
+        # Healthy.  Ramp back toward the configured base values.
+        at_base = (
+            self._max_concurrency >= self._base_max_concurrency
+            and self._current_rps >= self._base_rps
         )
-        return len(recent_errors) / estimated_requests
+        if at_base:
+            self._healthy_streak = 0
+            return
+        self._healthy_streak += 1
+        if self._healthy_streak < self._RAMP_UP_STREAK:
+            return
+        self._healthy_streak = 0
+        if self._max_concurrency < self._base_max_concurrency:
+            self._max_concurrency = min(
+                self._base_max_concurrency, self._max_concurrency + 1
+            )
+            self.semaphore.resize(self._max_concurrency)
+        if self._current_rps < self._base_rps:
+            self._current_rps = min(self._base_rps, self._current_rps + 1.0)
+            self.limiter = AsyncLimiter(max_rate=self._current_rps, time_period=1.0)
+        self.log.info(
+            "Recovering: headroom=%.3f -> concurrency=%d rps=%.1f",
+            headroom,
+            self._max_concurrency,
+            self._current_rps,
+        )
+
+    # Adaptive delay decays to zero over this many seconds after the last
+    # Retry-After observation.
+    _ADAPTIVE_DELAY_DECAY_SECONDS = 120.0
+
+    def _current_adaptive_delay(self) -> float:
+        """The pacing delay to apply right now, decayed by elapsed time.
+
+        The decay used to live inside ``_apply_retry_after_throttling``,
+        so it only ran when *another* ``Retry-After`` arrived.  A single
+        long ``Retry-After`` therefore pinned a delay --- up to 5 s --- on
+        every subsequent successful request for the rest of the run.  At
+        roughly 10 calls per PR that is around 50 s of pure sleeping per
+        PR.  Decaying on read makes the delay self-clearing.
+        """
+        if self._adaptive_delay <= 0 or self._last_adaptive_update is None:
+            return 0.0
+        elapsed = _now() - self._last_adaptive_update
+        if elapsed >= self._ADAPTIVE_DELAY_DECAY_SECONDS:
+            self._adaptive_delay = 0.0
+            return 0.0
+        remaining = 1.0 - (elapsed / self._ADAPTIVE_DELAY_DECAY_SECONDS)
+        return self._adaptive_delay * remaining
 
     def _apply_retry_after_throttling(self, retry_after_seconds: float) -> None:
-        """Apply adaptive throttling based on Retry-After header values."""
-        # If we're getting Retry-After frequently, add adaptive delay
+        """Set the pacing delay implied by a ``Retry-After`` header."""
         if retry_after_seconds > 30:
             # Long retry-after suggests we're hitting limits hard
-            self._adaptive_delay = min(5.0, retry_after_seconds * 0.1)
+            delay = min(5.0, retry_after_seconds * 0.1)
         elif retry_after_seconds > 10:
             # Medium retry-after suggests moderate pressure
-            self._adaptive_delay = min(2.0, retry_after_seconds * 0.05)
+            delay = min(2.0, retry_after_seconds * 0.05)
         else:
             # Short retry-after is normal, minimal delay
-            self._adaptive_delay = min(1.0, retry_after_seconds * 0.02)
+            delay = min(1.0, retry_after_seconds * 0.02)
 
-        # Gradually reduce adaptive delay over time
-        if self._last_adaptive_update is not None:
-            time_since_update = _now() - self._last_adaptive_update
-            if time_since_update > 60:  # Reduce delay after 1 minute
-                self._adaptive_delay *= 0.8
-
+        # Keep the strongest signal currently in force rather than letting
+        # a mild one reset a severe one that has not yet decayed.
+        self._adaptive_delay = max(delay, self._current_adaptive_delay())
         self._last_adaptive_update = _now()

--- a/tests/test_adaptive_throttling.py
+++ b/tests/test_adaptive_throttling.py
@@ -1,0 +1,382 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 The Linux Foundation
+
+"""Tests for adaptive rate-limit throttling in :mod:`github_async`.
+
+These cover the defects found in the 503-PR bulk-run audit (see
+``docs/BULK_RUN_PERFORMANCE_AUDIT.md``):
+
+- the ramp-up branch was unreachable, making back-off permanent;
+- the error rate was a constant by construction, so it never fired;
+- the concurrency semaphore was replaced while tasks held permits;
+- the adaptive delay only decayed when a new ``Retry-After`` arrived;
+- REST and GraphQL budgets shared one counter;
+- a missing rate-limit header defaulted to a headroom that throttled.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import httpx
+import pytest
+
+from dependamerge.github_async import GitHubAsync, _Budget, _ResizableSemaphore
+
+
+def _response(headers: dict[str, str]) -> httpx.Response:
+    return httpx.Response(
+        200, headers=headers, request=httpx.Request("GET", "http://x")
+    )
+
+
+def _client(**kwargs) -> GitHubAsync:
+    return GitHubAsync(token="t", **kwargs)
+
+
+# --------------------------------------------------------------------------
+# Budget accounting
+# --------------------------------------------------------------------------
+
+
+class TestBudget:
+    def test_headroom_is_remaining_over_limit(self) -> None:
+        b = _Budget(remaining=250, limit=5000, reset_epoch=None, updated_at=0.0)
+        assert b.headroom(now=0.0) == pytest.approx(0.05)
+
+    def test_headroom_is_full_after_reset(self) -> None:
+        """A stale near-zero budget must not pin the client at the floor."""
+        b = _Budget(remaining=0, limit=5000, reset_epoch=100.0, updated_at=0.0)
+        assert b.headroom(now=99.0) == 0.0
+        assert b.headroom(now=101.0) == 1.0
+
+    def test_zero_limit_reports_full_headroom(self) -> None:
+        b = _Budget(remaining=0, limit=0, reset_epoch=None, updated_at=0.0)
+        assert b.headroom(now=0.0) == 1.0
+
+
+class TestRecordBudget:
+    def test_rest_and_graphql_tracked_separately(self) -> None:
+        c = _client()
+        c._record_budget(
+            _response(
+                {
+                    "X-RateLimit-Remaining": "4900",
+                    "X-RateLimit-Limit": "5000",
+                    "X-RateLimit-Resource": "graphql",
+                }
+            )
+        )
+        c._record_budget(
+            _response(
+                {
+                    "X-RateLimit-Remaining": "100",
+                    "X-RateLimit-Limit": "5000",
+                    "X-RateLimit-Resource": "core",
+                }
+            )
+        )
+        assert set(c._budgets) == {"graphql", "core"}
+        # The binding constraint is the most depleted resource, so a
+        # healthy GraphQL allowance must not mask an exhausted REST one.
+        assert c._headroom() == pytest.approx(0.02)
+
+    def test_missing_headers_are_ignored(self) -> None:
+        """Absent headers previously defaulted to 1/60, tripping the throttle."""
+        c = _client()
+        c._record_budget(_response({}))
+        assert c._budgets == {}
+        assert c._headroom() is None
+
+    def test_unparsable_headers_are_ignored(self) -> None:
+        c = _client()
+        c._record_budget(
+            _response({"X-RateLimit-Remaining": "abc", "X-RateLimit-Limit": "5000"})
+        )
+        assert c._budgets == {}
+
+    def test_resource_defaults_to_core(self) -> None:
+        c = _client()
+        c._record_budget(
+            _response({"X-RateLimit-Remaining": "10", "X-RateLimit-Limit": "5000"})
+        )
+        assert "core" in c._budgets
+
+
+# --------------------------------------------------------------------------
+# Error rate
+# --------------------------------------------------------------------------
+
+
+class TestErrorRate:
+    def test_no_errors_is_zero(self) -> None:
+        c = _client()
+        for _ in range(10):
+            c._track_request()
+        assert c._get_recent_error_rate() == 0.0
+
+    def test_rate_is_a_real_ratio(self) -> None:
+        """Regression: this used to be exactly 0.1 whenever any error existed."""
+        c = _client()
+        for _ in range(99):
+            c._track_request()
+        c._track_error("transient_error")
+        assert c._get_recent_error_rate() == pytest.approx(0.01)
+
+    def test_rate_rises_with_errors(self) -> None:
+        c = _client()
+        for _ in range(10):
+            c._track_request()
+        for _ in range(10):
+            c._track_error("transient_error")
+        assert c._get_recent_error_rate() == pytest.approx(0.5)
+
+    def test_high_error_rate_is_reachable(self) -> None:
+        """The old implementation could never exceed the 0.1 / 0.2 thresholds."""
+        c = _client()
+        c._track_request()
+        for _ in range(9):
+            c._track_error("transient_error")
+        rate = c._get_recent_error_rate()
+        assert rate > 0.2
+
+
+# --------------------------------------------------------------------------
+# Tuning: throttle down and, crucially, back up again
+# --------------------------------------------------------------------------
+
+
+class TestTune:
+    def test_low_headroom_throttles_down(self) -> None:
+        c = _client(max_concurrency=20, requests_per_second=8.0)
+        c._tune(headroom=0.05)
+        assert c._max_concurrency == 10
+        assert c._current_rps == pytest.approx(4.0)
+
+    def test_throttling_is_bounded_by_floors(self) -> None:
+        c = _client(max_concurrency=20, requests_per_second=8.0)
+        for _ in range(12):
+            c._tune(headroom=0.01)
+        assert c._max_concurrency == 2
+        assert c._current_rps == pytest.approx(1.0)
+
+    def test_healthy_headroom_ramps_back_up(self) -> None:
+        """Regression: the ramp-up branch was unreachable, so this stayed at 2."""
+        c = _client(max_concurrency=20, requests_per_second=8.0)
+        for _ in range(12):
+            c._tune(headroom=0.01)
+        assert c._max_concurrency == 2
+
+        for _ in range(GitHubAsync._RAMP_UP_STREAK * 3):
+            c._tune(headroom=0.9)
+        assert c._max_concurrency > 2
+        assert c._current_rps > 1.0
+
+    def test_ramp_up_needs_a_sustained_streak(self) -> None:
+        c = _client(max_concurrency=20, requests_per_second=8.0)
+        c._tune(headroom=0.01)
+        throttled = c._max_concurrency
+        for _ in range(GitHubAsync._RAMP_UP_STREAK - 1):
+            c._tune(headroom=0.9)
+        assert c._max_concurrency == throttled
+        c._tune(headroom=0.9)
+        assert c._max_concurrency == throttled + 1
+
+    def test_throttling_resets_the_healthy_streak(self) -> None:
+        c = _client(max_concurrency=20, requests_per_second=8.0)
+        c._tune(headroom=0.01)
+        for _ in range(GitHubAsync._RAMP_UP_STREAK - 1):
+            c._tune(headroom=0.9)
+        c._tune(headroom=0.01)
+        assert c._healthy_streak == 0
+
+    def test_ramp_up_stops_at_configured_base(self) -> None:
+        c = _client(max_concurrency=6, requests_per_second=3.0)
+        for _ in range(GitHubAsync._RAMP_UP_STREAK * 20):
+            c._tune(headroom=0.9)
+        assert c._max_concurrency == 6
+        assert c._current_rps == pytest.approx(3.0)
+
+    def test_unknown_headroom_does_not_tune(self) -> None:
+        c = _client(max_concurrency=20, requests_per_second=8.0)
+        c._tune(headroom=None)
+        assert c._max_concurrency == 20
+        assert c._current_rps == pytest.approx(8.0)
+
+    def test_high_error_rate_throttles_even_with_budget(self) -> None:
+        c = _client(max_concurrency=20, requests_per_second=8.0)
+        c._track_request()
+        for _ in range(9):
+            c._track_error("transient_error")
+        c._tune(headroom=1.0)
+        assert c._max_concurrency < 20
+
+
+# --------------------------------------------------------------------------
+# Adaptive delay decay
+# --------------------------------------------------------------------------
+
+
+class TestAdaptiveDelay:
+    def test_delay_is_zero_when_unset(self) -> None:
+        assert _client()._current_adaptive_delay() == 0.0
+
+    def test_delay_decays_to_zero_over_time(self, monkeypatch) -> None:
+        """Regression: decay only ran when another Retry-After arrived."""
+        import dependamerge.github_async as mod
+
+        now = 1000.0
+        monkeypatch.setattr(mod, "_now", lambda: now)
+        c = _client()
+        c._apply_retry_after_throttling(60.0)
+        assert c._current_adaptive_delay() == pytest.approx(5.0)
+
+        now = 1000.0 + GitHubAsync._ADAPTIVE_DELAY_DECAY_SECONDS / 2
+        assert c._current_adaptive_delay() == pytest.approx(2.5)
+
+        now = 1000.0 + GitHubAsync._ADAPTIVE_DELAY_DECAY_SECONDS + 1
+        assert c._current_adaptive_delay() == 0.0
+
+    def test_mild_signal_does_not_reset_a_severe_one(self, monkeypatch) -> None:
+        import dependamerge.github_async as mod
+
+        now = 1000.0
+        monkeypatch.setattr(mod, "_now", lambda: now)
+        c = _client()
+        c._apply_retry_after_throttling(60.0)
+        c._apply_retry_after_throttling(1.0)
+        assert c._current_adaptive_delay() == pytest.approx(5.0)
+
+
+# --------------------------------------------------------------------------
+# Resizable semaphore
+# --------------------------------------------------------------------------
+
+
+class TestResizableSemaphore:
+    @pytest.mark.asyncio
+    async def test_acts_as_a_semaphore(self) -> None:
+        sem = _ResizableSemaphore(2, 2)
+        async with sem:
+            async with sem:
+                assert sem._sem.locked()
+
+    @pytest.mark.asyncio
+    async def test_shrink_reduces_effective_capacity(self) -> None:
+        sem = _ResizableSemaphore(4, 4)
+        sem.resize(1)
+        await sem._settle()
+        assert sem.capacity == 1
+        async with sem:
+            assert sem._sem.locked()
+
+    @pytest.mark.asyncio
+    async def test_grow_restores_capacity(self) -> None:
+        sem = _ResizableSemaphore(4, 4)
+        sem.resize(1)
+        await sem._settle()
+        sem.resize(4)
+        await sem._settle()
+        assert sem.capacity == 4
+        held = [sem.__aenter__() for _ in range(4)]
+        await asyncio.gather(*held)
+        assert sem._sem.locked()
+        for _ in range(4):
+            await sem.__aexit__(None, None, None)
+
+    @pytest.mark.asyncio
+    async def test_permit_held_across_resize_releases_cleanly(self) -> None:
+        """Regression: swapping the object leaked permits into a dead semaphore.
+
+        A task holding a permit from before the resize must still be
+        releasing into the same object afterwards, so total capacity stays
+        consistent rather than being transiently exceeded.
+        """
+        sem = _ResizableSemaphore(4, 4)
+        await sem.__aenter__()
+        sem.resize(2)
+        await sem._settle()
+        await sem.__aexit__(None, None, None)
+        # 4 max, 2 ballast held -> exactly 2 acquirable, no more.
+        await sem.__aenter__()
+        await sem.__aenter__()
+        assert sem._sem.locked()
+        await sem.__aexit__(None, None, None)
+        await sem.__aexit__(None, None, None)
+
+    @pytest.mark.asyncio
+    async def test_resize_never_exceeds_maximum(self) -> None:
+        sem = _ResizableSemaphore(4, 4)
+        sem.resize(99)
+        await sem._settle()
+        assert sem.capacity == 4
+
+    @pytest.mark.asyncio
+    async def test_resize_floor_is_one(self) -> None:
+        sem = _ResizableSemaphore(4, 4)
+        sem.resize(0)
+        await sem._settle()
+        assert sem.capacity == 1
+
+    @pytest.mark.asyncio
+    async def test_resize_does_not_block_caller(self) -> None:
+        """Shrinking while fully subscribed must not deadlock the response path."""
+        sem = _ResizableSemaphore(2, 2)
+        await sem.__aenter__()
+        await sem.__aenter__()
+        sem.resize(1)  # cannot take ballast yet; must return immediately
+        assert sem.capacity == 1
+        await sem.__aexit__(None, None, None)
+        await sem.__aexit__(None, None, None)
+        await sem.aclose()
+
+    @pytest.mark.asyncio
+    async def test_aclose_cancels_pending_resize(self) -> None:
+        sem = _ResizableSemaphore(2, 2)
+        await sem.__aenter__()
+        await sem.__aenter__()
+        sem.resize(1)
+        await sem.aclose()
+        await sem.__aexit__(None, None, None)
+        await sem.__aexit__(None, None, None)
+
+
+# --------------------------------------------------------------------------
+# End-to-end: the ratchet no longer latches
+# --------------------------------------------------------------------------
+
+
+class TestNoPermanentRatchet:
+    def test_recovers_after_budget_resets(self, monkeypatch) -> None:
+        """The 503-PR run's failure mode, in miniature.
+
+        Budget drains below 10%, the client throttles to the floor, the
+        hourly window resets, and throughput must return. Previously it
+        stayed at 2 concurrent / 1.0 rps for the life of the process.
+        """
+        import dependamerge.github_async as mod
+
+        now = 1000.0
+        monkeypatch.setattr(mod, "_now", lambda: now)
+        c = _client(max_concurrency=20, requests_per_second=8.0)
+
+        for _ in range(12):
+            c._record_budget(
+                _response(
+                    {
+                        "X-RateLimit-Remaining": "100",
+                        "X-RateLimit-Limit": "5000",
+                        "X-RateLimit-Reset": "2000",
+                        "X-RateLimit-Resource": "core",
+                    }
+                )
+            )
+            c._tune(c._headroom())
+        assert c._max_concurrency == 2
+        assert c._current_rps == pytest.approx(1.0)
+
+        now = 2001.0  # window reset
+        for _ in range(GitHubAsync._RAMP_UP_STREAK * 25):
+            c._tune(c._headroom())
+        assert c._max_concurrency == 20
+        assert c._current_rps == pytest.approx(8.0)


### PR DESCRIPTION
## Summary

Fixes the adaptive rate-limit throttle in `GitHubAsync`, which could only ever
reduce throughput. Over a long run it decayed to the floor of 2 concurrent /
1.0 rps and stayed there for the lifetime of the process.

This is what turned a 503-PR bulk merge over `lfreleng-actions` into an
81-minute run that collapsed after roughly 300 merges.

The first commit documents the full audit; the second implements the P0 fixes
identified by it.

## Commits

1. **`Docs: Add bulk run performance audit`** — `docs/BULK_RUN_PERFORMANCE_AUDIT.md`,
   the measured analysis behind these changes, plus a `write-good` exclusion for
   the report.
2. **`Fix: Stop adaptive throttle latching at the floor`** — the throttle fixes
   and 31 new tests.

## The defects

**Ramp-up was unreachable.** The recovery branch sat in the `else:` of
`if limit > 0:`, but GitHub always reports a positive `X-RateLimit-Limit`, so
that branch never ran. Back-off was permanent. Throttling down and ramping back
up are now the two branches of one condition, with recovery gated on a
sustained run of healthy responses so a single lucky response cannot undo a
throttle.

**The error rate was a constant.** `_get_recent_error_rate` divided the error
count by an estimate derived from that same count
(`errors / (errors * 10)`) — exactly `0.1` whenever any error existed, `0.0`
otherwise. Both call sites compared it against `0.1` and `0.2`, so the error
signal could never fire. Requests are now counted, giving a real ratio.

**The semaphore was replaced while tasks held permits.** Tasks released into
the old object while new arrivals saw a fresh one with its full count
unclaimed, breaching the cap at exactly the moment the client was trying to
back off. A single semaphore now persists for the process; capacity is reduced
by acquiring and holding ballast permits, so every acquire/release pairs up.

**The adaptive delay never decayed.** Its decay logic lived inside the function
that set it, so it only ran when *another* `Retry-After` arrived. A single
`Retry-After: 60` pinned a 5-second sleep onto every subsequent successful
request for the rest of the run — around 50 s per PR at ~10 calls each. It now
decays with elapsed time on read.

## Also fixed

- **REST and GraphQL budgets are tracked separately** by `X-RateLimit-Resource`.
  They are independent allowances — GraphQL reports *points* — so a healthy
  GraphQL allowance was masking an exhausted REST budget and vice versa.
- **Missing rate-limit headers no longer default to `remaining=1, limit=60`**,
  a headroom of 1.7% that tripped the throttle on any response lacking headers.
  Unknown now means "do not tune".
- **The secondary-rate-limit path no longer stacks sleeps**, sleeping its full
  `Retry-After` *and* letting tenacity back off on top.

## Verification

- 1567 tests pass (31 new in `tests/test_adaptive_throttling.py`)
- Each new test names the defect it pins, including an end-to-end case
  reproducing the 503-PR failure mode in miniature: budget drains, client
  throttles to the floor, window resets, throughput returns
- Verified live against the GitHub API: REST and GraphQL land in separate
  budget buckets, headroom computes correctly, no spurious throttling

## Still to come

Not in this PR — P1 is the larger scaling win:

- Batch parked-PR polling into one aliased GraphQL query. Polling is currently
  O(parked) at 6 calls/min per PR; against an 83 calls/min REST budget, ~14
  parked PRs consume all of it. 60 parked PRs would drop from 360 calls/min to
  about 6.
- Re-verify PR state before reporting failure (21 of 34 reported failures in
  the audited run had actually merged).

## Related

- #405 — Dependabot PR title alignment
- #407 — detect and recover stuck ruleset workflows via close/reopen
- lfit/releng-reusable-workflows#854 — semantic check relaxation gap
- lfreleng-actions/.github#171 — cancelled duplicate runs blocking merges
