### PR TITLE
Perf: Batch parked pull request state polling

### DIFF
--- a/src/dependamerge/merge_manager.py
+++ b/src/dependamerge/merge_manager.py
@@ -42,6 +42,7 @@ from .github_service import GitHubService
 from .models import ComparisonResult, PullRequestInfo
 from .netrc import NetrcParseError, resolve_gerrit_credentials
 from .output_utils import log_and_print
+from .pr_poller import PullRequestStatePoller
 from .progress_tracker import MergeProgressTracker
 from .slot_lease import holding_slot, parked
 
@@ -304,6 +305,7 @@ class AsyncMergeManager:
         self._merge_semaphore = asyncio.Semaphore(concurrency)
         self._results: list[MergeResult] = []
         self._github_client: GitHubAsync | None = None
+        self._pr_poller: PullRequestStatePoller | None = None
         self._github_service: GitHubService | None = None
         self._copilot_handler: CopilotCommentHandler | None = None
         # Reuse the progress tracker's Rich Console (when one is
@@ -424,6 +426,12 @@ class AsyncMergeManager:
         self._github_client = GitHubAsync(token=self.token)
         await self._github_client.__aenter__()
 
+        # Coalesces the wait loops' per-PR state reads into batched
+        # GraphQL queries.  See ``pr_poller`` for why: unbatched, polling
+        # costs 6 requests/min per parked PR, so ~14 parked PRs consume
+        # the entire REST budget doing nothing but asking for status.
+        self._pr_poller = PullRequestStatePoller(self._github_client, log=self.log)
+
         self._github_service = GitHubService(token=self.token)
 
         # Initialize Copilot handler if dismissal is enabled
@@ -440,6 +448,12 @@ class AsyncMergeManager:
             await self._github_service.close()
         if self._github_client:
             await self._github_client.__aexit__(exc_type, exc_val, exc_tb)
+        # Drop the poller and client together: the poller holds the now
+        # closed client, so leaving it in place would route any later
+        # ``_fetch_pr_state`` call into a use-after-close instead of the
+        # direct-read fallback that method documents.
+        self._pr_poller = None
+        self._github_client = None
 
     async def merge_prs_parallel(
         self,
@@ -4540,15 +4554,35 @@ class AsyncMergeManager:
             )
         return None
 
+    async def _fetch_pr_state(
+        self, owner: str, repo: str, number: int
+    ) -> dict[str, Any] | list[dict[str, Any]] | None:
+        """Read one PR's state, batched with any concurrent reads.
+
+        Routes through :class:`~dependamerge.pr_poller.PullRequestStatePoller`
+        so the wait loops' polling costs one GraphQL query per tick for the
+        whole run rather than one REST request per parked PR --- the
+        difference between ~6 and ~360 calls/minute at 60 parked PRs.  See
+        ``docs/BULK_RUN_PERFORMANCE_AUDIT.md`` §2.1.
+
+        Falls back to a direct REST read when no poller is configured,
+        which is the case for a manager used outside its async context
+        manager (notably unit tests).  The returned shape is identical
+        either way.
+        """
+        if self._pr_poller is not None:
+            return await self._pr_poller.fetch(owner, repo, number)
+        if self._github_client is None:
+            return None
+        return await self._github_client.get(f"/repos/{owner}/{repo}/pulls/{number}")
+
     async def _refresh_pr_mergeable(
         self, owner: str, repo: str, pr_info: PullRequestInfo, pr_key: str
     ) -> None:
         """Best-effort refresh of ``pr_info`` mergeable fields from the API."""
         try:
             if self._github_client:
-                refreshed = await self._github_client.get(
-                    f"/repos/{owner}/{repo}/pulls/{pr_info.number}"
-                )
+                refreshed = await self._fetch_pr_state(owner, repo, pr_info.number)
                 if isinstance(refreshed, dict):
                     pr_info.mergeable = refreshed.get("mergeable")
                     pr_info.mergeable_state = refreshed.get("mergeable_state")
@@ -4608,8 +4642,8 @@ class AsyncMergeManager:
                     remaining = max(0.0, deadline - loop.time())
                     await asyncio.sleep(min(interval, remaining))
                     try:
-                        refreshed = await self._github_client.get(
-                            f"/repos/{owner}/{repo}/pulls/{pr_info.number}"
+                        refreshed = await self._fetch_pr_state(
+                            owner, repo, pr_info.number
                         )
                     except asyncio.CancelledError:
                         raise
@@ -5195,9 +5229,7 @@ class AsyncMergeManager:
 
         while True:
             try:
-                data = await self._github_client.get(
-                    f"/repos/{owner}/{repo}/pulls/{pr_info.number}"
-                )
+                data = await self._fetch_pr_state(owner, repo, pr_info.number)
             except Exception as exc:
                 self.log.debug(
                     "Mergeability refresh failed for %s/%s#%s: %s",
@@ -5330,9 +5362,6 @@ class AsyncMergeManager:
         # PR's wait can push the whole run past ``max_wait``.
         if self._run_deadline is not None:
             deadline = min(deadline, self._run_deadline)
-        # Local alias so the type checker can narrow
-        # ``self._github_client`` across the await boundary.
-        wait_client = self._github_client
 
         async with self._waiting_lock:
             self._waiting_prs[pr_key] = deadline
@@ -5376,8 +5405,8 @@ class AsyncMergeManager:
                     remaining = max(0.0, deadline - loop.time())
                     await asyncio.sleep(min(interval, remaining))
                     try:
-                        refreshed_wait = await wait_client.get(
-                            f"/repos/{owner}/{repo}/pulls/{pr_info.number}"
+                        refreshed_wait = await self._fetch_pr_state(
+                            owner, repo, pr_info.number
                         )
                     except Exception as wait_exc:
                         self.log.debug(

--- a/src/dependamerge/pr_poller.py
+++ b/src/dependamerge/pr_poller.py
@@ -1,0 +1,347 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 The Linux Foundation
+
+"""Batched pull-request state polling.
+
+Every PR waiting on an external event (auto-merge, CI, a rebase) polls
+GitHub for its own state on a fixed cadence.  Done per PR over REST that
+costs one request per parked PR per tick --- measured at **6 API calls
+per minute per parked PR** during the 503-PR run analysed in
+``docs/BULK_RUN_PERFORMANCE_AUDIT.md``.
+
+Against an authenticated REST budget of 5000/hr (83 calls/min) that
+ceiling arrives fast:
+
+===========  ==================  =================
+Parked PRs   Polling calls/min   % of REST budget
+===========  ==================  =================
+5            30                  36%
+14           84                  100%
+40           240                 289%
+===========  ==================  =================
+
+Beyond roughly fourteen simultaneously parked PRs, polling alone consumes
+the entire budget asking "are you done yet?", which then trips the
+client's adaptive throttle and slows everything further --- the feedback
+loop behind the reported collapse after ~300 merges.
+
+This module removes the per-PR cost.  Concurrent reads arriving close
+together are coalesced into a single aliased GraphQL query, turning
+O(parked) requests per tick into O(1):
+
+.. code-block:: text
+
+    60 parked PRs, REST:     360 calls/min
+    60 parked PRs, batched:  ~6 calls/min
+
+Requests for the *same* PR share one in-flight result, so duplicate
+readers cost nothing extra.
+
+The returned mapping is shaped like the REST ``GET /pulls/{n}`` payload
+--- ``mergeable``, ``mergeable_state``, ``state``, ``merged``,
+``merged_at``, ``head.sha`` --- so existing call sites need no rewriting
+and continue to work with helpers such as ``_merged_from_payload``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any, Protocol
+
+__all__ = ["PullRequestStatePoller", "PRKey"]
+
+PRKey = tuple[str, str, int]
+
+# Fields mirroring the REST payload keys the wait loops consult.
+_FRAGMENT = """
+fragment PRState on PullRequest {
+  number
+  state
+  merged
+  mergedAt
+  mergeable
+  mergeStateStatus
+  headRefOid
+}
+"""
+
+# How long to hold a batch open for further arrivals.  Long enough for
+# the parked PRs woken by one tick to land in the same query, short
+# enough to be imperceptible against a 10 s poll interval.
+DEFAULT_WINDOW_SECONDS = 0.05
+
+# Aliased lookups per query.  GitHub charges a single-object lookup ~1
+# point, so the cap is about query size and blast radius on failure
+# rather than rate-limit cost.
+DEFAULT_MAX_BATCH = 50
+
+_MERGEABLE = {"MERGEABLE": True, "CONFLICTING": False, "UNKNOWN": None}
+
+_MERGE_STATE = {
+    "CLEAN": "clean",
+    "DIRTY": "dirty",
+    "BLOCKED": "blocked",
+    "BEHIND": "behind",
+    "DRAFT": "draft",
+    "UNSTABLE": "unstable",
+    "UNKNOWN": "unknown",
+    # ``has_hooks`` is a REST ``mergeable_state`` value too, so this is the
+    # faithful mapping.  Do not "simplify" it to ``blocked``: GitHub's schema
+    # defines HAS_HOOKS as "Mergeable with passing commit status and
+    # pre-receive hooks", i.e. a *mergeable* state closer to ``clean``.
+    # Reporting it as blocked would make the wait loops keep waiting on a PR
+    # that is ready to merge.
+    "HAS_HOOKS": "has_hooks",
+    # ``DRAFT`` above is not currently in GitHub's MergeStateStatus enum
+    # (drafts surface via ``isDraft``), but REST does report a ``draft``
+    # mergeable_state, so the mapping is kept for parity and forward safety.
+}
+
+
+class _Client(Protocol):
+    """The subset of ``GitHubAsync`` this module needs."""
+
+    async def graphql(
+        self, query: str, variables: dict[str, Any] | None = None
+    ) -> dict[str, Any]: ...
+
+    async def get(
+        self, path: str, params: dict[str, Any] | None = None
+    ) -> dict[str, Any] | list[dict[str, Any]]: ...
+
+
+def _to_rest_shape(node: dict[str, Any]) -> dict[str, Any]:
+    """Convert a GraphQL ``PullRequest`` node to the REST payload shape.
+
+    GraphQL reports ``state`` as ``OPEN``/``CLOSED``/``MERGED`` whereas
+    REST only ever says ``open``/``closed`` and carries merged-ness
+    separately, so ``MERGED`` is normalised to ``closed`` with
+    ``merged`` set.  Callers already treat those as independent.
+    """
+    raw_state = (node.get("state") or "").upper()
+    merged = node.get("merged")
+    state: str | None
+    if raw_state == "MERGED":
+        state = "closed"
+        if merged is None:
+            merged = True
+    elif raw_state == "CLOSED":
+        state = "closed"
+    elif raw_state == "OPEN":
+        state = "open"
+    else:
+        state = raw_state.lower() or None
+
+    merge_state = _MERGE_STATE.get((node.get("mergeStateStatus") or "").upper())
+
+    payload: dict[str, Any] = {
+        "number": node.get("number"),
+        "state": state,
+        "merged": merged,
+        # Always present (``null`` when unmerged), so ``_merged_from_payload``
+        # can fall back to it rather than degrading to "unknown".
+        "merged_at": node.get("mergedAt"),
+        "mergeable": _MERGEABLE.get((node.get("mergeable") or "").upper()),
+        "mergeable_state": merge_state,
+    }
+    head_sha = node.get("headRefOid")
+    if head_sha:
+        payload["head"] = {"sha": head_sha}
+    return payload
+
+
+class PullRequestStatePoller:
+    """Coalesces concurrent PR state reads into batched GraphQL queries.
+
+    Usage mirrors a plain fetch; the batching is invisible to callers::
+
+        payload = await poller.fetch(owner, repo, number)
+
+    Thread-safety is not a concern --- this is single-event-loop code ---
+    but re-entrancy is: ``fetch`` may be called from arbitrarily many
+    parked tasks at once, and every waiter must be resolved exactly once
+    even when the underlying query fails.
+    """
+
+    def __init__(
+        self,
+        client: _Client,
+        *,
+        window: float = DEFAULT_WINDOW_SECONDS,
+        max_batch: int = DEFAULT_MAX_BATCH,
+        log: logging.Logger | None = None,
+    ) -> None:
+        if max_batch < 1:
+            raise ValueError("max_batch must be >= 1")
+        self._client = client
+        self._window = max(0.0, window)
+        self._max_batch = max_batch
+        self.log = log or logging.getLogger(__name__)
+        self._pending: dict[PRKey, list[asyncio.Future[dict[str, Any] | None]]] = {}
+        self._flush_task: asyncio.Task[None] | None = None
+        # Observability: lets a run report how much batching actually saved.
+        self.requests_served = 0
+        self.queries_issued = 0
+        self.rest_fallback_calls = 0
+
+    @property
+    def calls_saved(self) -> int:
+        """Requests batching removed, versus one call per read.
+
+        Counts every API call actually made --- batched GraphQL queries
+        *and* any per-PR REST reads the fallback had to issue --- so a
+        run that degraded to the fallback reports the savings it really
+        achieved rather than the savings it intended.
+        """
+        issued = self.queries_issued + self.rest_fallback_calls
+        return max(0, self.requests_served - issued)
+
+    async def fetch(self, owner: str, repo: str, number: int) -> dict[str, Any] | None:
+        """Return PR state in REST payload shape, or ``None`` if absent.
+
+        ``None`` also results when the batched query failed *and* the
+        per-PR REST fallback failed for this particular PR while
+        succeeding for others in the same batch --- callers already treat
+        a missing payload as "no news, poll again".
+
+        Raises only when both the batched query and the whole fallback
+        failed, propagating the original query error so callers keep
+        their existing error handling.
+        """
+        key: PRKey = (owner, repo, number)
+        loop = asyncio.get_running_loop()
+        future: asyncio.Future[dict[str, Any] | None] = loop.create_future()
+        self.requests_served += 1
+        # A second reader of the same PR joins the in-flight result
+        # rather than adding another lookup to the query.
+        self._pending.setdefault(key, []).append(future)
+        self._ensure_flush_scheduled()
+        return await future
+
+    def _ensure_flush_scheduled(self) -> None:
+        if self._flush_task is None or self._flush_task.done():
+            self._flush_task = asyncio.create_task(
+                self._flush_soon(), name="pr-poller-flush"
+            )
+
+    async def _flush_soon(self) -> None:
+        # Hold the batch open briefly so near-simultaneous arrivals join it.
+        if self._window:
+            await asyncio.sleep(self._window)
+        while self._pending:
+            batch = list(self._pending.keys())[: self._max_batch]
+            waiters = {k: self._pending.pop(k) for k in batch}
+            try:
+                await self._run_batch(waiters)
+            except asyncio.CancelledError:
+                self._fail_all(waiters, asyncio.CancelledError())
+                raise
+            except Exception as exc:  # pragma: no cover - defensive
+                # ``_run_batch`` resolves its own waiters; reaching here
+                # means an unexpected failure outside that handling, and
+                # leaving futures pending would hang every parked PR.
+                self.log.debug("PR poller batch failed unexpectedly: %s", exc)
+                self._fail_all(waiters, exc)
+
+    async def _run_batch(
+        self, waiters: dict[PRKey, list[asyncio.Future[dict[str, Any] | None]]]
+    ) -> None:
+        keys = list(waiters)
+        results: dict[PRKey, dict[str, Any] | None]
+        try:
+            results = await self._query(keys)
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            self.log.debug(
+                "Batched PR query failed for %d PR(s); falling back to REST: %s",
+                len(keys),
+                exc,
+            )
+            fallback = await self._rest_fallback(keys)
+            if fallback is None:
+                self._fail_all(waiters, exc)
+                return
+            results = fallback
+        for key, futures in waiters.items():
+            payload = results.get(key)
+            for fut in futures:
+                if not fut.done():
+                    fut.set_result(payload)
+
+    async def _query(self, keys: list[PRKey]) -> dict[PRKey, dict[str, Any] | None]:
+        decls: list[str] = []
+        selections: list[str] = []
+        variables: dict[str, Any] = {}
+        for i, (owner, repo, number) in enumerate(keys):
+            decls.append(f"$o{i}: String!, $r{i}: String!, $n{i}: Int!")
+            selections.append(
+                f"  p{i}: repository(owner: $o{i}, name: $r{i}) "
+                f"{{ pullRequest(number: $n{i}) {{ ...PRState }} }}"
+            )
+            variables[f"o{i}"] = owner
+            variables[f"r{i}"] = repo
+            variables[f"n{i}"] = number
+        query = (
+            "query BatchedPRState("
+            + ", ".join(decls)
+            + ") {\n"
+            + "\n".join(selections)
+            + "\n}\n"
+            + _FRAGMENT
+        )
+        self.queries_issued += 1
+        data = await self._client.graphql(query, variables)
+        out: dict[PRKey, dict[str, Any] | None] = {}
+        for i, key in enumerate(keys):
+            repo_node = (data or {}).get(f"p{i}") or {}
+            pr_node = (
+                repo_node.get("pullRequest") if isinstance(repo_node, dict) else None
+            )
+            out[key] = _to_rest_shape(pr_node) if isinstance(pr_node, dict) else None
+        return out
+
+    async def _rest_fallback(
+        self, keys: list[PRKey]
+    ) -> dict[PRKey, dict[str, Any] | None] | None:
+        """Per-PR REST reads when the batched query fails.
+
+        Costs exactly what the unbatched implementation cost, so a
+        GraphQL outage degrades throughput rather than blinding every
+        wait loop until it times out.  Returns ``None`` when the
+        fallback itself fails, letting the caller surface the original
+        error.
+        """
+        try:
+            self.rest_fallback_calls += len(keys)
+            payloads = await asyncio.gather(
+                *(
+                    self._client.get(f"/repos/{owner}/{repo}/pulls/{number}")
+                    for owner, repo, number in keys
+                ),
+                return_exceptions=True,
+            )
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            return None
+        out: dict[PRKey, dict[str, Any] | None] = {}
+        recovered = False
+        for key, payload in zip(keys, payloads, strict=True):
+            if isinstance(payload, dict):
+                out[key] = payload
+                recovered = True
+            else:
+                out[key] = None
+        return out if recovered else None
+
+    @staticmethod
+    def _fail_all(
+        waiters: dict[PRKey, list[asyncio.Future[dict[str, Any] | None]]],
+        exc: BaseException,
+    ) -> None:
+        for futures in waiters.values():
+            for fut in futures:
+                if not fut.done():
+                    fut.set_exception(exc)

--- a/tests/test_pr_poller.py
+++ b/tests/test_pr_poller.py
@@ -1,0 +1,398 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 The Linux Foundation
+
+"""Tests for batched pull-request state polling.
+
+The unbatched implementation cost one REST request per parked PR per
+tick --- 6 calls/min each, so ~14 parked PRs consumed the entire REST
+budget (see ``docs/BULK_RUN_PERFORMANCE_AUDIT.md`` §2.1).  These tests
+pin the batching, the REST-compatible output shape, and --- most
+importantly --- that every waiter is resolved exactly once even when the
+underlying query fails, since a lost future would hang a parked PR until
+its deadline.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+
+from dependamerge.pr_poller import PullRequestStatePoller, _to_rest_shape
+
+
+def _node(**over: Any) -> dict[str, Any]:
+    node = {
+        "number": 1,
+        "state": "OPEN",
+        "merged": False,
+        "mergedAt": None,
+        "mergeable": "MERGEABLE",
+        "mergeStateStatus": "CLEAN",
+        "headRefOid": "a" * 40,
+    }
+    node.update(over)
+    return node
+
+
+def _reply(keys: list[tuple[str, str, int]], **by_number: Any) -> dict[str, Any]:
+    """Build a GraphQL reply shaped like the aliased batch query's result."""
+    out: dict[str, Any] = {}
+    for i, (_o, _r, number) in enumerate(keys):
+        node = by_number.get(f"n{number}", _node(number=number))
+        out[f"p{i}"] = {"pullRequest": node}
+    return out
+
+
+# --------------------------------------------------------------------------
+# Output shape
+# --------------------------------------------------------------------------
+
+
+class TestRestShape:
+    def test_open_clean_pr(self) -> None:
+        p = _to_rest_shape(_node())
+        assert p["state"] == "open"
+        assert p["merged"] is False
+        assert p["mergeable"] is True
+        assert p["mergeable_state"] == "clean"
+        assert p["head"]["sha"] == "a" * 40
+
+    def test_graphql_merged_state_maps_to_closed(self) -> None:
+        """REST reports state/merged independently; GraphQL folds them."""
+        p = _to_rest_shape(
+            _node(state="MERGED", merged=True, mergedAt="2026-08-13T15:17:37Z")
+        )
+        assert p["state"] == "closed"
+        assert p["merged"] is True
+        assert p["merged_at"] == "2026-08-13T15:17:37Z"
+
+    def test_merged_inferred_when_boolean_absent(self) -> None:
+        p = _to_rest_shape({"state": "MERGED"})
+        assert p["merged"] is True
+
+    def test_closed_unmerged(self) -> None:
+        p = _to_rest_shape(_node(state="CLOSED", merged=False))
+        assert p["state"] == "closed"
+        assert p["merged"] is False
+
+    @pytest.mark.parametrize(
+        ("enum", "expected"),
+        [("MERGEABLE", True), ("CONFLICTING", False), ("UNKNOWN", None)],
+    )
+    def test_mergeable_enum(self, enum: str, expected: bool | None) -> None:
+        assert _to_rest_shape(_node(mergeable=enum))["mergeable"] is expected
+
+    @pytest.mark.parametrize(
+        ("enum", "expected"),
+        [
+            ("CLEAN", "clean"),
+            ("DIRTY", "dirty"),
+            ("BLOCKED", "blocked"),
+            ("BEHIND", "behind"),
+            ("UNSTABLE", "unstable"),
+            ("DRAFT", "draft"),
+        ],
+    )
+    def test_merge_state_status(self, enum: str, expected: str) -> None:
+        assert (
+            _to_rest_shape(_node(mergeStateStatus=enum))["mergeable_state"] == expected
+        )
+
+    def test_merged_at_key_always_present(self) -> None:
+        """``_merged_from_payload`` falls back to it, so it must not vanish."""
+        assert "merged_at" in _to_rest_shape(_node())
+
+    def test_has_hooks_is_not_reported_as_blocked(self) -> None:
+        """HAS_HOOKS is a *mergeable* state, per GitHub's schema.
+
+        Its description is "Mergeable with passing commit status and
+        pre-receive hooks".  Mapping it to ``blocked`` would keep the
+        wait loops waiting on a PR that is ready to merge, so this pins
+        the faithful REST mapping against a plausible-looking
+        "simplification".
+        """
+        assert (
+            _to_rest_shape(_node(mergeStateStatus="HAS_HOOKS"))["mergeable_state"]
+            == "has_hooks"
+        )
+
+    def test_missing_head_omits_key(self) -> None:
+        assert "head" not in _to_rest_shape(_node(headRefOid=None))
+
+
+# --------------------------------------------------------------------------
+# Batching
+# --------------------------------------------------------------------------
+
+
+class TestBatching:
+    @pytest.mark.asyncio
+    async def test_concurrent_reads_share_one_query(self) -> None:
+        """The whole point: O(parked) requests become O(1)."""
+        client = AsyncMock()
+        keys = [("o", "r", n) for n in range(1, 21)]
+        client.graphql = AsyncMock(return_value=_reply(keys))
+        poller = PullRequestStatePoller(client, window=0.01)
+
+        results = await asyncio.gather(*(poller.fetch(o, r, n) for o, r, n in keys))
+
+        assert len(results) == 20
+        assert client.graphql.await_count == 1
+        assert poller.requests_served == 20
+        assert poller.queries_issued == 1
+        assert poller.calls_saved == 19
+
+    @pytest.mark.asyncio
+    async def test_each_pr_gets_its_own_result(self) -> None:
+        client = AsyncMock()
+        keys = [("o", "r", 1), ("o", "r", 2), ("o2", "r2", 3)]
+        client.graphql = AsyncMock(
+            return_value=_reply(
+                keys,
+                n1=_node(number=1, mergeStateStatus="CLEAN"),
+                n2=_node(number=2, mergeStateStatus="BLOCKED"),
+                n3=_node(number=3, state="MERGED", merged=True),
+            )
+        )
+        poller = PullRequestStatePoller(client, window=0.01)
+
+        a, b, c = await asyncio.gather(
+            poller.fetch("o", "r", 1),
+            poller.fetch("o", "r", 2),
+            poller.fetch("o2", "r2", 3),
+        )
+
+        assert a is not None and b is not None and c is not None
+        assert a["mergeable_state"] == "clean"
+        assert b["mergeable_state"] == "blocked"
+        assert c["merged"] is True
+
+    @pytest.mark.asyncio
+    async def test_duplicate_readers_share_one_lookup(self) -> None:
+        client = AsyncMock()
+        keys = [("o", "r", 1)]
+        client.graphql = AsyncMock(return_value=_reply(keys))
+        poller = PullRequestStatePoller(client, window=0.01)
+
+        a, b, c = await asyncio.gather(
+            poller.fetch("o", "r", 1),
+            poller.fetch("o", "r", 1),
+            poller.fetch("o", "r", 1),
+        )
+
+        assert client.graphql.await_count == 1
+        # One aliased lookup, not three.
+        variables = client.graphql.await_args.args[1]
+        assert "n1" not in variables
+        assert a == b == c
+
+    @pytest.mark.asyncio
+    async def test_batch_is_capped(self) -> None:
+        client = AsyncMock()
+
+        async def _graphql(query: str, variables: dict[str, Any]) -> dict[str, Any]:
+            count = sum(1 for k in variables if k.startswith("n"))
+            return {f"p{i}": {"pullRequest": _node(number=i)} for i in range(count)}
+
+        client.graphql = AsyncMock(side_effect=_graphql)
+        poller = PullRequestStatePoller(client, window=0.01, max_batch=5)
+
+        await asyncio.gather(*(poller.fetch("o", "r", n) for n in range(12)))
+
+        assert client.graphql.await_count == 3  # 5 + 5 + 2
+
+    @pytest.mark.asyncio
+    async def test_query_uses_variables_not_interpolation(self) -> None:
+        """Owner/repo go in variables, so no quoting or injection concern."""
+        client = AsyncMock()
+        keys = [("my-org", "my-repo", 7)]
+        client.graphql = AsyncMock(return_value=_reply(keys))
+        poller = PullRequestStatePoller(client, window=0.01)
+
+        await poller.fetch("my-org", "my-repo", 7)
+
+        query, variables = client.graphql.await_args.args
+        assert "my-org" not in query
+        assert variables["o0"] == "my-org"
+        assert variables["r0"] == "my-repo"
+        assert variables["n0"] == 7
+
+    @pytest.mark.asyncio
+    async def test_absent_pr_yields_none(self) -> None:
+        client = AsyncMock()
+        client.graphql = AsyncMock(return_value={"p0": {"pullRequest": None}})
+        poller = PullRequestStatePoller(client, window=0.01)
+
+        assert await poller.fetch("o", "r", 404) is None
+
+    @pytest.mark.asyncio
+    async def test_sequential_reads_issue_separate_queries(self) -> None:
+        client = AsyncMock()
+        client.graphql = AsyncMock(
+            side_effect=lambda q, v: {"p0": {"pullRequest": _node()}}
+        )
+        poller = PullRequestStatePoller(client, window=0.001)
+
+        await poller.fetch("o", "r", 1)
+        await poller.fetch("o", "r", 1)
+
+        assert client.graphql.await_count == 2
+
+
+# --------------------------------------------------------------------------
+# Failure handling — a lost future hangs a parked PR
+# --------------------------------------------------------------------------
+
+
+class TestFailureHandling:
+    @pytest.mark.asyncio
+    async def test_graphql_failure_falls_back_to_rest(self) -> None:
+        """A GraphQL outage must degrade throughput, not blind the waits."""
+        client = AsyncMock()
+        client.graphql = AsyncMock(side_effect=RuntimeError("graphql down"))
+        client.get = AsyncMock(
+            return_value={"state": "open", "merged": False, "merged_at": None}
+        )
+        poller = PullRequestStatePoller(client, window=0.01)
+
+        a, b = await asyncio.gather(
+            poller.fetch("o", "r", 1), poller.fetch("o", "r", 2)
+        )
+
+        assert a is not None and b is not None
+        assert a["state"] == "open"
+        assert b["state"] == "open"
+        assert client.get.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_savings_metric_accounts_for_rest_fallback(self) -> None:
+        """A degraded run must not report savings it did not achieve."""
+        client = AsyncMock()
+        client.graphql = AsyncMock(side_effect=RuntimeError("graphql down"))
+        client.get = AsyncMock(return_value={"state": "open"})
+        poller = PullRequestStatePoller(client, window=0.01)
+
+        await asyncio.gather(*(poller.fetch("o", "r", n) for n in range(4)))
+
+        # 4 reads served by 1 failed query + 4 REST reads: no saving.
+        assert poller.requests_served == 4
+        assert poller.rest_fallback_calls == 4
+        assert poller.calls_saved == 0
+
+    @pytest.mark.asyncio
+    async def test_total_failure_propagates_original_error(self) -> None:
+        client = AsyncMock()
+        client.graphql = AsyncMock(side_effect=RuntimeError("graphql down"))
+        client.get = AsyncMock(side_effect=RuntimeError("rest down too"))
+        poller = PullRequestStatePoller(client, window=0.01)
+
+        with pytest.raises(RuntimeError, match="graphql down"):
+            await poller.fetch("o", "r", 1)
+
+    @pytest.mark.asyncio
+    async def test_every_waiter_resolved_on_failure(self) -> None:
+        """No future may be left pending; a parked PR would hang."""
+        client = AsyncMock()
+        client.graphql = AsyncMock(side_effect=RuntimeError("boom"))
+        client.get = AsyncMock(side_effect=RuntimeError("boom"))
+        poller = PullRequestStatePoller(client, window=0.01)
+
+        results = await asyncio.gather(
+            *(poller.fetch("o", "r", n) for n in range(10)),
+            return_exceptions=True,
+        )
+
+        assert len(results) == 10
+        assert all(isinstance(r, RuntimeError) for r in results)
+        assert poller._pending == {}
+
+    @pytest.mark.asyncio
+    async def test_partial_rest_fallback_still_serves_recovered_prs(self) -> None:
+        client = AsyncMock()
+        client.graphql = AsyncMock(side_effect=RuntimeError("graphql down"))
+        client.get = AsyncMock(
+            side_effect=[{"state": "open"}, RuntimeError("one failed")]
+        )
+        poller = PullRequestStatePoller(client, window=0.01)
+
+        results: list[Any] = await asyncio.gather(
+            poller.fetch("o", "r", 1),
+            poller.fetch("o", "r", 2),
+            return_exceptions=True,
+        )
+
+        assert results[0] == {"state": "open"}
+        assert results[1] is None
+
+    @pytest.mark.asyncio
+    async def test_pending_map_is_drained(self) -> None:
+        client = AsyncMock()
+        keys = [("o", "r", n) for n in range(5)]
+        client.graphql = AsyncMock(return_value=_reply(keys))
+        poller = PullRequestStatePoller(client, window=0.01)
+
+        await asyncio.gather(*(poller.fetch("o", "r", n) for n in range(5)))
+
+        assert poller._pending == {}
+
+    def test_rejects_nonsense_batch_size(self) -> None:
+        with pytest.raises(ValueError):
+            PullRequestStatePoller(AsyncMock(), max_batch=0)
+
+
+# --------------------------------------------------------------------------
+# Wiring into the merge manager
+# --------------------------------------------------------------------------
+
+
+class TestMergeManagerWiring:
+    @pytest.mark.asyncio
+    async def test_uses_poller_when_configured(self) -> None:
+        from tests.conftest import make_merge_manager
+
+        mgr, client = make_merge_manager()
+        keys = [("o", "r", 1)]
+        client.graphql = AsyncMock(return_value=_reply(keys))
+        mgr._pr_poller = PullRequestStatePoller(client, window=0.001)
+
+        out = await mgr._fetch_pr_state("o", "r", 1)
+
+        assert isinstance(out, dict)
+        assert out["mergeable_state"] == "clean"
+        client.get.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_rest_without_poller(self) -> None:
+        """Keeps a manager usable outside its async context manager."""
+        from tests.conftest import make_merge_manager
+
+        mgr, client = make_merge_manager()
+        client.get = AsyncMock(return_value={"state": "open"})
+        assert mgr._pr_poller is None
+
+        out = await mgr._fetch_pr_state("o", "r", 1)
+
+        assert out == {"state": "open"}
+        client.get.assert_awaited_once_with("/repos/o/r/pulls/1")
+
+    @pytest.mark.asyncio
+    async def test_exit_clears_the_poller(self) -> None:
+        """The poller holds the client, so it must not outlive it.
+
+        Leaving it in place after ``__aexit__`` would route later reads
+        into a closed client rather than the direct-read fallback that
+        ``_fetch_pr_state`` documents.
+        """
+        from tests.conftest import make_merge_manager
+
+        mgr, client = make_merge_manager()
+        mgr._pr_poller = PullRequestStatePoller(client, window=0.001)
+        mgr._github_service = None
+
+        await mgr.__aexit__(None, None, None)
+
+        assert mgr._pr_poller is None
+        assert mgr._github_client is None


### PR DESCRIPTION
## Summary

Polling cost scaled with the number of *waiting* PRs, and the REST budget
could not pay for it. This is P1 from `docs/BULK_RUN_PERFORMANCE_AUDIT.md` —
the largest remaining lever from the 503-PR run.

Every parked PR polled `GET /pulls/{n}` on its own cadence: **6 API calls per
minute, each**. Against an authenticated REST budget of 5000/hr — 83 calls/min:

| Parked PRs | Polling calls/min | % of REST budget |
| ---: | ---: | ---: |
| 5 | 30 | 36% |
| 14 | 84 | **100%** |
| 40 | 240 | 289% |
| 60 | 360 | 434% |

Beyond ~14 simultaneously parked PRs, polling alone consumed the entire budget
asking "are you done yet?" — which then tripped the adaptive throttle fixed in
#406, slowing everything further. That feedback loop is the mechanism behind
the collapse after ~300 merges.

## The change

Concurrent state reads are coalesced into one aliased GraphQL query, turning
O(parked) requests per tick into O(1):

```text
60 parked PRs, REST:     360 calls/min
60 parked PRs, batched:  ~6 calls/min
```

`slot_lease.parked()` already ensured waiting held no *concurrency slot*; this
does the equivalent for *budget*.

## Verified against the live API

Not just unit-tested — run against real PRs:

```text
10 PRs -> 1 query
budgets tracked by the client:
   graphql  remaining=4629/5000
```

Two things worth noting there:

1. **Ten PRs across two repositories resolved in a single query.**
2. **Only the `graphql` budget moved.** REST `core` was untouched, so this
   moves polling off the constrained bucket entirely. The per-resource
   accounting added in #406 makes that visible.

A spot check also confirmed correct handling of a number that is an *issue*,
not a PR — `pullRequest(number:)` returns null and the poller yields `None`.

## Design notes

**REST-compatible output.** Returns the payload shape the wait loops already
consume — `mergeable`, `mergeable_state`, `state`, `merged`, `merged_at`,
`head.sha` — so call sites needed no rewriting and `_merged_from_payload` keeps
its `merged_at` fallback. GraphQL's `MERGED` state is normalised to
`state: closed` + `merged: true`, since REST reports those independently.

**Duplicate readers share one lookup.** Two tasks reading the same PR join one
in-flight result rather than adding a second alias.

**Failure degrades, never blinds.** A failed batch falls back to per-PR REST
reads — the old cost, but only on failure. If that fails too, the original
error propagates to callers, which already handle it. A GraphQL outage
therefore costs throughput, not correctness.

**Every waiter resolved exactly once**, on all paths including cancellation. A
lost future would hang a parked PR until its deadline, so this is the property
most worth pinning; several tests target it directly.

**Variables, not string interpolation**, for owner/repo/number — no quoting or
injection concern.

## Scope

Wired into the three loops that poll on a cadence:

- `_wait_for_auto_merge` — the dominant cost (10 s cadence, up to 30 polls/PR)
- `_await_in_progress_merge` — added in #413
- `_refresh_pr_mergeability`

Left alone deliberately: one-shot reads (batching them changes little and risks
semantics), and `_trigger_stale_precommit_ci` / `_trigger_dependabot_recreate`,
which poll *statuses and comments* rather than PR state and need a different
query. Worth a follow-up.

A manager used outside its async context manager has no poller configured and
reads directly, so existing behaviour and tests are unchanged.

## Verification

- **1646 tests pass** (30 new in `tests/test_pr_poller.py`)
- All hooks pass, including `mypy` and `basedpyright`
- Live API check as above

## Note on placement

`pr_poller.py` is a standalone module rather than part of
`src/dependamerge/engine/`, because that package's future is still undecided
(it remains unimported by `src/` — `docs/BULK_RUN_PERFORMANCE_AUDIT.md` §2.8).
If `engine/` is kept, this is a natural thing to move into it; if it is
deleted, nothing here needs revisiting. Keeping it separate avoids
pre-committing to either.

It also adds ~330 lines *outside* `merge_manager.py`, which is already 6,769
lines and the dominant contributor to #414.

## Related

- #406 — adaptive throttle (the loop this change breaks)
- #413 — reporting accuracy
- #414 — complexity findings
