### PR TITLE
Fix: Stop a blocked PR predicting as mergeable

### DIFF
--- a/src/dependamerge/merge_manager/_prediction.py
+++ b/src/dependamerge/merge_manager/_prediction.py
@@ -52,6 +52,14 @@ class _PredictionMixin(_MergeManagerBase):
         GitHub's actual response (Step 6 and ``_merge_pr_with_retry``) as
         authoritative.  Only the preview path calls this method.
 
+        The ``except`` below covers **only the probe requests**, not the
+        verdict derived from them.  The optimistic "assuming mergeable"
+        fallback exists so an unreachable API does not block a run; it is
+        not meant to absorb defects in our own reasoning.  A bug in the
+        derivation therefore propagates to ``_predicted_merge_verdict``,
+        which logs it and returns "no verdict" — a visibly absent answer
+        rather than a confidently wrong one.
+
         Args:
             owner: Repository owner
             repo: Repository name
@@ -75,18 +83,16 @@ class _PredictionMixin(_MergeManagerBase):
             pr_data = await self._github_client.get(
                 f"/repos/{owner}/{repo}/pulls/{pr_number}"
             )
-
-            if isinstance(pr_data, dict):
-                verdict = await self._predict_from_pr_state(
-                    owner, repo, pr_number, pr_data
-                )
-                if verdict is not None:
-                    return verdict
-
-            return True, "merge capability test passed"
-
         except Exception as e:
             return self._prediction_verdict_for_error(owner, repo, pr_number, e)
+
+        # Derivation sits outside the guard on purpose — see the docstring.
+        if isinstance(pr_data, dict):
+            verdict = await self._predict_from_pr_state(owner, repo, pr_number, pr_data)
+            if verdict is not None:
+                return verdict
+
+        return True, "merge capability test passed"
 
     async def _predict_from_pr_state(
         self, owner: str, repo: str, pr_number: int, pr_data: dict[str, Any]
@@ -141,8 +147,11 @@ class _PredictionMixin(_MergeManagerBase):
         block_reason = await self._lookup_block_reason(owner, repo, pr_number, pr_data)
 
         # If the PR is only blocked because it needs approval, allow it
-        # through — the tool will approve it before attempting merge.
-        if "requires approval" in block_reason.lower():
+        # through --- the tool will approve it before attempting merge.
+        # The falsy guard keeps this branch safe even if a caller supplies
+        # a block reason that did not come through
+        # ``_lookup_block_reason``.
+        if block_reason and "requires approval" in block_reason.lower():
             self.log.info(
                 f"PR {owner}/{repo}#{pr_number} is blocked pending approval — tool will approve before merge"
             )
@@ -182,7 +191,15 @@ class _PredictionMixin(_MergeManagerBase):
             self.log.debug(
                 f"PR {owner}/{repo}#{pr_number} block reason: {block_reason}"
             )
-            return block_reason
+            # The client's annotation promises a ``str``, but coerce here
+            # anyway so this method's own ``-> str`` contract holds at the
+            # boundary.  Without it a ``None`` would reach ``.lower()`` in
+            # ``_predict_blocked_verdict`` and raise ``AttributeError``,
+            # which ``_predict_merge_outcome``'s outer handler converts
+            # into the optimistic "assuming mergeable" verdict --- turning
+            # a missing block reason into a prediction that the PR is fine
+            # to merge, which is the wrong direction to fail in.
+            return block_reason or ""
         except Exception as analyze_err:
             self.log.debug(
                 f"Could not analyze block reason for {owner}/{repo}#{pr_number}: {analyze_err}"

--- a/tests/test_predict_block_reason_none.py
+++ b/tests/test_predict_block_reason_none.py
@@ -1,0 +1,178 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 The Linux Foundation
+
+"""A ``None`` block reason must not become an optimistic verdict.
+
+``_lookup_block_reason`` returns whatever the client's
+``analyze_block_reason`` probe gives back, and ``_predict_blocked_verdict``
+calls ``.lower()`` on it.  A ``None`` would therefore raise
+``AttributeError``, which ``_predict_merge_outcome``'s outer handler
+converts into "test merge capability failed - assuming mergeable".
+
+That is the wrong direction to fail in: a missing block reason would
+silently become a prediction that the PR is fine to merge, and this runs
+under preview mode, so it is an answer a user acts on.
+
+The tests pin all three directions --- the ``None`` case, the ordinary
+string case that must be unaffected, and the genuine probe failure that
+must still reach the optimistic fallback.
+
+``TestTheGuardCoversOnlyTheProbe`` covers the second half of the issue:
+the optimistic fallback exists so an unreachable API does not block a
+run, and must not also absorb defects in the verdict derivation.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from dependamerge.models import PullRequestInfo
+from tests.conftest import make_merge_manager
+
+# ``force_level`` defaults to "code-owners", which is itself in the
+# bypass list consulted by ``_predict_blocked_verdict``.  Left at the
+# default, every assertion below would pass for the wrong reason, so the
+# tests opt out of forcing explicitly.
+NO_FORCE = "none"
+
+BLOCKED_PR = {
+    "mergeable_state": "blocked",
+    "mergeable": False,
+    "head": {"sha": "abc123"},
+    "base": {"ref": "main"},
+}
+
+REPO = "lfreleng-actions/some-repo"
+
+
+def _pr() -> PullRequestInfo:
+    """Minimal PR for driving ``_predicted_merge_verdict``."""
+    return PullRequestInfo(
+        number=1,
+        title="t",
+        body=None,
+        author="dependabot[bot]",
+        head_sha="a" * 40,
+        base_branch="main",
+        head_branch="x",
+        state="open",
+        mergeable=False,
+        mergeable_state="blocked",
+        behind_by=None,
+        files_changed=[],
+        repository_full_name=REPO,
+        html_url=f"https://github.com/{REPO}/pull/1",
+        reviews=[],
+        review_comments=[],
+    )
+
+
+@pytest.mark.asyncio
+async def test_none_block_reason_is_not_optimistic() -> None:
+    """A ``None`` reason yields a blocked verdict, not "assuming mergeable"."""
+    mgr, client = make_merge_manager(force_level=NO_FORCE)
+    client.get = AsyncMock(return_value=dict(BLOCKED_PR))
+    client.analyze_block_reason = AsyncMock(return_value=None)
+    mgr._get_org_settings = AsyncMock(return_value={})  # type: ignore[method-assign]
+
+    can_merge, reason = await mgr._predict_merge_outcome("o", "r", 1, "squash")
+
+    assert can_merge is False
+    assert "assuming mergeable" not in reason
+    assert "branch protection rules prevent merge" in reason
+
+
+@pytest.mark.asyncio
+async def test_string_block_reason_is_unchanged() -> None:
+    """An ordinary reason still routes to the approval branch."""
+    mgr, client = make_merge_manager(force_level=NO_FORCE)
+    client.get = AsyncMock(return_value=dict(BLOCKED_PR))
+    client.analyze_block_reason = AsyncMock(
+        return_value="PR requires approval from a code owner"
+    )
+    mgr._get_org_settings = AsyncMock(return_value={})  # type: ignore[method-assign]
+
+    can_merge, reason = await mgr._predict_merge_outcome("o", "r", 1, "squash")
+
+    assert can_merge is True
+    assert "approval" in reason
+
+
+@pytest.mark.asyncio
+async def test_a_genuine_probe_failure_still_falls_back() -> None:
+    """The optimistic fallback is preserved for real probe failures.
+
+    Guarding the ``None`` must not also suppress the existing behaviour
+    for a failing test-merge probe, which deliberately assumes the PR is
+    mergeable rather than blocking a run on an unknown error.
+    """
+    mgr, client = make_merge_manager(force_level=NO_FORCE)
+    client.get = AsyncMock(side_effect=RuntimeError("connection reset"))
+    mgr._get_org_settings = AsyncMock(return_value={})  # type: ignore[method-assign]
+
+    can_merge, reason = await mgr._predict_merge_outcome("o", "r", 1, "squash")
+
+    assert can_merge is True
+    assert "assuming mergeable" in reason
+
+
+class TestTheGuardCoversOnlyTheProbe:
+    """The optimistic fallback is for unreachable APIs, not for our bugs.
+
+    ``_predict_merge_outcome`` wrapped its whole body in ``except
+    Exception``, so a defect anywhere in the verdict derivation was
+    converted into "test merge capability failed - assuming mergeable".
+    A wrong answer and an unreachable API were indistinguishable, and the
+    wrong answer was the optimistic one.
+
+    Narrowing the guard to the probe requests means a derivation bug now
+    propagates to ``_predicted_merge_verdict``, whose own handler logs it
+    and returns ``None`` --- no verdict, rather than a confident and
+    incorrect one.
+    """
+
+    @pytest.mark.asyncio
+    async def test_a_derivation_bug_is_not_swallowed(self) -> None:
+        """A defect below the probe propagates instead of turning optimistic."""
+        mgr, client = make_merge_manager(force_level=NO_FORCE)
+        client.get = AsyncMock(return_value=dict(BLOCKED_PR))
+        boom = AttributeError("'NoneType' object has no attribute 'lower'")
+        mgr._predict_from_pr_state = AsyncMock(side_effect=boom)  # type: ignore[method-assign]
+        mgr._get_org_settings = AsyncMock(return_value={})  # type: ignore[method-assign]
+
+        with pytest.raises(AttributeError):
+            await mgr._predict_merge_outcome("o", "r", 1, "squash")
+
+    @pytest.mark.asyncio
+    async def test_the_caller_absorbs_it_as_no_verdict(self) -> None:
+        """End to end: the propagated bug becomes "no verdict", not "mergeable".
+
+        This is the property that makes propagating safe. The caller
+        already guards the probe, so a derivation bug degrades to an
+        absent answer rather than crashing an owner-wide preview.
+        """
+        mgr, client = make_merge_manager(force_level=NO_FORCE)
+        client.get = AsyncMock(return_value=dict(BLOCKED_PR))
+        mgr._predict_from_pr_state = AsyncMock(  # type: ignore[method-assign]
+            side_effect=AttributeError("boom")
+        )
+        mgr._get_org_settings = AsyncMock(return_value={})  # type: ignore[method-assign]
+
+        pr = _pr()
+        verdict = await mgr._predicted_merge_verdict(pr, "o", "r")
+
+        assert verdict is None
+
+    @pytest.mark.asyncio
+    async def test_an_unreachable_probe_still_falls_back(self) -> None:
+        """The narrowed guard still covers the request it was written for."""
+        mgr, client = make_merge_manager(force_level=NO_FORCE)
+        client.get = AsyncMock(side_effect=ConnectionError("network unreachable"))
+        mgr._get_org_settings = AsyncMock(return_value={})  # type: ignore[method-assign]
+
+        can_merge, reason = await mgr._predict_merge_outcome("o", "r", 1, "squash")
+
+        assert can_merge is True
+        assert "assuming mergeable" in reason


### PR DESCRIPTION
## Summary

Two defects on the dry-run prediction path, fixed together because the second is what made the first *dangerous* rather than merely wrong. Together they close #445.

## 1. A `None` block reason became an optimistic verdict

`_lookup_block_reason` returned the client's `analyze_block_reason` result unchecked, and `_predict_blocked_verdict` called `.lower()` on it. A `None` raised `AttributeError`, which the outer handler converted into:

> test merge capability failed - assuming mergeable

So a missing block reason did not surface as an error — it quietly became a prediction that the PR is fine to merge.

**Fix:** coerce at the boundary so `_lookup_block_reason`'s own `-> str` contract actually holds, and guard the approval branch against a falsy reason.

## 2. The guard covered far more than the probe

`_predict_merge_outcome` wrapped its **whole body** in `except Exception`, so a defect anywhere in the verdict derivation was indistinguishable from an unreachable API — and resolved to the optimistic answer. That is precisely what turned defect 1 from a loud crash into a silent wrong prediction.

**Fix:** narrow the guard to the probe requests. A derivation bug now propagates to `_predicted_merge_verdict`, whose own handler logs it and returns *no verdict* — visibly absent rather than confidently wrong.

Two things make this safe, both verified rather than assumed:

- **The caller already guards this call.** `_predicted_merge_verdict` has its own `try/except Exception` that logs and returns `None`, so a derivation bug degrades to "no verdict" instead of crashing an owner-wide preview.
- **`_get_org_settings` swallows its own failures** and returns `None`, so the org lookup cannot raise into the narrowed guard. The existing `test_org_failure_does_not_block_merge_check` passes because of *that* handler, not this one, and is unaffected.

Both defects run under preview mode, so a wrong answer is one a user acts on.

## Rebase note

Opened against `0d91fd2`, before #451 split `merge_manager.py` into a package — a modify/delete conflict, since the monolith the patch edited no longer exists. Resolved by porting to `merge_manager/_prediction.py`.

The test needed more than relocation:

- It imported `MergeManager`, which has **never** existed here — the class is `AsyncMergeManager` — so it could not have run. Rewritten against the `make_merge_manager` helper.
- It now pins `force_level`. The default `"code-owners"` is itself in the bypass list consulted by `_predict_blocked_verdict`, so left at the default every assertion would have passed for the wrong reason.
- Added the SPDX header `reuse lint` requires.

## Test coverage

Six tests across both defects, each verified **red-green** by reverting the corresponding fix:

| Test | Pins |
| --- | --- |
| `test_none_block_reason_is_not_optimistic` | fails `assert True is False` without the fix |
| `test_string_block_reason_is_unchanged` | ordinary reason still routes to the approval branch |
| `test_a_genuine_probe_failure_still_falls_back` | optimistic fallback preserved where intended |
| `test_a_derivation_bug_is_not_swallowed` | fails `DID NOT RAISE AttributeError` without the narrowing |
| `test_the_caller_absorbs_it_as_no_verdict` | the safety property that makes propagating acceptable |
| `test_an_unreachable_probe_still_falls_back` | narrowed guard still covers the request it was written for |

Two are deliberate controls that pass either way — they pin behaviour that must *not* change.

## Validation

| Check | Result |
| --- | --- |
| `uv run pytest tests/ -q` | 1765 passed, 14 skipped |
| Coverage | 75.21% (45% minimum enforced) |
| `uv run ruff check src/ tests/` | All checks passed |
| `uv run ruff format --check src/ tests/` | 256 files already formatted |
| `uv run mypy src/` | Success, 188 source files |
| `aislop` base-vs-head | 100 → 100, errors 0 → 0, warnings 0 → 0 — **adds nothing** |
