### PR TITLE
Fix: Bump PyPI publish action to v0.2.0

### DIFF
--- a/.github/workflows/build-test-release.yaml
+++ b/.github/workflows/build-test-release.yaml
@@ -70,7 +70,7 @@ jobs:
 
       - name: 'Test PyPI publishing'
         # yamllint disable-line rule:line-length
-        uses: lfreleng-actions/pypi-publish-action@8e46bf1bb34889591549c37d949d38fee1ab2d6b  # v0.1.9
+        uses: lfreleng-actions/pypi-publish-action@276603f5d72b11427755ef139c6fb80489cec5d9  # v0.2.0
         with:
           environment: development
           tag: ${{ needs.release.outputs.tag }}
@@ -105,7 +105,7 @@ jobs:
 
       - name: 'PyPI release'
         # yamllint disable-line rule:line-length
-        uses: lfreleng-actions/pypi-publish-action@8e46bf1bb34889591549c37d949d38fee1ab2d6b  # v0.1.9
+        uses: lfreleng-actions/pypi-publish-action@276603f5d72b11427755ef139c6fb80489cec5d9  # v0.2.0
         with:
           environment: production
           tag: ${{ needs.release.outputs.tag }}


### PR DESCRIPTION
Bumps the PyPI publish action **v0.1.9 → v0.2.0** at both call sites, before the next tagged release fails.

## Why this repository is affected

This project builds with Hatchling:

```toml
[build-system]
requires = ["hatchling>=1.24", "hatch-vcs>=0.4"]
build-backend = "hatchling.build"
```

Hatchling 1.30 and newer emit `Metadata-Version: 2.5` by default, and the constraint here has no upper bound, so builds already produce it. Verified by building from this branch:

```console
$ uv build
dependamerge-0.10.2.dev0-py3-none-any.whl
Metadata-Version: 2.5
```

The publish action pinned here carried a twine that rejects that value. **Checked the actual artefact against both versions:**

```console
# twine 6.2.0 — what the v0.1.9 backend shipped
Checking dependamerge-0.10.2.dev0-py3-none-any.whl: ERROR
  InvalidDistribution: Invalid distribution metadata: '2.5' is not a
  valid metadata version

# twine 7.0.0 — what the v0.2.0 backend ships
Checking dependamerge-0.10.2.dev0-py3-none-any.whl: PASSED
```

So this is not a speculative bump: the next tagged release would have failed at the Test PyPI step, exactly as `lftools-uv` did in [run 31725353675](https://github.com/lfreleng-actions/lftools-uv/actions/runs/31725353675/job/94533884530).

The rejection comes from twine **inside the publish container**, not from PyPI. twine replaces `packaging`'s list of valid metadata versions with its own hard-coded copy, so it could not be worked around from this repository.

## What else v0.2.0 brings

- **All 30 open dependency security advisories cleared** in the backend, including two majors on the attestation signing path (`cryptography` 46→50, `pyopenssl` 25→26).
- **A metadata-version canary** in the backend's own CI: its test stub is now built with an *unpinned* Hatchling, so the newest core metadata version is always exercised against the pinned twine. A future metadata bump now breaks a job there rather than a release here.

## Scope

Both call sites move together, so the **Test PyPI** and **PyPI** jobs stay on one version of the publish action. Splitting them would leave the production path broken while Test PyPI passed.

## Pin correctness

The tag is annotated, so the pinned value is the **commit** it points at, not the tag object:

```console
$ git rev-parse v0.2.0
8798fe4e79f0c221b92f2c94a9ac3455d9ac178e   # tag object — NOT this

$ git rev-parse 'v0.2.0^{commit}'
276603f5d72b11427755ef139c6fb80489cec5d9   # commit — pinned
```

## Verification

- **Zizmor** (`--persona auditor`): no findings, and the baseline on `main` for the same file is also clean — nothing introduced.
- Pre-commit hooks pass.

## Limitation

The OIDC exchange and the actual attestation signing call need an ambient credential and could not be exercised locally. The first real trusted-publishing run after this merge is the true end-to-end test of that path.
