### PR TITLE
Fix: Stop reporting merged pull requests as failures

### DIFF
--- a/src/dependamerge/github_async.py
+++ b/src/dependamerge/github_async.py
@@ -242,6 +242,40 @@ class _Budget:
         return max(0.0, min(1.0, self.remaining / self.limit))
 
 
+# Approve-specific retry policy.  ``POST .../reviews`` returns transient
+# 500 often enough to matter in bulk runs, but a blanket retry of every
+# POST is unsafe, so this is applied only where duplicate-suppression is
+# possible (see ``approve_pull_request``).
+_APPROVE_MAX_ATTEMPTS = 3
+_APPROVE_RETRY_BASE_DELAY = 2.0
+
+# Server-side statuses worth retrying for an operation that can verify
+# its own effect afterwards.  Note 500 is intentionally *not* in
+# ``_is_retryable_status``: generic retries must not replay arbitrary
+# non-idempotent writes.
+# Statuses the outer approve retry handles.  Deliberately **only** 500:
+# ``_request`` already retries 429/502/503/504 (``_is_retryable_status``)
+# plus transport and rate-limit errors via tenacity, six attempts each.
+# Including those here too would nest the loops --- up to 18 requests and
+# two sets of backoff sleeps for one approval --- which is precisely the
+# API-budget waste this work is trying to remove.  500 is the one status
+# ``_request`` does not retry, because a blanket replay of failed POSTs
+# is unsafe; it is safe *here* only because this call can verify its own
+# effect first (see ``approve_pull_request``).
+_TRANSIENT_SERVER_STATUSES = frozenset({500})
+
+
+def _is_transient_server_error(exc: Exception) -> bool:
+    """Whether ``exc`` is a server-side failure the outer retry should own.
+
+    Anything already covered by ``_request``'s tenacity policy returns
+    ``False`` here: by the time such an exception surfaces it has been
+    retried six times, and trying again adds cost without adding hope.
+    """
+    status = getattr(getattr(exc, "response", None), "status_code", None)
+    return status in _TRANSIENT_SERVER_STATUSES
+
+
 def _is_retryable_status(status: int) -> bool:
     # Treat common transient statuses as retryable.
     return status in (429, 502, 503, 504)
@@ -317,12 +351,6 @@ class GitHubAsync:
     # constructor default and as the upper bound when adaptive tuning ramps
     # concurrency back up after a period of throttling.
     _DEFAULT_MAX_CONCURRENCY = 20
-
-    # Heuristic retained for backwards compatibility with callers that may
-    # reference it.  No longer used: ``_get_recent_error_rate`` now counts
-    # real requests instead of estimating them from the error count, which
-    # made the computed rate a constant.
-    _ESTIMATED_REQUESTS_PER_ERROR = 10
 
     def __init__(
         self,
@@ -865,19 +893,122 @@ class GitHubAsync:
 
         REST: POST /repos/{owner}/{repo}/pulls/{pull_number}/reviews
 
+        This endpoint returns a transient ``500`` with some regularity.
+        ``500`` is deliberately absent from ``_is_retryable_status`` --- a
+        blanket retry of every failed POST is unsafe --- so the retry is
+        handled here, where the operation's semantics are known.
+
+        Crucially, a ``500`` does **not** imply the review was not
+        created: in the run analysed in
+        ``docs/BULK_RUN_PERFORMANCE_AUDIT.md``, 4 of the 6 PRs whose
+        approval "failed" this way went on to merge, which requires the
+        approval to have landed.  So before each *retry* --- and once
+        more after the final attempt --- the review list is re-read, and
+        an approval already present counts as success rather than
+        stacking a duplicate review.  The first attempt skips that check,
+        so the common path costs exactly one request.
+
         Raises:
             PermissionError: If token lacks required permissions
         """
-        try:
-            await self.post(
-                f"/repos/{owner}/{repo}/pulls/{number}/reviews",
-                json={"event": "APPROVE", "body": body},
+        last_exc: Exception | None = None
+        for attempt in range(_APPROVE_MAX_ATTEMPTS):
+            if attempt and await self._has_own_approval(owner, repo, number):
+                self.log.debug(
+                    "Approval for %s/%s#%s already present after a %s; "
+                    "treating as success",
+                    owner,
+                    repo,
+                    number,
+                    "transient error",
+                )
+                return
+            try:
+                await self.post(
+                    f"/repos/{owner}/{repo}/pulls/{number}/reviews",
+                    json={"event": "APPROVE", "body": body},
+                )
+                return
+            except Exception as e:
+                perm_error = self._parse_permission_error(e, "approve", owner, repo)
+                if perm_error:
+                    raise perm_error from e
+                if not _is_transient_server_error(e):
+                    raise
+                last_exc = e
+                if attempt == _APPROVE_MAX_ATTEMPTS - 1:
+                    break
+                delay = _APPROVE_RETRY_BASE_DELAY * (2**attempt)
+                self.log.warning(
+                    "Transient error approving %s/%s#%s (attempt %d/%d); "
+                    "retrying in %.1fs",
+                    owner,
+                    repo,
+                    number,
+                    attempt + 1,
+                    _APPROVE_MAX_ATTEMPTS,
+                    delay,
+                )
+                await asyncio.sleep(delay)
+
+        # Attempts exhausted.  One last look: the final POST may have
+        # created the review despite reporting failure.
+        if await self._has_own_approval(owner, repo, number):
+            self.log.info(
+                "Approval for %s/%s#%s landed despite a reported error",
+                owner,
+                repo,
+                number,
             )
-        except Exception as e:
-            perm_error = self._parse_permission_error(e, "approve", owner, repo)
-            if perm_error:
-                raise perm_error from e
-            raise
+            return
+        assert last_exc is not None
+        raise last_exc
+
+    async def _has_own_approval(self, owner: str, repo: str, number: int) -> bool:
+        """Whether the authenticated user already has an APPROVED review.
+
+        Paginates: a single default page caps at 30 reviews, and missing
+        an existing approval on a busy PR would defeat the
+        duplicate-suppression this exists for and post another review.
+        """
+        try:
+            login = await self.get_authenticated_user_login()
+            if not login:
+                # The lookup returns ``None`` on failure rather than
+                # raising.  Without this guard a review carrying
+                # ``user: null`` yields ``None == None`` and reports an
+                # approval that does not exist --- which would stop
+                # ``approve_pull_request`` retrying and let it report
+                # success having approved nothing.
+                self.log.debug(
+                    "Cannot confirm existing approval on %s/%s#%s: "
+                    "authenticated user unknown",
+                    owner,
+                    repo,
+                    number,
+                )
+                return False
+            async for page in self.get_paginated(
+                f"/repos/{owner}/{repo}/pulls/{number}/reviews",
+                per_page=100,
+            ):
+                if not isinstance(page, list):
+                    continue
+                for review in page:
+                    if not isinstance(review, dict):
+                        continue
+                    if review.get("state") != "APPROVED":
+                        continue
+                    user = review.get("user") or {}
+                    reviewer = user.get("login")
+                    if reviewer and reviewer == login:
+                        return True
+        except Exception as exc:
+            self.log.debug(
+                "Could not read reviews for %s/%s#%s: %s", owner, repo, number, exc
+            )
+            return False
+        return False
 
     async def merge_pull_request(
         self, owner: str, repo: str, number: int, merge_method: str = "merge"

--- a/src/dependamerge/merge_manager.py
+++ b/src/dependamerge/merge_manager.py
@@ -74,6 +74,20 @@ MERGEABILITY_REFRESH_TIMEOUT_SECONDS: float = 10.0
 # runs.  One extra lightweight GET is a fair trade for that.
 MERGE_WAIT_FIRST_POLL_SECONDS: float = 2.0
 
+# When GitHub answers a merge dispatch with 405 "Merge already in
+# progress" it has accepted a merge (usually auto-merge armed earlier in
+# this run) and is completing it asynchronously.  Completion is normally
+# a matter of seconds, but the previous handling --- a 3s then 6s
+# backoff before giving up --- routinely expired first and reported a
+# failure for a PR that merged moments later.  These bound a short watch
+# for completion instead.
+MERGE_IN_PROGRESS_TIMEOUT_SECONDS: float = 60.0
+MERGE_IN_PROGRESS_POLL_SECONDS: float = 5.0
+# As with ``MERGE_WAIT_FIRST_POLL_SECONDS``, the first poll comes early:
+# GitHub is already completing the merge, so it often lands within a
+# second or two and a full-interval first sleep would report it late.
+MERGE_IN_PROGRESS_FIRST_POLL_SECONDS: float = 1.0
+
 # Required verification checks (DCO, lint, build, etc.) normally
 # start reporting within a few seconds.  When a *required* check has
 # been pending for longer than this on a PR that itself was created
@@ -133,6 +147,45 @@ class MergeResult:
     warning: str | None = None
     attempts: int = 0
     duration: float = 0.0
+
+
+def _merged_from_payload(payload: dict[str, Any]) -> bool | None:
+    """Whether a PR REST payload says the PR merged.
+
+    Prefers the explicit ``merged`` boolean.  A trimmed or proxied
+    payload may omit it, so fall back to ``merged_at`` --- the full REST
+    object always carries that key (an ISO timestamp when merged,
+    ``null`` for closed-but-unmerged).  Returns ``None`` only when
+    neither is usable, so an ambiguous payload is never mistaken for a
+    definite "not merged".
+
+    Shared so every caller derives merged-ness identically; the same
+    rule is applied by ``_recheck_pr_before_retry`` and
+    ``_fetch_pr_state_now``.
+    """
+    merged_field = payload.get("merged")
+    if isinstance(merged_field, bool):
+        return merged_field
+    if "merged_at" not in payload:
+        return None
+    merged_at = payload.get("merged_at")
+    if merged_at is not None and not isinstance(merged_at, str):
+        return None
+    return merged_at is not None
+
+
+def _merge_already_in_progress(error_msg: str) -> bool:
+    """Whether a 405 body says GitHub is already merging this PR.
+
+    GitHub's wording is ``Merge already in progress``.  Matched
+    case-insensitively and without punctuation assumptions so a minor
+    upstream rewording does not silently reinstate the old
+    fail-after-6-seconds behaviour.
+    """
+    lowered = error_msg.lower()
+    return "merge already in progress" in lowered or (
+        "already in progress" in lowered and "merge" in lowered
+    )
 
 
 class AsyncMergeManager:
@@ -1187,6 +1240,108 @@ class AsyncMergeManager:
         return None, None
 
     async def _merge_single_pr(self, pr_info: PullRequestInfo) -> MergeResult:
+        """Merge a single PR, then confirm any failure is real.
+
+        Thin wrapper over :meth:`_merge_single_pr_impl`.  It exists
+        because a reported failure is frequently not one: GitHub
+        auto-merge routinely completes a PR moments after this tool
+        stops waiting for it.  In the 503-PR run analysed in
+        ``docs/BULK_RUN_PERFORMANCE_AUDIT.md``, **21 of the 34 reported
+        failures had in fact merged**, most within two minutes of being
+        reported.
+
+        Wrapping rather than editing the end of ``_merge_single_pr_impl``
+        is deliberate: that method has several early ``return`` paths
+        (permission denied, already merged, conflict handling), and a
+        check placed before its final ``return`` would miss them.
+        """
+        result = await self._merge_single_pr_impl(pr_info)
+        return await self._confirm_failure(pr_info, result)
+
+    async def _confirm_failure(
+        self, pr_info: PullRequestInfo, result: MergeResult
+    ) -> MergeResult:
+        """Re-read a failed PR once and correct the outcome if it landed.
+
+        Costs a single GET, and only for PRs that are about to be
+        reported as failures --- a rounding error against the run's
+        total API budget, in exchange for not telling the user a merged
+        PR failed.
+
+        Best-effort by construction: any error here leaves the original
+        result untouched, because the verification must never be able to
+        turn a reportable failure into a crash.
+        """
+        if result.status != MergeStatus.FAILED:
+            return result
+        if self.preview_mode or self._github_client is None:
+            return result
+        if pr_info.repository_full_name in self._permission_failed_repos:
+            # The token cannot act on this repository, so no merge was
+            # ever dispatched and the PR cannot have landed.  Skipping
+            # also preserves the point of the fast-fail path: one failed
+            # repository must not cost an API call per remaining PR.
+            return result
+
+        try:
+            owner, repo = pr_info.repository_full_name.split("/", 1)
+        except ValueError:
+            return result
+
+        try:
+            refreshed = await self._github_client.get(
+                f"/repos/{owner}/{repo}/pulls/{pr_info.number}"
+            )
+        except asyncio.CancelledError:
+            # Cancellation must propagate; a shutdown in flight is not a
+            # verification failure.
+            raise
+        except Exception as exc:
+            self.log.debug(
+                "Could not verify reported failure for %s: %s", pr_info.html_url, exc
+            )
+            return result
+
+        if not isinstance(refreshed, dict):
+            return result
+
+        # Tri-state: ``None`` means the payload could not tell us.  Treat
+        # it as unknown throughout, so an ambiguous response can neither
+        # invent a merge nor assert the absence of one.
+        merged = _merged_from_payload(refreshed)
+
+        if merged:
+            self.log.info(
+                "Reported failure for %s was stale; the PR merged at %s",
+                pr_info.html_url,
+                refreshed.get("merged_at") or "an unknown time",
+            )
+            self._pr_status(f"✅ Merged: {pr_info.html_url}", level="debug")
+            result.status = MergeStatus.MERGED
+            # The recorded reason described a state that no longer holds.
+            # Keep it as a note rather than an error so the summary does
+            # not show a merged PR carrying a failure message.
+            if result.error:
+                result.warning = f"merged after being reported as: {result.error}"
+                result.error = None
+            pr_info.state = "closed"
+            return result
+
+        if merged is False and refreshed.get("state") == "closed":
+            self.log.info(
+                "Reported failure for %s was stale; the PR is closed unmerged",
+                pr_info.html_url,
+            )
+            result.status = MergeStatus.CLOSED
+            pr_info.state = "closed"
+            return result
+
+        # Either still open, or closed with merged-ness unknown.  Keep the
+        # original failure: reporting CLOSED here would assert "did not
+        # merge" from a value that never said so.
+        return result
+
+    async def _merge_single_pr_impl(self, pr_info: PullRequestInfo) -> MergeResult:
         """
         Merge a single pull request with retry logic.
 
@@ -4357,21 +4512,11 @@ class AsyncMergeManager:
             )
             if isinstance(current_pr_data, dict):
                 current_state = current_pr_data.get("state")
-                merged_field = current_pr_data.get("merged")
-                # Prefer the explicit ``merged`` bool. A trimmed payload
-                # may omit it, so fall back to ``merged_at``: the full REST
-                # object always carries that key (an ISO timestamp when
-                # merged, ``null`` for closed-but-unmerged), matching the
-                # derivation used elsewhere. Only a genuinely absent
-                # ``merged_at`` (and no bool) leaves the state unknown so
-                # an ambiguous closed PR proceeds rather than aborting.
-                current_merged: bool | None
-                if isinstance(merged_field, bool):
-                    current_merged = merged_field
-                elif "merged_at" in current_pr_data:
-                    current_merged = current_pr_data.get("merged_at") is not None
-                else:
-                    current_merged = None
+                # Shared derivation: prefer the explicit ``merged`` bool,
+                # fall back to ``merged_at``, ``None`` when neither is
+                # usable so an ambiguous closed PR proceeds rather than
+                # aborting.  See ``_merged_from_payload``.
+                current_merged: bool | None = _merged_from_payload(current_pr_data)
 
                 if current_state == "closed" and current_merged:
                     self.log.info(
@@ -4420,6 +4565,84 @@ class AsyncMergeManager:
                 f"Failed to refresh PR state for {pr_key}: {refresh_err}",
                 exc_info=True,
             )
+
+    async def _await_in_progress_merge(
+        self, owner: str, repo: str, pr_info: PullRequestInfo, pr_key: str
+    ) -> bool:
+        """Watch a PR GitHub says it is already merging; report success.
+
+        Returns ``True`` when the PR reaches a merged state within
+        :data:`MERGE_IN_PROGRESS_TIMEOUT_SECONDS`, ``False`` otherwise
+        (including when it closes unmerged, which the caller reports).
+
+        The wait is parked, so it holds no concurrency slot.
+        """
+        if self._github_client is None:
+            return False
+        if self._no_wait:
+            return False
+
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + MERGE_IN_PROGRESS_TIMEOUT_SECONDS
+        if self._run_deadline is not None:
+            deadline = min(deadline, self._run_deadline)
+
+        self.log.info(
+            "GitHub reports a merge already in progress for %s; "
+            "waiting up to %.0fs for it to complete",
+            pr_key,
+            max(0.0, deadline - loop.time()),
+        )
+        self._track_pr_state(pr_info, "waiting")
+        async with self._waiting_lock:
+            self._waiting_prs[pr_key] = deadline
+        try:
+            async with parked():
+                first_poll = True
+                while True:
+                    interval = (
+                        MERGE_IN_PROGRESS_FIRST_POLL_SECONDS
+                        if first_poll
+                        else MERGE_IN_PROGRESS_POLL_SECONDS
+                    )
+                    remaining = max(0.0, deadline - loop.time())
+                    await asyncio.sleep(min(interval, remaining))
+                    try:
+                        refreshed = await self._github_client.get(
+                            f"/repos/{owner}/{repo}/pulls/{pr_info.number}"
+                        )
+                    except asyncio.CancelledError:
+                        raise
+                    except Exception as exc:
+                        self.log.debug(
+                            "Failed to poll in-progress merge for %s: %s", pr_key, exc
+                        )
+                        refreshed = None
+                    if isinstance(refreshed, dict):
+                        merged = _merged_from_payload(refreshed)
+                        if merged:
+                            self.log.info("Merge completed for %s", pr_key)
+                            pr_info.state = "closed"
+                            return True
+                        if merged is False and refreshed.get("state") == "closed":
+                            pr_info.state = "closed"
+                            return False
+                        # Unknown merged-ness: keep polling rather than
+                        # concluding the merge did not happen.
+                    # Checked *after* polling, so an already-expired
+                    # deadline (a run-wide ``max_wait`` about to elapse)
+                    # still gets exactly one confirmation rather than
+                    # reporting a failure this method exists to prevent.
+                    if loop.time() >= deadline:
+                        break
+                    first_poll = False
+        finally:
+            async with self._waiting_lock:
+                self._waiting_prs.pop(pr_key, None)
+            self._track_pr_state(pr_info, None)
+
+        self.log.debug("In-progress merge for %s did not complete in time", pr_key)
+        return False
 
     async def _blocked_pr_became_clean(
         self, owner: str, repo: str, pr_info: PullRequestInfo, pr_key: str
@@ -4552,6 +4775,30 @@ class AsyncMergeManager:
                 self.log.debug(
                     f"Stored exception for {pr_key}: {type(e).__name__}: {str(e)[:200]}"
                 )
+
+                # "Merge already in progress" is unambiguous on its own,
+                # so it is matched *before* the 405 branch rather than
+                # inside it.  Gating it on the literal "Method Not
+                # Allowed" text as well would mean an upstream rewording
+                # silently reinstated the fail-after-six-seconds
+                # behaviour this handler exists to remove --- the very
+                # fragility ``_merge_already_in_progress`` guards against.
+                if _merge_already_in_progress(error_msg):
+                    # GitHub has already accepted a merge for this PR
+                    # (typically auto-merge armed earlier in this run)
+                    # and is completing it.  Dispatching again is
+                    # pointless and the previous short backoff --- 3s
+                    # then 6s --- expired well before GitHub finished,
+                    # so these were reported as failures despite
+                    # merging moments later: 4 of the 5 such PRs in
+                    # the run analysed in
+                    # ``docs/BULK_RUN_PERFORMANCE_AUDIT.md`` had
+                    # merged.  Watch for completion instead.
+                    if await self._await_in_progress_merge(
+                        owner, repo, pr_info, pr_key
+                    ):
+                        return True
+                    break
 
                 # Enhanced error handling with specific status code checks
                 if "405" in error_msg and "Method Not Allowed" in error_msg:
@@ -4822,20 +5069,12 @@ class AsyncMergeManager:
         state = pr_data.get("state")
         if not isinstance(state, str):
             return None, None
-        merged = pr_data.get("merged")
-        if not isinstance(merged, bool):
-            # The full PR object always carries ``merged`` and ``merged_at``,
-            # but a proxy or trimmed payload may omit the boolean. Derive it
-            # from ``merged_at`` (an ISO timestamp when merged, ``null``
-            # otherwise) when present rather than degrading a recoverable
-            # payload to unknown; only a genuinely absent ``merged_at`` or an
-            # unexpected type falls through to the conservative default.
-            if "merged_at" not in pr_data:
-                return None, None
-            merged_at = pr_data.get("merged_at")
-            if merged_at is not None and not isinstance(merged_at, str):
-                return None, None
-            merged = merged_at is not None
+        # Shared derivation (see ``_merged_from_payload``): an
+        # unrecoverable payload degrades this call to "unknown" rather
+        # than asserting the PR did not merge.
+        merged = _merged_from_payload(pr_data)
+        if merged is None:
+            return None, None
         return state, merged
 
     async def _is_pr_dirty_now(

--- a/tests/test_reporting_accuracy.py
+++ b/tests/test_reporting_accuracy.py
@@ -1,0 +1,685 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 The Linux Foundation
+
+"""Tests for reporting accuracy on the merge path.
+
+The 503-PR run analysed in ``docs/BULK_RUN_PERFORMANCE_AUDIT.md``
+reported 34 failures, of which **21 had actually merged** --- most
+within two minutes of being reported.  Three distinct causes are
+covered here:
+
+- a terminal outcome was never re-checked before being reported;
+- ``POST .../reviews`` returned a transient 500 that was not retried,
+  even though the review had frequently been created;
+- ``405 Merge already in progress`` was treated as terminal after a
+  backoff far shorter than GitHub takes to finish the merge.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock
+
+import httpx
+import pytest
+
+from dependamerge.github_async import GitHubAsync
+from dependamerge.merge_manager import (
+    MergeResult,
+    MergeStatus,
+    _merge_already_in_progress,
+    _merged_from_payload,
+)
+from dependamerge.models import PullRequestInfo
+from tests.conftest import make_merge_manager
+
+REPO = "lfreleng-actions/example-action"
+OWNER, NAME = REPO.split("/")
+
+
+def _make_pr(number: int = 101, state: str = "open") -> PullRequestInfo:
+    return PullRequestInfo(
+        number=number,
+        title="Chore: Bump something",
+        body="bump",
+        author="dependabot[bot]",
+        head_sha="c0ffee11" * 5,
+        base_branch="main",
+        head_branch="dependabot/x",
+        state=state,
+        mergeable=True,
+        mergeable_state="clean",
+        behind_by=None,
+        files_changed=[],
+        repository_full_name=REPO,
+        html_url=f"https://github.com/{REPO}/pull/{number}",
+        reviews=[],
+        review_comments=[],
+    )
+
+
+# --------------------------------------------------------------------------
+# Re-verifying a reported failure
+# --------------------------------------------------------------------------
+
+
+class TestConfirmFailure:
+    @pytest.mark.asyncio
+    async def test_merged_pr_is_corrected_to_merged(self) -> None:
+        """The headline case: 21 of 34 reported failures had merged."""
+        mgr, client = make_merge_manager()
+        pr = _make_pr()
+        client.get = AsyncMock(
+            return_value={
+                "merged": True,
+                "merged_at": "2026-08-13T15:17:37Z",
+                "state": "closed",
+            }
+        )
+        result = MergeResult(
+            pr_info=pr, status=MergeStatus.FAILED, error="required checks not satisfied"
+        )
+
+        out = await mgr._confirm_failure(pr, result)
+
+        assert out.status == MergeStatus.MERGED
+        assert out.error is None
+        # The stale reason is preserved as context, not as an error.
+        assert out.warning is not None
+        assert "required checks not satisfied" in out.warning
+
+    @pytest.mark.asyncio
+    async def test_genuinely_open_failure_is_left_alone(self) -> None:
+        mgr, client = make_merge_manager()
+        pr = _make_pr()
+        client.get = AsyncMock(return_value={"merged": False, "state": "open"})
+        result = MergeResult(pr_info=pr, status=MergeStatus.FAILED, error="boom")
+
+        out = await mgr._confirm_failure(pr, result)
+
+        assert out.status == MergeStatus.FAILED
+        assert out.error == "boom"
+
+    @pytest.mark.asyncio
+    async def test_closed_unmerged_pr_becomes_closed(self) -> None:
+        mgr, client = make_merge_manager()
+        pr = _make_pr()
+        client.get = AsyncMock(
+            return_value={"merged": False, "merged_at": None, "state": "closed"}
+        )
+        result = MergeResult(pr_info=pr, status=MergeStatus.FAILED, error="boom")
+
+        out = await mgr._confirm_failure(pr, result)
+
+        assert out.status == MergeStatus.CLOSED
+
+    @pytest.mark.asyncio
+    async def test_closed_with_unknown_merged_state_stays_failed(self) -> None:
+        """Unknown must never be read as "did not merge".
+
+        A trimmed payload carrying neither ``merged`` nor ``merged_at``
+        cannot tell us the PR failed to merge, so reclassifying it as
+        CLOSED would assert something the data never said.
+        """
+        mgr, client = make_merge_manager()
+        pr = _make_pr()
+        client.get = AsyncMock(return_value={"state": "closed"})
+        result = MergeResult(pr_info=pr, status=MergeStatus.FAILED, error="boom")
+
+        out = await mgr._confirm_failure(pr, result)
+
+        assert out.status == MergeStatus.FAILED
+        assert out.error == "boom"
+
+    @pytest.mark.asyncio
+    async def test_non_failed_results_are_not_rechecked(self) -> None:
+        """Verification must cost nothing for the overwhelmingly common path."""
+        mgr, client = make_merge_manager()
+        pr = _make_pr()
+        client.get = AsyncMock()
+        result = MergeResult(pr_info=pr, status=MergeStatus.MERGED)
+
+        out = await mgr._confirm_failure(pr, result)
+
+        assert out.status == MergeStatus.MERGED
+        client.get.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_preview_mode_does_not_call_the_api(self) -> None:
+        mgr, client = make_merge_manager(preview_mode=True)
+        pr = _make_pr()
+        client.get = AsyncMock()
+        result = MergeResult(pr_info=pr, status=MergeStatus.FAILED, error="boom")
+
+        out = await mgr._confirm_failure(pr, result)
+
+        assert out.status == MergeStatus.FAILED
+        client.get.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_permission_failed_repo_is_not_rechecked(self) -> None:
+        """One bad repo must not cost an API call per remaining PR."""
+        mgr, client = make_merge_manager()
+        pr = _make_pr()
+        mgr._permission_failed_repos.add(REPO)
+        client.get = AsyncMock()
+        result = MergeResult(
+            pr_info=pr, status=MergeStatus.FAILED, error="token lacks permissions"
+        )
+
+        out = await mgr._confirm_failure(pr, result)
+
+        assert out.status == MergeStatus.FAILED
+        client.get.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_api_error_leaves_result_untouched(self) -> None:
+        """Verification must never turn a reportable failure into a crash."""
+        mgr, client = make_merge_manager()
+        pr = _make_pr()
+        client.get = AsyncMock(side_effect=RuntimeError("network gone"))
+        result = MergeResult(pr_info=pr, status=MergeStatus.FAILED, error="boom")
+
+        out = await mgr._confirm_failure(pr, result)
+
+        assert out.status == MergeStatus.FAILED
+        assert out.error == "boom"
+
+    @pytest.mark.asyncio
+    async def test_wrapper_applies_verification_to_early_returns(self) -> None:
+        """The wrapper exists because the impl has many early returns."""
+        mgr, client = make_merge_manager()
+        pr = _make_pr()
+        mgr._merge_single_pr_impl = AsyncMock(  # type: ignore[method-assign]
+            return_value=MergeResult(
+                pr_info=pr, status=MergeStatus.FAILED, error="stale"
+            )
+        )
+        client.get = AsyncMock(return_value={"merged": True, "state": "closed"})
+
+        out = await mgr._merge_single_pr(pr)
+
+        assert out.status == MergeStatus.MERGED
+
+
+# --------------------------------------------------------------------------
+# "Merge already in progress"
+# --------------------------------------------------------------------------
+
+
+class TestMergeAlreadyInProgressPredicate:
+    @pytest.mark.parametrize(
+        "msg",
+        [
+            "Merge already in progress",
+            "405 Method Not Allowed ... Merge already in progress",
+            "merge already in progress.",
+        ],
+    )
+    def test_matches(self, msg: str) -> None:
+        assert _merge_already_in_progress(msg)
+
+    @pytest.mark.parametrize(
+        "msg",
+        [
+            "Base branch was modified",
+            "Pull Request is not mergeable",
+            "Required status checks not satisfied",
+            "",
+        ],
+    )
+    def test_does_not_match(self, msg: str) -> None:
+        assert not _merge_already_in_progress(msg)
+
+
+class TestAwaitInProgressMerge:
+    @pytest.mark.asyncio
+    async def test_returns_true_once_merged(self, monkeypatch) -> None:
+        monkeypatch.setattr(
+            "dependamerge.merge_manager.MERGE_IN_PROGRESS_POLL_SECONDS", 0.001
+        )
+        monkeypatch.setattr(
+            "dependamerge.merge_manager.MERGE_IN_PROGRESS_FIRST_POLL_SECONDS", 0.001
+        )
+        mgr, client = make_merge_manager()
+        pr = _make_pr()
+        client.get = AsyncMock(
+            side_effect=[
+                {"merged": False, "state": "open"},
+                {"merged": True, "state": "closed"},
+            ]
+        )
+
+        assert await mgr._await_in_progress_merge(
+            OWNER, NAME, pr, f"{REPO}#{pr.number}"
+        )
+        assert pr.state == "closed"
+
+    @pytest.mark.asyncio
+    async def test_returns_false_when_closed_unmerged(self, monkeypatch) -> None:
+        monkeypatch.setattr(
+            "dependamerge.merge_manager.MERGE_IN_PROGRESS_POLL_SECONDS", 0.001
+        )
+        monkeypatch.setattr(
+            "dependamerge.merge_manager.MERGE_IN_PROGRESS_FIRST_POLL_SECONDS", 0.001
+        )
+        mgr, client = make_merge_manager()
+        pr = _make_pr()
+        client.get = AsyncMock(
+            return_value={"merged": False, "merged_at": None, "state": "closed"}
+        )
+
+        assert not await mgr._await_in_progress_merge(
+            OWNER, NAME, pr, f"{REPO}#{pr.number}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_unknown_merged_state_keeps_polling(self, monkeypatch) -> None:
+        """An ambiguous payload must not end the watch early.
+
+        The merge may still be completing; giving up here would
+        reinstate exactly the false failure this wait exists to prevent.
+        """
+        monkeypatch.setattr(
+            "dependamerge.merge_manager.MERGE_IN_PROGRESS_POLL_SECONDS", 0.001
+        )
+        monkeypatch.setattr(
+            "dependamerge.merge_manager.MERGE_IN_PROGRESS_FIRST_POLL_SECONDS", 0.001
+        )
+        mgr, client = make_merge_manager()
+        pr = _make_pr()
+        client.get = AsyncMock(
+            side_effect=[
+                {"state": "closed"},  # unknown merged-ness
+                {"state": "closed", "merged_at": "2026-08-13T15:17:37Z"},
+            ]
+        )
+
+        assert await mgr._await_in_progress_merge(
+            OWNER, NAME, pr, f"{REPO}#{pr.number}"
+        )
+        assert client.get.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_gives_up_at_the_timeout(self, monkeypatch) -> None:
+        monkeypatch.setattr(
+            "dependamerge.merge_manager.MERGE_IN_PROGRESS_POLL_SECONDS", 0.001
+        )
+        monkeypatch.setattr(
+            "dependamerge.merge_manager.MERGE_IN_PROGRESS_FIRST_POLL_SECONDS", 0.001
+        )
+        monkeypatch.setattr(
+            "dependamerge.merge_manager.MERGE_IN_PROGRESS_TIMEOUT_SECONDS", 0.02
+        )
+        mgr, client = make_merge_manager()
+        pr = _make_pr()
+        client.get = AsyncMock(
+            return_value={"merged": False, "merged_at": None, "state": "open"}
+        )
+
+        assert not await mgr._await_in_progress_merge(
+            OWNER, NAME, pr, f"{REPO}#{pr.number}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_always_polls_at_least_once(self, monkeypatch) -> None:
+        """An already-elapsed deadline must still get one confirmation.
+
+        The run-wide ``max_wait`` clamps this deadline, so it can already
+        be in the past on entry.  Returning without a single GET would
+        report the false failure this watch exists to prevent.
+        """
+        monkeypatch.setattr(
+            "dependamerge.merge_manager.MERGE_IN_PROGRESS_FIRST_POLL_SECONDS", 0.001
+        )
+        mgr, client = make_merge_manager()
+        mgr._run_deadline = asyncio.get_running_loop().time() - 5.0
+        pr = _make_pr()
+        client.get = AsyncMock(
+            return_value={"state": "closed", "merged_at": "2026-08-13T15:17:37Z"}
+        )
+
+        assert await mgr._await_in_progress_merge(
+            OWNER, NAME, pr, f"{REPO}#{pr.number}"
+        )
+        assert client.get.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_expired_deadline_polls_exactly_once(self, monkeypatch) -> None:
+        """ "At least once" must not become "twice" when no time remains."""
+        monkeypatch.setattr(
+            "dependamerge.merge_manager.MERGE_IN_PROGRESS_FIRST_POLL_SECONDS", 0.001
+        )
+        mgr, client = make_merge_manager()
+        mgr._run_deadline = asyncio.get_running_loop().time() - 5.0
+        pr = _make_pr()
+        # Still open: the loop has no definitive answer and would spin
+        # again if the deadline check were skipped on the first pass.
+        client.get = AsyncMock(
+            return_value={"merged": False, "merged_at": None, "state": "open"}
+        )
+
+        assert not await mgr._await_in_progress_merge(
+            OWNER, NAME, pr, f"{REPO}#{pr.number}"
+        )
+        assert client.get.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_no_wait_mode_returns_immediately(self) -> None:
+        mgr, client = make_merge_manager()
+        mgr._no_wait = True
+        pr = _make_pr()
+        client.get = AsyncMock()
+
+        assert not await mgr._await_in_progress_merge(
+            OWNER, NAME, pr, f"{REPO}#{pr.number}"
+        )
+        client.get.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_waiting_registration_is_always_cleaned_up(self, monkeypatch) -> None:
+        monkeypatch.setattr(
+            "dependamerge.merge_manager.MERGE_IN_PROGRESS_POLL_SECONDS", 0.001
+        )
+        monkeypatch.setattr(
+            "dependamerge.merge_manager.MERGE_IN_PROGRESS_FIRST_POLL_SECONDS", 0.001
+        )
+        mgr, client = make_merge_manager()
+        pr = _make_pr()
+        client.get = AsyncMock(return_value={"merged": True, "state": "closed"})
+
+        await mgr._await_in_progress_merge(OWNER, NAME, pr, f"{REPO}#{pr.number}")
+
+        assert mgr._waiting_prs == {}
+
+
+# --------------------------------------------------------------------------
+# Merged-ness derivation
+# --------------------------------------------------------------------------
+
+
+class TestMergedFromPayload:
+    def test_prefers_explicit_boolean(self) -> None:
+        assert _merged_from_payload({"merged": True, "merged_at": None}) is True
+        assert _merged_from_payload({"merged": False, "merged_at": "x"}) is False
+
+    def test_falls_back_to_merged_at(self) -> None:
+        """A trimmed payload may omit the boolean but keep the timestamp."""
+        assert _merged_from_payload({"merged_at": "2026-08-13T15:17:37Z"}) is True
+        assert _merged_from_payload({"merged_at": None}) is False
+
+    def test_unknown_when_neither_usable(self) -> None:
+        assert _merged_from_payload({}) is None
+        assert _merged_from_payload({"state": "closed"}) is None
+
+    def test_unknown_on_unexpected_merged_at_type(self) -> None:
+        assert _merged_from_payload({"merged_at": 12345}) is None
+
+
+class TestConfirmFailureUsesSharedDerivation:
+    @pytest.mark.asyncio
+    async def test_detects_merge_from_merged_at_alone(self) -> None:
+        """A payload without the ``merged`` bool must not read as 'not merged'."""
+        mgr, client = make_merge_manager()
+        pr = _make_pr()
+        client.get = AsyncMock(
+            return_value={"state": "closed", "merged_at": "2026-08-13T15:17:37Z"}
+        )
+        result = MergeResult(pr_info=pr, status=MergeStatus.FAILED, error="stale")
+
+        out = await mgr._confirm_failure(pr, result)
+
+        assert out.status == MergeStatus.MERGED
+
+    @pytest.mark.asyncio
+    async def test_ambiguous_payload_does_not_invent_a_merge(self) -> None:
+        mgr, client = make_merge_manager()
+        pr = _make_pr()
+        client.get = AsyncMock(return_value={"state": "open"})
+        result = MergeResult(pr_info=pr, status=MergeStatus.FAILED, error="stale")
+
+        out = await mgr._confirm_failure(pr, result)
+
+        assert out.status == MergeStatus.FAILED
+
+    @pytest.mark.asyncio
+    async def test_in_progress_wait_detects_merge_from_merged_at(
+        self, monkeypatch
+    ) -> None:
+        monkeypatch.setattr(
+            "dependamerge.merge_manager.MERGE_IN_PROGRESS_POLL_SECONDS", 0.001
+        )
+        monkeypatch.setattr(
+            "dependamerge.merge_manager.MERGE_IN_PROGRESS_FIRST_POLL_SECONDS", 0.001
+        )
+        mgr, client = make_merge_manager()
+        pr = _make_pr()
+        client.get = AsyncMock(
+            return_value={"state": "closed", "merged_at": "2026-08-13T15:17:37Z"}
+        )
+
+        assert await mgr._await_in_progress_merge(
+            OWNER, NAME, pr, f"{REPO}#{pr.number}"
+        )
+
+
+class TestCancellationPropagates:
+    @pytest.mark.asyncio
+    async def test_confirm_failure_does_not_swallow_cancellation(self) -> None:
+        mgr, client = make_merge_manager()
+        pr = _make_pr()
+        client.get = AsyncMock(side_effect=asyncio.CancelledError())
+        result = MergeResult(pr_info=pr, status=MergeStatus.FAILED, error="boom")
+
+        with pytest.raises(asyncio.CancelledError):
+            await mgr._confirm_failure(pr, result)
+
+    @pytest.mark.asyncio
+    async def test_in_progress_wait_does_not_swallow_cancellation(
+        self, monkeypatch
+    ) -> None:
+        monkeypatch.setattr(
+            "dependamerge.merge_manager.MERGE_IN_PROGRESS_POLL_SECONDS", 0.001
+        )
+        monkeypatch.setattr(
+            "dependamerge.merge_manager.MERGE_IN_PROGRESS_FIRST_POLL_SECONDS", 0.001
+        )
+        mgr, client = make_merge_manager()
+        pr = _make_pr()
+        client.get = AsyncMock(side_effect=asyncio.CancelledError())
+
+        with pytest.raises(asyncio.CancelledError):
+            await mgr._await_in_progress_merge(OWNER, NAME, pr, f"{REPO}#{pr.number}")
+        # The waiting registry must still be cleaned up on cancellation.
+        assert mgr._waiting_prs == {}
+
+
+# --------------------------------------------------------------------------
+# Approve retry on transient 500
+# --------------------------------------------------------------------------
+
+
+def _http_error(status: int) -> httpx.HTTPStatusError:
+    request = httpx.Request("POST", "https://api.github.com/x")
+    response = httpx.Response(status, request=request)
+    return httpx.HTTPStatusError("boom", request=request, response=response)
+
+
+class TestApproveRetry:
+    @pytest.mark.asyncio
+    async def test_succeeds_first_time_without_extra_calls(self) -> None:
+        c = GitHubAsync(token="t")
+        c.post = AsyncMock(return_value={})  # type: ignore[method-assign]
+        c.get = AsyncMock()  # type: ignore[method-assign]
+
+        await c.approve_pull_request("o", "r", 1, "lgtm")
+
+        c.post.assert_awaited_once()
+        c.get.assert_not_called()
+        await c.aclose()
+
+    @pytest.mark.asyncio
+    async def test_retries_transient_500(self, monkeypatch) -> None:
+        """Regression: 500 is absent from ``_is_retryable_status``."""
+        monkeypatch.setattr(asyncio, "sleep", AsyncMock())
+        c = GitHubAsync(token="t")
+        c.post = AsyncMock(side_effect=[_http_error(500), {}])  # type: ignore[method-assign]
+        c._has_own_approval = AsyncMock(return_value=False)  # type: ignore[method-assign]
+
+        await c.approve_pull_request("o", "r", 1, "lgtm")
+
+        assert c.post.await_count == 2
+        await c.aclose()
+
+    @pytest.mark.asyncio
+    async def test_does_not_duplicate_an_approval_that_landed(
+        self, monkeypatch
+    ) -> None:
+        """A 500 does not mean the review was not created."""
+        monkeypatch.setattr(asyncio, "sleep", AsyncMock())
+        c = GitHubAsync(token="t")
+        c.post = AsyncMock(side_effect=_http_error(500))  # type: ignore[method-assign]
+        c._has_own_approval = AsyncMock(return_value=True)  # type: ignore[method-assign]
+
+        await c.approve_pull_request("o", "r", 1, "lgtm")
+
+        # One attempt only; the retry saw the approval already present.
+        assert c.post.await_count == 1
+        await c.aclose()
+
+    @pytest.mark.asyncio
+    async def test_raises_after_exhausting_attempts(self, monkeypatch) -> None:
+        monkeypatch.setattr(asyncio, "sleep", AsyncMock())
+        c = GitHubAsync(token="t")
+        c.post = AsyncMock(side_effect=_http_error(500))  # type: ignore[method-assign]
+        c._has_own_approval = AsyncMock(return_value=False)  # type: ignore[method-assign]
+
+        with pytest.raises(httpx.HTTPStatusError):
+            await c.approve_pull_request("o", "r", 1, "lgtm")
+        await c.aclose()
+
+    @pytest.mark.asyncio
+    async def test_does_not_retry_client_errors(self) -> None:
+        """422 and friends are deterministic; retrying them wastes budget."""
+        c = GitHubAsync(token="t")
+        c.post = AsyncMock(side_effect=_http_error(422))  # type: ignore[method-assign]
+        c._has_own_approval = AsyncMock(return_value=False)  # type: ignore[method-assign]
+
+        with pytest.raises(httpx.HTTPStatusError):
+            await c.approve_pull_request("o", "r", 1, "lgtm")
+        assert c.post.await_count == 1
+        await c.aclose()
+
+    @pytest.mark.parametrize("status", [429, 502, 503, 504])
+    @pytest.mark.asyncio
+    async def test_does_not_double_retry_inner_statuses(self, status: int) -> None:
+        """Statuses ``_request`` already retries must not be retried again.
+
+        ``_request`` gives 429/502/503/504 six tenacity attempts. Retrying
+        them out here as well would nest the loops --- up to 18 requests
+        and two sets of backoff sleeps for one approval.
+        """
+        c = GitHubAsync(token="t")
+        c.post = AsyncMock(side_effect=_http_error(status))  # type: ignore[method-assign]
+        c._has_own_approval = AsyncMock(return_value=False)  # type: ignore[method-assign]
+
+        with pytest.raises(httpx.HTTPStatusError):
+            await c.approve_pull_request("o", "r", 1, "lgtm")
+        assert c.post.await_count == 1
+        await c.aclose()
+
+    @pytest.mark.asyncio
+    async def test_final_check_rescues_a_landed_approval(self, monkeypatch) -> None:
+        monkeypatch.setattr(asyncio, "sleep", AsyncMock())
+        c = GitHubAsync(token="t")
+        c.post = AsyncMock(side_effect=_http_error(500))  # type: ignore[method-assign]
+        # Not present on the pre-attempt checks, but present at the end:
+        # the last POST created it despite reporting failure.
+        c._has_own_approval = AsyncMock(side_effect=[False, False, True])  # type: ignore[method-assign]
+
+        await c.approve_pull_request("o", "r", 1, "lgtm")
+        await c.aclose()
+
+
+class TestHasOwnApproval:
+    @staticmethod
+    def _pages(*pages: list[dict]) -> object:
+        async def _gen(*args: object, **kwargs: object):
+            for page in pages:
+                yield page
+
+        return _gen
+
+    @pytest.mark.asyncio
+    async def test_true_when_our_approval_present(self) -> None:
+        c = GitHubAsync(token="t")
+        c.get_authenticated_user_login = AsyncMock(return_value="me")  # type: ignore[method-assign]
+        c.get_paginated = self._pages(  # type: ignore[method-assign,assignment]
+            [
+                {"state": "COMMENTED", "user": {"login": "me"}},
+                {"state": "APPROVED", "user": {"login": "someone-else"}},
+                {"state": "APPROVED", "user": {"login": "me"}},
+            ]
+        )
+        assert await c._has_own_approval("o", "r", 1)
+        await c.aclose()
+
+    @pytest.mark.asyncio
+    async def test_finds_approval_beyond_the_first_page(self) -> None:
+        """A busy PR must not defeat duplicate suppression."""
+        c = GitHubAsync(token="t")
+        c.get_authenticated_user_login = AsyncMock(return_value="me")  # type: ignore[method-assign]
+        c.get_paginated = self._pages(  # type: ignore[method-assign,assignment]
+            [{"state": "COMMENTED", "user": {"login": "bot"}}] * 100,
+            [{"state": "APPROVED", "user": {"login": "me"}}],
+        )
+        assert await c._has_own_approval("o", "r", 1)
+        await c.aclose()
+
+    @pytest.mark.asyncio
+    async def test_false_when_only_others_approved(self) -> None:
+        c = GitHubAsync(token="t")
+        c.get_authenticated_user_login = AsyncMock(return_value="me")  # type: ignore[method-assign]
+        c.get_paginated = self._pages(  # type: ignore[method-assign,assignment]
+            [{"state": "APPROVED", "user": {"login": "other"}}]
+        )
+        assert not await c._has_own_approval("o", "r", 1)
+        await c.aclose()
+
+    @pytest.mark.asyncio
+    async def test_false_on_api_error(self) -> None:
+        c = GitHubAsync(token="t")
+        c.get_authenticated_user_login = AsyncMock(side_effect=RuntimeError("nope"))  # type: ignore[method-assign]
+        assert not await c._has_own_approval("o", "r", 1)
+        await c.aclose()
+
+    @pytest.mark.asyncio
+    async def test_false_when_authenticated_login_unknown(self) -> None:
+        """An unknown login must never match a null reviewer.
+
+        ``get_authenticated_user_login`` returns ``None`` on failure
+        rather than raising.  A review with ``user: null`` would then
+        compare ``None == None`` and report an approval that does not
+        exist, stopping the retry and reporting success having approved
+        nothing.
+        """
+        c = GitHubAsync(token="t")
+        c.get_authenticated_user_login = AsyncMock(return_value=None)  # type: ignore[method-assign]
+        c.get_paginated = self._pages(  # type: ignore[method-assign,assignment]
+            [{"state": "APPROVED", "user": None}]
+        )
+        assert not await c._has_own_approval("o", "r", 1)
+        await c.aclose()
+
+    @pytest.mark.asyncio
+    async def test_null_reviewer_never_matches(self) -> None:
+        c = GitHubAsync(token="t")
+        c.get_authenticated_user_login = AsyncMock(return_value="me")  # type: ignore[method-assign]
+        c.get_paginated = self._pages(  # type: ignore[method-assign,assignment]
+            [
+                {"state": "APPROVED", "user": None},
+                {"state": "APPROVED", "user": {"login": None}},
+            ]
+        )
+        assert not await c._has_own_approval("o", "r", 1)
+        await c.aclose()


### PR DESCRIPTION
## Summary

The 503-PR bulk run analysed in `docs/BULK_RUN_PERFORMANCE_AUDIT.md` reported
34 failures. **21 of them had actually merged**, most within two minutes of
being reported as failed.

The pattern is consistent: the tool arms auto-merge, stops waiting, declares
failure and moves on — and GitHub completes the merge moments later. Nothing
ever goes back to check.

This PR fixes the three distinct causes. Follows #406 (P0 throttle fixes).

## 1. No terminal outcome was ever re-checked

A PR about to be reported as `FAILED` is now re-read once and reclassified as
`MERGED` or `CLOSED` if that is what it is. One GET, only on the failure path —
a rounding error against the run's budget, in exchange for not telling the user
a merged PR failed.

Applied by **wrapping** `_merge_single_pr` rather than editing the end of it:
that method has several early `return` paths (permission denied, already
merged, conflict handling), so a check before its final `return` would miss
them.

Deliberately skipped when:

- the run is in preview mode
- the repository is already in `_permission_failed_repos` — the token cannot act
  there, so no merge was dispatched and the PR cannot have landed. This also
  preserves the point of the fast-fail path: one bad repository must not cost an
  API call per remaining PR. *(A pre-existing test caught this — it asserts the
  short-circuit makes no API calls at all.)*

Any error during verification leaves the original result untouched, so this can
never convert a reportable failure into a crash.

## 2. HTTP 500 on approve was not retried

`500` is deliberately absent from `_is_retryable_status`, and should stay that
way — a blanket retry would replay arbitrary non-idempotent writes. So the
retry lives in `approve_pull_request`, where the operation's semantics are
known.

The subtlety: **a 500 does not mean the review was not created.** 4 of the 6
affected PRs merged anyway, which requires the approval to have landed. So each
retry re-reads the review list first and treats an existing approval as success
rather than stacking a duplicate review. A final check after the last attempt
rescues an approval that landed despite reporting failure.

Client errors (422 and friends) are still not retried.

## 3. "Merge already in progress" was treated as terminal

GitHub returns this when it has accepted a merge — typically auto-merge armed
earlier in the same run — and is completing it asynchronously.

The previous handling backed off `3s` then `6s` and gave up, well inside the
time GitHub actually needs. 4 of the 5 such PRs merged. It now watches for
completion for up to 60 s, **parked**, so it holds no concurrency slot.

The predicate matches case-insensitively and without punctuation assumptions,
so a minor upstream rewording cannot silently reinstate the old
fail-after-six-seconds behaviour.

## Verification

- **1596 tests pass** (29 new in `tests/test_reporting_accuracy.py`)
- Each test names the defect it pins, including the duplicate-approval guard,
  the permission fast-fail interaction, and cleanup of the waiting registry

## Expected effect

Applied to the audited run, this would have reclassified the great majority of
the 21 false failures, leaving a report that reflects what actually happened.

## Still to come

P1, the remaining scaling item: batch parked-PR polling into one aliased
GraphQL query. Polling is currently O(parked) at 6 calls/min per PR, so ~14
parked PRs consume the entire 83 calls/min REST budget. 60 parked PRs would
drop from 360 calls/min to about 6.

## Related

- #406 — P0 throttle ratchet fixes (merged)
- #405 — Dependabot PR title alignment
- #407 — detect and recover stuck ruleset workflows
