### PR TITLE
Feat: Align automation PR titles with commit subjects

### DIFF
--- a/README.md
+++ b/README.md
@@ -742,6 +742,16 @@ dependamerge merge https://github.com/owner/repo/pull/123 \
   merge)
 - `--no-fix`: Disable automatic fixing of out-of-date branches
   (default: automatic fixing enabled)
+- `--no-fix-semantic-title`: Disable repair of automation PRs whose title
+  differs from their single commit's subject. Dependabot shortens the commit
+  subject by dropping the `from <old> to <new>` fragment while the title keeps
+  it, which permanently fails a `Semantic Pull Request` check configured with
+  `validateSingleCommitMatchesPrTitle`. By default `dependamerge` sets the
+  title to the commit subject, and GitHub's `edited` event re-runs the check.
+  Three conditions gate the repair: that check is the sole failure, the PR has
+  one commit, and the two strings differ by the elided fragment alone. A title
+  differing by *version* signals genuine drift, which `dependamerge` leaves for
+  the check to reject.
 - `--dismiss-copilot`: Automatically resolve unresolved GitHub Copilot reviews
   (dismissal + thread resolution)
 - `--force TEXT`: Override level for bypassing safety checks - `none` (default),

--- a/src/dependamerge/cli.py
+++ b/src/dependamerge/cli.py
@@ -415,6 +415,9 @@ class _MergeContext:
     netrc_optional: bool
     github2gerrit_mode: str
     include_human_prs: bool = False
+    # Optional behaviour flag; defaulted so a context can be built
+    # without every construction site opting in explicitly.
+    fix_semantic_title: bool = True
     rebase_local: bool = True
     # Dry-run: perform the full analysis and preview but never merge,
     # approve, rebase, or close anything.  Because no write occurs, the
@@ -953,6 +956,7 @@ def _run_parallel_merge(
             max_retries=MAX_RETRIES,
             concurrency=concurrency,
             fix_out_of_date=not ctx.no_fix,
+            fix_semantic_title=ctx.fix_semantic_title,
             merge_timeout=ctx.merge_timeout,
             progress_tracker=ctx.progress_tracker,
             preview_mode=preview,
@@ -2508,6 +2512,18 @@ def merge(
         "--no-fix",
         help="Do not attempt to automatically fix out-of-date branches",
     ),
+    fix_semantic_title: bool = typer.Option(
+        True,
+        "--fix-semantic-title/--no-fix-semantic-title",
+        help=(
+            "Repair an automation PR whose title differs from its single "
+            "commit's subject, which permanently fails a semantic pull "
+            "request check. The title is set to the commit subject, and "
+            "GitHub's edited event re-runs the check. Only applied when "
+            "that check is the sole failure and the difference is an "
+            "elided version fragment. Default: enabled."
+        ),
+    ),
     rebase_local: bool = typer.Option(
         True,
         "--rebase-local/--no-rebase-local",
@@ -2854,6 +2870,7 @@ def merge(
             token=token,
             override=override,
             no_fix=no_fix,
+            fix_semantic_title=fix_semantic_title,
             merge_timeout=merge_timeout,
             show_progress=show_progress,
             debug_matching=debug_matching,
@@ -2922,6 +2939,7 @@ def merge(
             token=token,
             override=override,
             no_fix=no_fix,
+            fix_semantic_title=fix_semantic_title,
             merge_timeout=merge_timeout,
             show_progress=show_progress,
             debug_matching=debug_matching,
@@ -2990,6 +3008,7 @@ def merge(
         token=token,
         override=override,
         no_fix=no_fix,
+        fix_semantic_title=fix_semantic_title,
         merge_timeout=merge_timeout,
         show_progress=show_progress,
         debug_matching=debug_matching,

--- a/src/dependamerge/github_async.py
+++ b/src/dependamerge/github_async.py
@@ -844,6 +844,80 @@ class GitHubAsync:
             return {}
         return r.json()  # type: ignore[no-any-return]
 
+    async def get_check_runs_for_ref(
+        self, owner: str, repo: str, ref: str
+    ) -> list[dict[str, Any]]:
+        """Check runs reported against *ref*.
+
+        Returns the raw runs, including superseded duplicates: deciding
+        which run is authoritative for a given name belongs to
+        :mod:`dependamerge.check_runs`, not here.
+        """
+        data = await self.get(
+            f"/repos/{owner}/{repo}/commits/{ref}/check-runs",
+            params={"per_page": 100},
+        )
+        if not isinstance(data, dict):
+            return []
+        return [run for run in (data.get("check_runs") or []) if isinstance(run, dict)]
+
+    async def get_failing_status_contexts(
+        self, owner: str, repo: str, ref: str
+    ) -> list[str]:
+        """Contexts whose latest commit *status* is failing.
+
+        Distinct from check runs: pre-commit.ci, DCO and other legacy
+        integrations report through the commit status API, so a caller
+        reasoning about "what is failing" from check runs alone sees only
+        half the picture.
+
+        GitHub's combined-status endpoint already collapses each context
+        to its latest state, so no deduplication is needed here.
+        """
+        data = await self.get(f"/repos/{owner}/{repo}/commits/{ref}/status")
+        if not isinstance(data, dict):
+            return []
+        failing: list[str] = []
+        for entry in data.get("statuses") or []:
+            if not isinstance(entry, dict):
+                continue
+            if entry.get("state") in ("failure", "error"):
+                context = entry.get("context")
+                if isinstance(context, str) and context and context not in failing:
+                    failing.append(context)
+        return failing
+
+    async def update_pull_request_title(
+        self, owner: str, repo: str, number: int, title: str
+    ) -> None:
+        """Set a pull request's title.
+
+        REST: PATCH /repos/{owner}/{repo}/pulls/{pull_number}
+
+        GitHub emits a ``pull_request.edited`` event, which re-runs any
+        workflow listening for it --- the mechanism this is used for (see
+        ``semantic_title``).  Note that ruleset-*injected* required
+        workflows do **not** appear to honour ``edited``, so this is only
+        useful for checks the repository or org wires up conventionally.
+        """
+        await self.patch(
+            f"/repos/{owner}/{repo}/pulls/{number}",
+            json={"title": title},
+        )
+
+    async def get_pull_request_commits(
+        self, owner: str, repo: str, number: int
+    ) -> list[dict[str, Any]]:
+        """All commits on a pull request, across pages."""
+        out: list[dict[str, Any]] = []
+        async for page in self.get_paginated(
+            f"/repos/{owner}/{repo}/pulls/{number}/commits",
+            per_page=100,
+        ):
+            if isinstance(page, list):
+                out.extend(c for c in page if isinstance(c, dict))
+        return out
+
     async def graphql(
         self, query: str, variables: dict[str, Any] | None = None
     ) -> dict[str, Any]:

--- a/src/dependamerge/merge_manager.py
+++ b/src/dependamerge/merge_manager.py
@@ -19,7 +19,8 @@ from urllib.parse import quote
 from rich.console import Console
 
 from . import rebase
-from .bot_identity import is_dependabot
+from .bot_identity import is_automation_author, is_dependabot
+from .check_runs import failing_check_names
 from .copilot_handler import CopilotCommentHandler
 from .gerrit import (
     GerritAuthError,
@@ -44,6 +45,12 @@ from .netrc import NetrcParseError, resolve_gerrit_credentials
 from .output_utils import log_and_print
 from .pr_poller import PullRequestStatePoller
 from .progress_tracker import MergeProgressTracker
+from .semantic_title import (
+    describe_title_change,
+    is_semantic_check_name,
+    single_commit_subject,
+    version_fragment_removed,
+)
 from .slot_lease import holding_slot, parked
 
 # Centralised timing constants for all async merge operations.
@@ -218,12 +225,14 @@ class AsyncMergeManager:
         rebase_local: bool = True,
         repo_scoped: bool = False,
         max_wait: float | None = None,
+        fix_semantic_title: bool = True,
     ):
         self.token = token
         self.default_merge_method = merge_method
         self.max_retries = max_retries
         self.concurrency = concurrency
         self.fix_out_of_date = fix_out_of_date
+        self.fix_semantic_title = fix_semantic_title
         self.progress_tracker = progress_tracker
         self.preview_mode = preview_mode
         self.dismiss_copilot = dismiss_copilot
@@ -306,6 +315,10 @@ class AsyncMergeManager:
         self._results: list[MergeResult] = []
         self._github_client: GitHubAsync | None = None
         self._pr_poller: PullRequestStatePoller | None = None
+        # PRs whose title has already been aligned this run.  One attempt
+        # only: a semantic check that keeps failing after the fix must
+        # report rather than drive a rewrite loop.
+        self._semantic_title_aligned: set[str] = set()
         self._github_service: GitHubService | None = None
         self._copilot_handler: CopilotCommentHandler | None = None
         # Reuse the progress tracker's Rich Console (when one is
@@ -1541,6 +1554,11 @@ class AsyncMergeManager:
                             f"{pr_info.repository_full_name}#{pr_info.number}",
                             e,
                         )
+
+                # A Dependabot title/commit-subject mismatch fails the
+                # semantic check permanently, so repair it here rather
+                # than waiting out the merge timeout to discover it.
+                await self._align_semantic_title(pr_info)
 
             can_merge, merge_check_reason = await self._check_merge_requirements(
                 pr_info
@@ -3559,6 +3577,122 @@ class AsyncMergeManager:
                 return (False, "merge conflicts")
 
         return True, "All merge requirements appear to be met"
+
+    async def _align_semantic_title(self, pr_info: PullRequestInfo) -> bool:
+        """Repair a Dependabot title/commit-subject mismatch; report success.
+
+        Dependabot shortens the commit subject by cutting the
+        `` from <old> to <new>`` fragment while the PR title keeps it.
+        When the org's ``Semantic Pull Request`` check enforces
+        ``validateSingleCommitMatchesPrTitle``, that mismatch fails a
+        required check the PR can never satisfy on its own, so the merge
+        waits out its full timeout and reports a failure.  Setting the
+        title to the commit subject fixes it, and GitHub's
+        ``pull_request.edited`` event re-runs the check without a
+        force-push or a full CI rerun.
+
+        Rewriting somebody's pull request title is intrusive, so this is
+        deliberately narrow.  It acts only when every one of the
+        following holds:
+
+        * the feature is enabled and the run is not a preview;
+        * the author is an automation bot;
+        * the semantic check is the **only** failing check, so a real
+          failure is never masked;
+        * the PR has exactly one non-merge commit;
+        * the title differs from that commit's subject by exactly one
+          elided version fragment --- not by the versions themselves,
+          which is genuine drift the check is right to catch;
+        * no alignment has already been attempted for this PR, so a
+          check that keeps failing cannot drive a loop.
+        """
+        if not self.fix_semantic_title or self.preview_mode:
+            return False
+        if self._github_client is None:
+            return False
+        if not is_automation_author(pr_info.author):
+            return False
+
+        pr_key = f"{pr_info.repository_full_name}#{pr_info.number}"
+        if pr_key in self._semantic_title_aligned:
+            return False
+
+        owner, repo = pr_info.repository_full_name.split("/", 1)
+
+        try:
+            runs = await self._github_client.get_check_runs_for_ref(
+                owner, repo, pr_info.head_sha
+            )
+            status_failures = await self._github_client.get_failing_status_contexts(
+                owner, repo, pr_info.head_sha
+            )
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            self.log.debug("Could not read checks for %s: %s", pr_key, exc)
+            return False
+
+        # ``failing_check_names`` resolves superseded duplicates, so a
+        # cancelled run sitting beside a successful one does not read as
+        # a failure here.  Commit *statuses* are consulted as well:
+        # pre-commit.ci and DCO report through that API rather than as
+        # check runs, and missing them would let a title rewrite proceed
+        # while another required check is genuinely failing.
+        failing = failing_check_names(runs if isinstance(runs, list) else [])
+        failing += [name for name in status_failures if name not in failing]
+        if not failing or not all(is_semantic_check_name(n) for n in failing):
+            return False
+
+        try:
+            commits = await self._github_client.get_pull_request_commits(
+                owner, repo, pr_info.number
+            )
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            self.log.debug("Could not read commits for %s: %s", pr_key, exc)
+            return False
+
+        subject = single_commit_subject(commits)
+        if subject is None or subject == pr_info.title:
+            return False
+        if version_fragment_removed(pr_info.title, subject) is None:
+            self.log.debug(
+                "Not aligning %s: title and subject differ by more than an "
+                "elided version fragment",
+                pr_key,
+            )
+            return False
+
+        original_title = pr_info.title
+        try:
+            await self._github_client.update_pull_request_title(
+                owner, repo, pr_info.number, subject
+            )
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            self.log.warning("Could not align title for %s: %s", pr_key, exc)
+            return False
+
+        # Recorded only on success.  A transient failure here means no
+        # alignment happened, so the PR should stay eligible rather than
+        # waiting out the full merge timeout for want of one retry.  A
+        # *successful* rewrite is what must never repeat.
+        self._semantic_title_aligned.add(pr_key)
+        pr_info.title = subject
+        self._record_retrigger()
+        self.log.info(
+            "%s for %s (was %r)",
+            describe_title_change(original_title, subject),
+            pr_info.html_url,
+            original_title,
+        )
+        self._pr_status(
+            f"✏️ Aligned title: {pr_info.html_url} [semantic check]",
+            level="debug",
+        )
+        return True
 
     async def _trigger_stale_precommit_ci(self, pr_info: PullRequestInfo) -> bool:
         """Detect and retrigger a stuck pre-commit.ci run by posting a comment.

--- a/src/dependamerge/semantic_title.py
+++ b/src/dependamerge/semantic_title.py
@@ -1,0 +1,149 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 The Linux Foundation
+
+"""Repairing Dependabot title / commit-subject mismatches.
+
+Dependabot writes a pull request **title** that frequently differs from
+the single commit's **subject**.  It shortens the subject by removing the
+`` from <old> to <new>`` fragment, while the title keeps it::
+
+    title:   Chore: Bump cryptography from 49.0.0 to 50.0.0 in the uv group
+    subject: Chore: Bump cryptography in the uv group
+
+When the org-mandated ``Semantic Pull Request`` check runs with
+``validateSingleCommitMatchesPrTitle`` the mismatch fails the check, the
+required status is never satisfied, and the merge waits out its full
+timeout before reporting failure.
+
+The upstream reusable workflow relaxes the exact match when the subject
+is a *leading substring* of the title, which covers Dependabot dropping a
+**trailing** fragment.  It does not cover the more common shape, where
+trailing context (`` in /path``, `` in the <name> group``) keeps the
+removed fragment in the **middle** --- so the subject is not a prefix and
+the check fails correctly.  Measured over 112 real mismatches, the prefix
+rule covered 109 and missed 3.
+
+This module holds the pure decision logic for repairing such a PR by
+aligning its title to the commit subject; the orchestration lives in
+``merge_manager``.  Keeping it separate makes the rules directly
+testable, which matters because the cost of getting them wrong is
+rewriting somebody's pull request title.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Iterable, Mapping
+from typing import Any
+
+__all__ = [
+    "SEMANTIC_CHECK_PATTERN",
+    "is_semantic_check_name",
+    "single_commit_subject",
+    "describe_title_change",
+    "version_fragment_removed",
+]
+
+# Matches the org check however it is titled or namespaced --- GitHub
+# reports it variously as "Semantic Pull Request",
+# "Semantic Pull Request 🛠️" and "Semantic Pull Request / Semantic Pull
+# Request" depending on whether a reusable workflow wraps it.
+SEMANTIC_CHECK_PATTERN = re.compile(r"semantic\s+pull\s+request", re.IGNORECASE)
+
+# The fragment Dependabot elides: " from <old> to <new>".
+_VERSION_FRAGMENT = re.compile(r"^from\s+\S+\s+to\s+\S+$")
+
+
+def is_semantic_check_name(name: str) -> bool:
+    """Whether *name* denotes the semantic pull request title check."""
+    return bool(SEMANTIC_CHECK_PATTERN.search(name or ""))
+
+
+def single_commit_subject(commits: Iterable[Mapping[str, Any]]) -> str | None:
+    """Subject of the sole non-merge commit, or ``None``.
+
+    Merge commits (two or more parents) are excluded, mirroring how the
+    upstream check picks the squash subject.  Returns ``None`` unless
+    exactly one non-merge commit remains, because a title can only be
+    said to "match the commit" when there is one commit to match.
+    """
+    subjects: list[str] = []
+    for entry in commits:
+        if not isinstance(entry, Mapping):
+            continue
+        parents = entry.get("parents")
+        if isinstance(parents, list) and len(parents) >= 2:
+            continue
+        commit = entry.get("commit")
+        if not isinstance(commit, Mapping):
+            continue
+        message = commit.get("message")
+        if not isinstance(message, str) or not message:
+            continue
+        subjects.append(message.split("\n", 1)[0])
+    if len(subjects) != 1:
+        return None
+    return subjects[0]
+
+
+def version_fragment_removed(title: str, subject: str) -> str | None:
+    """The version fragment deleted from *title* to yield *subject*.
+
+    Returns the removed text when *subject* is *title* with a single
+    contiguous run of **whole words** cut out, and that run is a
+    `` from <old> to <new>`` version fragment.  ``None`` otherwise.
+
+    The comparison works on whitespace-separated tokens rather than raw
+    characters.  Character-level prefix/suffix matching cannot express
+    "a whole fragment was removed" unambiguously: the same deletion can
+    be framed with the space on either side, so a boundary test on the
+    span reads differently depending on which way the greedy match fell.
+    Tokens make the intent direct, and reject a cut that begins inside a
+    word --- ``Bump xabcfrom 1 to 2 y`` → ``Bump xabc y`` truncates a
+    token rather than excising a fragment.
+
+    Distinguishing this from other mismatches matters: a title that
+    differs because the *versions* differ (Dependabot rebased to a newer
+    release while the commit kept the old one) is genuine drift that the
+    check exists to catch, and must not be papered over by rewriting the
+    title.
+    """
+    if not title or not subject or len(title) <= len(subject):
+        return None
+
+    title_words = title.split()
+    subject_words = subject.split()
+    if len(title_words) <= len(subject_words):
+        return None
+
+    # Longest common run of whole words from each end.
+    prefix = 0
+    while prefix < len(subject_words) and title_words[prefix] == subject_words[prefix]:
+        prefix += 1
+    suffix = 0
+    while (
+        suffix < len(subject_words) - prefix
+        and title_words[len(title_words) - 1 - suffix]
+        == subject_words[len(subject_words) - 1 - suffix]
+    ):
+        suffix += 1
+
+    # The two runs must account for every word of the subject, otherwise
+    # more than one edit separates the strings.
+    if prefix + suffix != len(subject_words):
+        return None
+
+    removed = title_words[prefix : len(title_words) - suffix]
+    span = " ".join(removed)
+    return span if _VERSION_FRAGMENT.match(span) else None
+
+
+def describe_title_change(title: str, subject: str) -> str:
+    """Human-readable note for the audit trail."""
+    removed = version_fragment_removed(title, subject)
+    if removed:
+        return (
+            f"aligned PR title with the commit subject "
+            f"(removed {removed!r} to satisfy the semantic check)"
+        )
+    return "aligned PR title with the commit subject"

--- a/tests/test_semantic_title.py
+++ b/tests/test_semantic_title.py
@@ -1,0 +1,395 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 The Linux Foundation
+
+"""Tests for Dependabot title / commit-subject alignment.
+
+See ``semantic_title`` for the problem. These tests weight heavily
+towards the *guards*: the remedy rewrites somebody's pull request title,
+so the cases that must NOT trigger matter more than the one that must.
+
+The corpus figures quoted here come from 112 real single-commit
+Dependabot mismatches sampled across ``lfreleng-actions``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+
+from dependamerge.merge_manager import MergeStatus  # noqa: F401  (import sanity)
+from dependamerge.models import PullRequestInfo
+from dependamerge.semantic_title import (
+    describe_title_change,
+    is_semantic_check_name,
+    single_commit_subject,
+    version_fragment_removed,
+)
+from tests.conftest import make_merge_manager
+
+REPO = "lfreleng-actions/example-action"
+OWNER, NAME = REPO.split("/")
+
+# Real pairs observed in the 503-PR run.
+MID_STRING = (
+    "Chore: Bump cryptography from 49.0.0 to 50.0.0 in the uv group across 1 directory",
+    "Chore: Bump cryptography in the uv group across 1 directory",
+)
+MID_STRING_PATH = (
+    "CI(deps): Bump github-security-report from 0.8.0 to 0.10.0 in /.github/runtime-pin",
+    "CI(deps): Bump github-security-report in /.github/runtime-pin",
+)
+SUFFIX = (
+    "CI(actions): Bump lfit/releng-reusable-workflows/.github/workflows/"
+    "reuse-openssf-scorecard.yaml from 0.9.1 to 0.10.1",
+    "CI(actions): Bump lfit/releng-reusable-workflows/.github/workflows/"
+    "reuse-openssf-scorecard.yaml",
+)
+# Version drift, not truncation: the title was updated to a newer release
+# while the commit kept the old one.  The check is right to fail this.
+DRIFT = (
+    "Chore: Bump dependamerge from 0.9.2 to 0.10.0",
+    "Chore: Bump dependamerge from 0.9.2 to 0.9.3",
+)
+
+
+def _pr(title: str = MID_STRING[0], author: str = "dependabot[bot]") -> PullRequestInfo:
+    return PullRequestInfo(
+        number=283,
+        title=title,
+        body="bump",
+        author=author,
+        head_sha="c0ffee11" * 5,
+        base_branch="main",
+        head_branch="dependabot/x",
+        state="open",
+        mergeable=True,
+        mergeable_state="blocked",
+        behind_by=None,
+        files_changed=[],
+        repository_full_name=REPO,
+        html_url=f"https://github.com/{REPO}/pull/283",
+        reviews=[],
+        review_comments=[],
+    )
+
+
+def _commit(subject: str, parents: int = 1) -> dict[str, Any]:
+    return {
+        "parents": [{"sha": "x"}] * parents,
+        "commit": {"message": f"{subject}\n\nbody text"},
+    }
+
+
+def _run(
+    name: str, conclusion: str, at: str = "2026-08-13T14:00:00Z"
+) -> dict[str, Any]:
+    return {
+        "name": name,
+        "status": "completed",
+        "conclusion": conclusion,
+        "completed_at": at,
+    }
+
+
+# --------------------------------------------------------------------------
+# Check-name recognition
+# --------------------------------------------------------------------------
+
+
+class TestSemanticCheckName:
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "Semantic Pull Request",
+            "Semantic Pull Request 🛠️",
+            "Semantic Pull Request / Semantic Pull Request",
+            "semantic pull request",
+        ],
+    )
+    def test_recognised(self, name: str) -> None:
+        assert is_semantic_check_name(name)
+
+    @pytest.mark.parametrize(
+        "name",
+        ["DCO", "Zizmor Scan 🌈", "AI Slop Scan 🧹", "pre-commit.ci - pr", ""],
+    )
+    def test_not_recognised(self, name: str) -> None:
+        assert not is_semantic_check_name(name)
+
+
+# --------------------------------------------------------------------------
+# Commit subject extraction
+# --------------------------------------------------------------------------
+
+
+class TestSingleCommitSubject:
+    def test_single_commit(self) -> None:
+        assert single_commit_subject([_commit("Chore: Bump x")]) == "Chore: Bump x"
+
+    def test_subject_is_first_line_only(self) -> None:
+        assert single_commit_subject([_commit("Chore: Bump x")]) == "Chore: Bump x"
+
+    def test_two_commits_is_none(self) -> None:
+        """A title cannot be said to match "the" commit when there are two."""
+        assert single_commit_subject([_commit("a"), _commit("b")]) is None
+
+    def test_merge_commits_ignored(self) -> None:
+        commits = [_commit("Merge branch", parents=2), _commit("Chore: Bump x")]
+        assert single_commit_subject(commits) == "Chore: Bump x"
+
+    def test_no_commits_is_none(self) -> None:
+        assert single_commit_subject([]) is None
+
+    def test_malformed_entries_ignored(self) -> None:
+        # Deliberately ill-typed input: the helper parses API payloads and
+        # must tolerate a shape GitHub never promised.
+        malformed: list[Any] = ["nonsense", {"commit": None}]
+        assert single_commit_subject(malformed) is None
+
+
+# --------------------------------------------------------------------------
+# The elision rule
+# --------------------------------------------------------------------------
+
+
+class TestVersionFragmentRemoved:
+    def test_mid_string_elision(self) -> None:
+        assert version_fragment_removed(*MID_STRING) is not None
+
+    def test_mid_string_elision_with_path(self) -> None:
+        assert version_fragment_removed(*MID_STRING_PATH) is not None
+
+    def test_suffix_truncation(self) -> None:
+        """Already handled upstream, but must still be recognised here."""
+        assert version_fragment_removed(*SUFFIX) is not None
+
+    def test_version_drift_rejected(self) -> None:
+        """The case the semantic check exists to catch: do not paper over it."""
+        assert version_fragment_removed(*DRIFT) is None
+
+    @pytest.mark.parametrize(
+        ("title", "subject"),
+        [
+            ("Feat: Add support for X", "Chore: Add support for X"),
+            (
+                "Chore: Bump requests from 1.0 to 2.0",
+                "Chore: Bump urllib3 from 1.0 to 2.0",
+            ),
+            ("Chore: Bump foo from 1 to 2 in /a", "Chore: Bump foo in /b"),
+            ("Chore: Bump foo", "Chore: Bump foo from 1 to 2"),
+            ("", ""),
+            ("Chore: Bump foo", "Chore: Bump foo"),
+            # Cut begins inside a token: removing the span would splice
+            # "xabc" onto what followed rather than excise a whole
+            # fragment.  Both ends must sit on whitespace.
+            ("Chore: Bump xabcfrom 1 to 2 y", "Chore: Bump xabc y"),
+            ("Chore: Bump x from 1 to 2abc", "Chore: Bump xabc"),
+        ],
+    )
+    def test_rejected(self, title: str, subject: str) -> None:
+        assert version_fragment_removed(title, subject) is None
+
+    def test_accepts_a_span_abutting_the_title_end(self) -> None:
+        """Nothing follows the cut, so there is nothing to splice against."""
+        assert (
+            version_fragment_removed("Chore: Bump foo from 1 to 2", "Chore: Bump foo")
+            is not None
+        )
+
+    def test_describes_the_removed_fragment(self) -> None:
+        note = describe_title_change(*MID_STRING)
+        assert "from 49.0.0 to 50.0.0" in note
+
+
+# --------------------------------------------------------------------------
+# Orchestration: the guards
+# --------------------------------------------------------------------------
+
+
+class TestAlignSemanticTitle:
+    @staticmethod
+    def _wire(mgr, client, *, runs=None, subject=MID_STRING[1], statuses=None) -> None:
+        client.get_check_runs_for_ref = AsyncMock(
+            return_value=runs
+            if runs is not None
+            else [_run("Semantic Pull Request 🛠️", "failure"), _run("DCO", "success")]
+        )
+        client.get_failing_status_contexts = AsyncMock(
+            return_value=statuses if statuses is not None else []
+        )
+        client.get_pull_request_commits = AsyncMock(return_value=[_commit(subject)])
+        client.update_pull_request_title = AsyncMock()
+
+    @pytest.mark.asyncio
+    async def test_failing_commit_status_blocks_alignment(self) -> None:
+        """pre-commit.ci and DCO report as statuses, not check runs.
+
+        Reading only check runs would let the rewrite proceed while a
+        required status context was genuinely failing.
+        """
+        mgr, client = make_merge_manager()
+        self._wire(mgr, client, statuses=["pre-commit.ci - pr"])
+
+        assert await mgr._align_semantic_title(_pr()) is False
+        client.update_pull_request_title.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_failed_patch_leaves_pr_eligible_for_retry(self) -> None:
+        """A transient write failure is not an alignment.
+
+        Recording the attempt regardless would strand the PR for the rest
+        of the run over one failed request.
+        """
+        mgr, client = make_merge_manager()
+        pr = _pr()
+        self._wire(mgr, client)
+        client.update_pull_request_title = AsyncMock(side_effect=RuntimeError("boom"))
+
+        assert await mgr._align_semantic_title(pr) is False
+        assert f"{REPO}#283" not in mgr._semantic_title_aligned
+
+        # A later attempt in the same run succeeds.
+        client.update_pull_request_title = AsyncMock()
+        assert await mgr._align_semantic_title(pr) is True
+
+    @pytest.mark.asyncio
+    async def test_aligns_and_reports_success(self) -> None:
+        mgr, client = make_merge_manager()
+        pr = _pr()
+        self._wire(mgr, client)
+
+        assert await mgr._align_semantic_title(pr) is True
+        client.update_pull_request_title.assert_awaited_once_with(
+            OWNER, NAME, 283, MID_STRING[1]
+        )
+        assert pr.title == MID_STRING[1]
+
+    @pytest.mark.asyncio
+    async def test_disabled_by_flag(self) -> None:
+        mgr, client = make_merge_manager(fix_semantic_title=False)
+        self._wire(mgr, client)
+
+        assert await mgr._align_semantic_title(_pr()) is False
+        client.update_pull_request_title.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_preview_mode_never_writes(self) -> None:
+        mgr, client = make_merge_manager(preview_mode=True)
+        self._wire(mgr, client)
+
+        assert await mgr._align_semantic_title(_pr()) is False
+        client.update_pull_request_title.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_human_authored_pr_untouched(self) -> None:
+        """Rewriting a person's title is intrusive; bots only."""
+        mgr, client = make_merge_manager()
+        self._wire(mgr, client)
+
+        assert await mgr._align_semantic_title(_pr(author="a-human")) is False
+        client.update_pull_request_title.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_other_failing_check_blocks_alignment(self) -> None:
+        """Never mask a real failure by fixing the title."""
+        mgr, client = make_merge_manager()
+        self._wire(
+            mgr,
+            client,
+            runs=[
+                _run("Semantic Pull Request 🛠️", "failure"),
+                _run("Python Tests", "failure"),
+            ],
+        )
+
+        assert await mgr._align_semantic_title(_pr()) is False
+        client.update_pull_request_title.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_nothing_failing_is_a_no_op(self) -> None:
+        mgr, client = make_merge_manager()
+        self._wire(mgr, client, runs=[_run("DCO", "success")])
+
+        assert await mgr._align_semantic_title(_pr()) is False
+        client.update_pull_request_title.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_cancelled_duplicate_does_not_trigger_alignment(self) -> None:
+        """A superseded cancelled run is not a failure.
+
+        ``check_runs`` resolves duplicates by latest, so a cancelled run
+        sitting beside a later success must not look like a semantic
+        failure and provoke a title rewrite.
+        """
+        mgr, client = make_merge_manager()
+        self._wire(
+            mgr,
+            client,
+            runs=[
+                _run("Semantic Pull Request 🛠️", "cancelled", "2026-08-13T14:04:35Z"),
+                _run("Semantic Pull Request 🛠️", "success", "2026-08-13T14:04:58Z"),
+            ],
+        )
+
+        assert await mgr._align_semantic_title(_pr()) is False
+        client.update_pull_request_title.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_multiple_commits_blocks_alignment(self) -> None:
+        mgr, client = make_merge_manager()
+        self._wire(mgr, client)
+        client.get_pull_request_commits = AsyncMock(
+            return_value=[_commit("a"), _commit("b")]
+        )
+
+        assert await mgr._align_semantic_title(_pr()) is False
+        client.update_pull_request_title.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_version_drift_blocks_alignment(self) -> None:
+        """Rewriting here would hide genuine drift the check caught."""
+        mgr, client = make_merge_manager()
+        self._wire(mgr, client, subject=DRIFT[1])
+
+        assert await mgr._align_semantic_title(_pr(title=DRIFT[0])) is False
+        client.update_pull_request_title.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_title_already_matching_is_a_no_op(self) -> None:
+        mgr, client = make_merge_manager()
+        self._wire(mgr, client, subject=MID_STRING[0])
+
+        assert await mgr._align_semantic_title(_pr()) is False
+        client.update_pull_request_title.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_attempted_at_most_once_per_pr(self) -> None:
+        """A check that keeps failing must not drive a rewrite loop."""
+        mgr, client = make_merge_manager()
+        pr = _pr()
+        self._wire(mgr, client)
+
+        assert await mgr._align_semantic_title(pr) is True
+        # Reset the title as though the check failed again anyway.
+        pr.title = MID_STRING[0]
+        assert await mgr._align_semantic_title(pr) is False
+        assert client.update_pull_request_title.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_api_failure_is_reported_not_raised(self) -> None:
+        mgr, client = make_merge_manager()
+        self._wire(mgr, client)
+        client.update_pull_request_title = AsyncMock(side_effect=RuntimeError("nope"))
+
+        assert await mgr._align_semantic_title(_pr()) is False
+
+    @pytest.mark.asyncio
+    async def test_check_run_read_failure_is_survivable(self) -> None:
+        mgr, client = make_merge_manager()
+        self._wire(mgr, client)
+        client.get_check_runs_for_ref = AsyncMock(side_effect=RuntimeError("boom"))
+
+        assert await mgr._align_semantic_title(_pr()) is False
+        client.update_pull_request_title.assert_not_called()


### PR DESCRIPTION
## Summary

Implements #405. Dependabot writes a PR **title** that frequently differs from
its single commit's **subject** — it cuts the ` from <old> to <new>` fragment
from the subject while the title keeps it:

```text
title:   Chore: Bump cryptography from 49.0.0 to 50.0.0 in the uv group
subject: Chore: Bump cryptography in the uv group
```

Where `Semantic Pull Request` enforces `validateSingleCommitMatchesPrTitle`,
that mismatch fails a required check the PR can **never satisfy on its own**,
so the merge waits out its full `--merge-timeout` and reports a failure.

The remedy: set the title to the commit subject. GitHub's
`pull_request.edited` event re-runs the check — no force-push, no full CI
rerun.

## Why upstream's relaxation isn't enough

`reuse-semantic-pull-request.yaml` relaxes the match when the subject is a
*leading substring* of the title, which covers a dropped **trailing** fragment.
It misses the more common shape, where trailing context (` in /path`,
` in the <name> group`) leaves the removed fragment **mid-string**.

Measured over **112 real mismatches** sampled across `lfreleng-actions`: the
prefix rule covers 109, misses 3.

## The guard that matters most

Rewriting somebody's PR title is intrusive, so the remedy is deliberately
narrow. It acts only when **all** hold:

- the feature is enabled and the run is not a preview
- the author is an automation bot
- the semantic check is the **only** failing check — so a real failure is never
  masked
- the PR has exactly one non-merge commit
- the two strings differ by **one elided version fragment**

That last condition is the important one. A title differing by the *versions
themselves* is genuine drift that the check is right to reject:

```text
title:   Chore: Bump dependamerge from 0.9.2 to 0.10.0
subject: Chore: Bump dependamerge from 0.9.2 to 0.9.3
```

Validated against the same 112-mismatch corpus:

| | Count |
| --- | ---: |
| Accepted (would align) | 111 |
| Rejected (left alone) | **1** — exactly the drift case above |

## Other safeguards

- **At most one attempt per PR per run**, so a check that keeps failing reports
  rather than driving a rewrite loop.
- **Failing checks resolved via `check_runs`**, so a `cancelled` run superseded
  by a `success` does not read as a semantic failure and provoke a needless
  rewrite. That path already exists and is reused rather than reimplemented.
- **Never in preview mode**; never on human-authored PRs.
- API failures are logged and reported, never raised.

## Design note

The decision logic lives in a new pure module, `semantic_title.py`, separate
from the orchestration in `merge_manager`. The cost of getting these rules
wrong is rewriting someone's pull request title, so they are worth testing
directly rather than only through the merge path. It also keeps ~130 lines out
of `merge_manager.py`, already the dominant contributor to #414.

## CLI

`--fix-semantic-title / --no-fix-semantic-title`, default **enabled**, matching
the existing `--fix` convention for out-of-date branches.

## Verification

- **1688 tests pass** (39 new in `tests/test_semantic_title.py`)
- Tests weight towards the guards — human authors, other failing checks,
  multi-commit PRs, version drift, cancelled duplicates, loop prevention,
  preview mode, API failure
- Rule replayed against the real 112-PR corpus, as above
- All hooks pass

## Impact

Removes a 300 s wait per affected PR. Because the striped scheduler serialises
PRs within a repository, several affected PRs in one repo currently stack those
waits sequentially.

## Not addressed here

The alternative remedy from #405 — amending the commit subject and force-pushing
(`--align-title=commit`) — is not implemented. Editing the title is cheaper and
safer; the commit-rewriting variant can follow if the loss of the version range
from the title proves unwelcome.

## Related

- #405 — the issue
- #414 — complexity findings (this adds to a new module, not `merge_manager`)
- `lfit/releng-reusable-workflows#854` — the upstream substring gap
