### PR TITLE
fix: handle missing block reason in preview

### DIFF
--- a/src/dependamerge/merge_manager/_prediction.py
+++ b/src/dependamerge/merge_manager/_prediction.py
@@ -182,7 +182,7 @@ class _PredictionMixin(_MergeManagerBase):
             self.log.debug(
                 f"PR {owner}/{repo}#{pr_number} block reason: {block_reason}"
             )
-            return block_reason
+            return block_reason or ""
         except Exception as analyze_err:
             self.log.debug(
                 f"Could not analyze block reason for {owner}/{repo}#{pr_number}: {analyze_err}"

--- a/tests/test_force_levels.py
+++ b/tests/test_force_levels.py
@@ -80,6 +80,35 @@ class TestForceLevelNone:
     """Test default force level (none) - respects all protections."""
 
     @pytest.mark.asyncio
+    async def test_blocks_when_block_reason_probe_returns_none(self, mocker):
+        """A missing probe result must not become an optimistic verdict."""
+        mock_github = mocker.AsyncMock()
+        mock_github.get.side_effect = lambda url: (
+            {
+                "mergeable": False,
+                "mergeable_state": "blocked",
+                "head": {"sha": "abc123"},
+            }
+            if "/pulls/" in url
+            else {}
+        )
+        mock_github.analyze_block_reason.return_value = None
+
+        async with AsyncMergeManager(
+            token="fake_token",
+            force_level="none",
+            preview_mode=True,
+        ) as manager:
+            manager._github_client = mock_github
+
+            can_merge, reason = await manager._predict_merge_outcome(
+                "test-org", "test-repo", 123, "merge"
+            )
+
+        assert can_merge is False
+        assert reason == "branch protection rules prevent merge (blocked)"
+
+    @pytest.mark.asyncio
     async def test_blocks_on_code_owner_requirement(self, sample_pr_info, mocker):
         """Test that code owner requirements block merge with force=none."""
         mock_github = mocker.AsyncMock()


### PR DESCRIPTION
Summary

- Normalize an empty block-reason probe result before the preview verdict calls lower().
- Add regression coverage for a client returning None.

Closes #445.

Validation

- Focused pytest regression passed with coverage disabled because a prior full-suite invocation held the Windows coverage database.
- Ruff check passed for both changed files.
- Ruff format check passed for both changed files.

AI assistance

Implemented with OpenAI Codex assistance.