### PR TITLE
Fix: Correct outcome accounting on failure paths

### DIFF
--- a/src/dependamerge/close_manager.py
+++ b/src/dependamerge/close_manager.py
@@ -136,7 +136,10 @@ class AsyncCloseManager:
 
                 target = self._resolve_close_target(pr_info, result)
                 if target is None:
-                    self._results.append(result)
+                    # No append here: the ``finally`` below is the single
+                    # append point.  Appending on this path too would
+                    # record every skipped PR twice, because ``return``
+                    # inside ``try`` runs ``finally`` first.
                     return result
 
                 repo_owner, repo_name = target
@@ -165,6 +168,10 @@ class AsyncCloseManager:
 
             finally:
                 result.duration = time.time() - start_time
+                # The single point at which a result enters ``_results``.
+                # ``get_summary`` and ``get_results`` both read this list,
+                # so a second append anywhere would inflate the counts the
+                # close command reports.
                 self._results.append(result)
 
         return result
@@ -257,6 +264,16 @@ class AsyncCloseManager:
                     f"✅ Closed: {pr_info.html_url}",
                     level="info",
                 )
+
+            except GitHubPermissionError:
+                # Broader than this clause, and deliberately ahead of it:
+                # a permission denial must reach the dedicated handler in
+                # ``_close_single_pr``, which explains *which* scope the
+                # token lacks.  Letting the generic clause below catch it
+                # would retry pointlessly --- the token cannot gain scopes
+                # between attempts --- and discard that guidance, turning
+                # an actionable failure into a vague one.
+                raise
 
             except Exception as e:
                 error_msg = str(e)

--- a/src/dependamerge/merge_manager/_failure.py
+++ b/src/dependamerge/merge_manager/_failure.py
@@ -165,57 +165,67 @@ class _FailureReportingMixin(_FailureSummaryFromExceptionMixin):
             return f"merge failed: {pr_info.mergeable_state}"
 
     async def _blocked_failure_summary(self, pr_info: PullRequestInfo) -> str:
-        """Summarise a ``blocked`` PR, naming the blocker where possible."""
+        """Summarise a ``blocked`` PR, naming the blocker where possible.
+
+        The guard covers **only** the analysis probe.  Wrapping the
+        conversion chain as well would make a defect in that chain
+        indistinguishable from a genuine analysis failure --- both would
+        surface as the generic fallback, which is plausible enough that a
+        silently broken conversion could persist indefinitely, with every
+        blocked PR simply reporting the generic reason.
+        """
         try:
             detailed_reason = await self._analyze_block_reason_async(pr_info)
-            # Convert the detailed reason to a more concise format for console output
-            if detailed_reason.startswith("Blocked by failing check:"):
-                check_name = detailed_reason.replace("Blocked by failing check: ", "")
-                return f"failing check: {check_name}"
-            elif (
-                detailed_reason.startswith("Blocked by")
-                and "failing checks" in detailed_reason
-            ):
-                return detailed_reason.replace("Blocked by ", "").lower()
-            elif "Human reviewer requested changes" in detailed_reason:
-                return "human reviewer requested changes"
-            elif "Copilot" in detailed_reason:
-                return detailed_reason.replace("Blocked by ", "").lower()
-            elif "ruleset" in detailed_reason.lower():
-                return "repository ruleset prevents merge"
-            elif "undetermined reason" in detailed_reason.lower():
-                return "blocked for an undetermined reason"
-            elif "branch protection" in detailed_reason.lower():
-                return "branch protection rules prevent merge"
-            else:
-                return detailed_reason.replace("Blocked by ", "").lower()
         except Exception as e:
             self.log.debug(f"Failed to get detailed block reason: {e}")
-            # Fallback to generic message
-
-        # Fallback logic when detailed analysis fails
-        if pr_info.mergeable is True:
-            return "branch protection rules prevent merge"
-        else:
+            # Fallback logic when detailed analysis fails
+            if pr_info.mergeable is True:
+                return "branch protection rules prevent merge"
             return "blocked by failing status checks"
 
+        # Convert the detailed reason to a more concise format for console output
+        if detailed_reason.startswith("Blocked by failing check:"):
+            check_name = detailed_reason.replace("Blocked by failing check: ", "")
+            return f"failing check: {check_name}"
+        elif (
+            detailed_reason.startswith("Blocked by")
+            and "failing checks" in detailed_reason
+        ):
+            return detailed_reason.replace("Blocked by ", "").lower()
+        elif "Human reviewer requested changes" in detailed_reason:
+            return "human reviewer requested changes"
+        elif "Copilot" in detailed_reason:
+            return detailed_reason.replace("Blocked by ", "").lower()
+        elif "ruleset" in detailed_reason.lower():
+            return "repository ruleset prevents merge"
+        elif "undetermined reason" in detailed_reason.lower():
+            return "blocked for an undetermined reason"
+        elif "branch protection" in detailed_reason.lower():
+            return "branch protection rules prevent merge"
+        else:
+            return detailed_reason.replace("Blocked by ", "").lower()
+
     async def _unknown_state_failure_summary(self, pr_info: PullRequestInfo) -> str:
-        """Summarise a PR whose mergeable state GitHub reports as unknown."""
+        """Summarise a PR whose mergeable state GitHub reports as unknown.
+
+        Scoped like :meth:`_blocked_failure_summary`, and for the same
+        reason: only the probe is guarded, so a conversion defect cannot
+        masquerade as a failed analysis.
+        """
         try:
             detailed_reason = await self._analyze_block_reason_async(pr_info)
-            if "failing check" in detailed_reason.lower():
-                if detailed_reason.startswith("Blocked by failing check:"):
-                    check_name = detailed_reason.replace(
-                        "Blocked by failing check: ", ""
-                    )
-                    return f"failing check: {check_name}"
-                else:
-                    return detailed_reason.replace("Blocked by ", "").lower()
-            else:
-                return detailed_reason.replace("Blocked by ", "").lower()
         except Exception as e:
             self.log.debug(f"Failed to analyze unknown state: {e}")
             return "status checks pending or failed"
+
+        if "failing check" in detailed_reason.lower():
+            if detailed_reason.startswith("Blocked by failing check:"):
+                check_name = detailed_reason.replace("Blocked by failing check: ", "")
+                return f"failing check: {check_name}"
+            else:
+                return detailed_reason.replace("Blocked by ", "").lower()
+        else:
+            return detailed_reason.replace("Blocked by ", "").lower()
 
     async def _get_merge_method_for_repo(self, owner: str, repo: str) -> str:
         """

--- a/src/dependamerge/merge_manager/_orchestration.py
+++ b/src/dependamerge/merge_manager/_orchestration.py
@@ -71,8 +71,13 @@ class _OrchestrationMixin(_MergeManagerBase):
         if self._github_client is not None:
             self._github_client.clear_block_reasons()
 
-        if not pr_list:
-            return []
+        # The accumulated results are run-scoped for the same reason, and
+        # are read back by ``get_results_summary``, ``get_failed_prs`` and
+        # ``get_successful_prs``.  Clearing them here rather than only on
+        # the normal path means a batch that filters down to nothing ---
+        # everything already merged, or everything excluded --- reports an
+        # empty run instead of the previous run's outcomes.
+        self._results = []
 
         # Resolve the owner-wide global wait ceiling for this run.  A
         # positive ``max_wait`` becomes a monotonic wall-clock deadline
@@ -87,6 +92,14 @@ class _OrchestrationMixin(_MergeManagerBase):
         self._no_wait = self._max_wait is not None and self._max_wait <= 0
         if self._max_wait is not None and self._max_wait > 0:
             self._run_deadline = asyncio.get_running_loop().time() + self._max_wait
+
+        # Every piece of run-scoped state is now reset, so an empty batch
+        # leaves the manager in the same condition a real run would.  The
+        # guard sits here rather than earlier because nothing above needs
+        # a PR, while everything below does --- the org-approval lookup
+        # reads ``pr_list[0]``.
+        if not pr_list:
+            return []
 
         if self.preview_mode:
             self.log.info(f"🔍 PREVIEW: Would merge {len(pr_list)} PRs")

--- a/src/dependamerge/merge_manager/_outcomes.py
+++ b/src/dependamerge/merge_manager/_outcomes.py
@@ -31,9 +31,24 @@ class _OutcomeTrackingMixin(_MergeManagerBase):
         Converts any propagated exception (from a per-PR task run with
         ``return_exceptions=True``) into a FAILED result for the matching
         PR, preserving the input ordering.
+
+        A ``BaseException`` that is not an ``Exception`` --- cancellation
+        in practice --- is re-raised rather than converted, so an
+        interrupted run fails as a cancellation instead of yielding a
+        results list with an exception object in it.
         """
         final_results: list[MergeResult] = []
         for i, result in enumerate(results):
+            if isinstance(result, BaseException) and not isinstance(result, Exception):
+                # ``asyncio.CancelledError`` derives from BaseException,
+                # not Exception, so it would otherwise fall through to the
+                # ``cast`` below --- a no-op at runtime, which would place
+                # the exception object in the results list and surface it
+                # much later as an ``AttributeError`` on ``.status``, with
+                # nothing tying it back to the cancelled PR.  Re-raising
+                # lets cancellation tear the run down here, matching
+                # ``_run_striped``, which propagates it explicitly.
+                raise result
             if isinstance(result, Exception):
                 pr_info = pr_list[i][0]
                 error_result = MergeResult(

--- a/tests/test_close_manager_accounting.py
+++ b/tests/test_close_manager_accounting.py
@@ -1,0 +1,178 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 The Linux Foundation
+
+"""Close-command accounting and permission diagnostics.
+
+Two defects lived on the close manager's failure paths, and both went
+unnoticed because nothing asserted on the length of ``_results`` or on
+the permission message.
+
+1. Every skipped PR was recorded **twice**.  The early-return branches
+   appended to ``_results`` and then returned from inside a ``try``
+   whose ``finally`` appended the same object again --- and ``return``
+   inside ``try`` runs ``finally`` first.  ``get_summary`` and
+   ``get_results`` both read that list, so a run skipping ten
+   already-closed PRs reported twenty outcomes.
+
+2. A permission denial never reached the handler written for it.  The
+   retry loop's inner ``except Exception`` is broader than the dedicated
+   ``except GitHubPermissionError`` that follows it, so it caught the
+   denial first --- retrying pointlessly, since a token cannot gain
+   scopes between attempts, and discarding the guidance that names the
+   missing scope.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from dependamerge.close_manager import AsyncCloseManager, CloseStatus
+from dependamerge.github_async import PermissionError as GitHubPermissionError
+from dependamerge.models import PullRequestInfo
+
+REPO = "lfreleng-actions/some-repo"
+
+
+def _pr(
+    *,
+    state: str = "open",
+    mergeable_state: str = "clean",
+    repository_full_name: str = REPO,
+) -> PullRequestInfo:
+    return PullRequestInfo(
+        number=1,
+        title="t",
+        body=None,
+        author="dependabot[bot]",
+        head_sha="a" * 40,
+        base_branch="main",
+        head_branch="x",
+        state=state,
+        mergeable=True,
+        mergeable_state=mergeable_state,
+        behind_by=None,
+        files_changed=[],
+        repository_full_name=repository_full_name,
+        html_url=f"https://github.com/{repository_full_name}/pull/1",
+        reviews=[],
+        review_comments=[],
+    )
+
+
+def _mgr(**overrides) -> AsyncCloseManager:
+    mgr = AsyncCloseManager(token="test-token", **overrides)
+    # Keep the console quiet and out of the assertions.
+    mgr._console = MagicMock()
+    return mgr
+
+
+class TestEachOutcomeIsRecordedOnce:
+    """``_results`` backs the reported counts, so duplicates inflate them."""
+
+    @pytest.mark.parametrize(
+        ("kwargs", "expected"),
+        [
+            ({"state": "closed"}, CloseStatus.SKIPPED),
+            ({"mergeable_state": "draft"}, CloseStatus.SKIPPED),
+            ({"repository_full_name": "malformed"}, CloseStatus.FAILED),
+        ],
+        ids=["already-closed", "draft", "malformed-repo"],
+    )
+    @pytest.mark.asyncio
+    async def test_a_skipped_pr_is_recorded_once(self, kwargs, expected) -> None:
+        mgr = _mgr()
+
+        result = await mgr._close_single_pr(_pr(**kwargs))
+
+        assert len(mgr._results) == 1
+        assert mgr._results[0] is result
+        assert result.status is expected
+        assert mgr.get_summary()["total"] == 1
+
+    @pytest.mark.asyncio
+    async def test_a_closed_pr_is_recorded_once(self) -> None:
+        """The path that already appended exactly once must be unchanged."""
+        mgr = _mgr()
+        client = AsyncMock()
+        client.close_pull_request = AsyncMock(return_value=None)
+        mgr._github_client = client
+
+        result = await mgr._close_single_pr(_pr())
+
+        assert len(mgr._results) == 1
+        assert result.status is CloseStatus.CLOSED
+
+    @pytest.mark.asyncio
+    async def test_a_preview_is_recorded_once(self) -> None:
+        mgr = _mgr(preview_mode=True)
+
+        result = await mgr._close_single_pr(_pr())
+
+        assert len(mgr._results) == 1
+        assert result.status is CloseStatus.CLOSED
+
+
+class TestPermissionErrorsReachTheirHandler:
+    """A denial is actionable only if the scope-specific guidance survives."""
+
+    @pytest.mark.asyncio
+    async def test_a_denial_is_not_retried(self) -> None:
+        """Retrying cannot help: the token gains no scopes between attempts."""
+        mgr = _mgr(max_retries=3)
+        client = AsyncMock()
+        client.close_pull_request = AsyncMock(
+            side_effect=GitHubPermissionError(
+                operation="close_pull_request",
+                message="Token lacks the required scope",
+            )
+        )
+        mgr._github_client = client
+
+        result = await mgr._close_single_pr(_pr())
+
+        assert client.close_pull_request.await_count == 1
+        assert result.status is CloseStatus.FAILED
+
+    @pytest.mark.asyncio
+    async def test_a_denial_keeps_its_guidance(self) -> None:
+        """The dedicated handler runs, so the operation is named for the user."""
+        mgr = _mgr()
+        client = AsyncMock()
+        client.close_pull_request = AsyncMock(
+            side_effect=GitHubPermissionError(
+                operation="close_pull_request",
+                message="Token lacks the required scope",
+            )
+        )
+        mgr._github_client = client
+
+        result = await mgr._close_single_pr(_pr())
+
+        printed = " ".join(
+            str(call.args[0]) for call in mgr._console.print.call_args_list if call.args
+        )
+        assert "Token Permission Issue" in printed
+        assert result.error and "scope" in result.error.lower()
+
+    @pytest.mark.asyncio
+    async def test_an_ordinary_error_is_still_retried(self) -> None:
+        """Narrowing must not disturb the retry behaviour it sits beside."""
+        mgr = _mgr(max_retries=2)
+        client = AsyncMock()
+        client.close_pull_request = AsyncMock(side_effect=RuntimeError("flaky"))
+        mgr._github_client = client
+
+        import dependamerge.close_manager as mod
+
+        original = mod.asyncio.sleep
+        mod.asyncio.sleep = AsyncMock(return_value=None)  # type: ignore[assignment]
+        try:
+            result = await mgr._close_single_pr(_pr())
+        finally:
+            mod.asyncio.sleep = original  # type: ignore[assignment]
+
+        assert client.close_pull_request.await_count == 2
+        assert result.status is CloseStatus.FAILED
+        assert len(mgr._results) == 1

--- a/tests/test_failure_summary_scoping.py
+++ b/tests/test_failure_summary_scoping.py
@@ -1,0 +1,153 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 The Linux Foundation
+
+"""Failure summaries must not hide their own conversion defects.
+
+``_blocked_failure_summary`` wrapped far more than the call it meant to
+guard: its ``except Exception`` covered the analysis probe *and* the
+whole string-conversion chain that follows it.  A genuine analysis
+failure and a bug in the conversion therefore produced identical output
+--- the generic fallback --- with nothing in the message or the logs to
+tell them apart.
+
+That is a diagnostics path, so it cannot cause a wrong merge.  What it
+can do is degrade exactly the output operators rely on when a merge is
+blocked and they need to know why: the fallback is plausible enough that
+a silently swallowed conversion bug could persist indefinitely, with
+every blocked PR reporting the generic reason and nobody suspecting the
+summary was failing rather than merely being unspecific.
+
+``_unknown_state_failure_summary`` carried the same shape and is fixed
+alongside it.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from dependamerge.models import PullRequestInfo
+from tests.conftest import make_merge_manager
+
+REPO = "lfreleng-actions/some-repo"
+
+
+def _pr(mergeable: bool = True, mergeable_state: str = "blocked") -> PullRequestInfo:
+    return PullRequestInfo(
+        number=1,
+        title="t",
+        body=None,
+        author="dependabot[bot]",
+        head_sha="a" * 40,
+        base_branch="main",
+        head_branch="x",
+        state="open",
+        mergeable=mergeable,
+        mergeable_state=mergeable_state,
+        behind_by=None,
+        files_changed=[],
+        repository_full_name=REPO,
+        html_url=f"https://github.com/{REPO}/pull/1",
+        reviews=[],
+        review_comments=[],
+    )
+
+
+class TestOnlyTheProbeIsGuarded:
+    """A failed analysis and a broken conversion must look different."""
+
+    @pytest.mark.asyncio
+    async def test_a_probe_failure_still_yields_the_fallback(self) -> None:
+        """The case the guard was written for is unchanged."""
+        mgr, _ = make_merge_manager()
+        mgr._analyze_block_reason_async = AsyncMock(  # type: ignore[method-assign]
+            side_effect=RuntimeError("analysis unavailable")
+        )
+
+        summary = await mgr._blocked_failure_summary(_pr(mergeable=True))
+
+        assert summary == "branch protection rules prevent merge"
+
+    @pytest.mark.asyncio
+    async def test_the_fallback_still_reflects_mergeability(self) -> None:
+        mgr, _ = make_merge_manager()
+        mgr._analyze_block_reason_async = AsyncMock(  # type: ignore[method-assign]
+            side_effect=RuntimeError("analysis unavailable")
+        )
+
+        summary = await mgr._blocked_failure_summary(_pr(mergeable=False))
+
+        assert summary == "blocked by failing status checks"
+
+    @pytest.mark.asyncio
+    async def test_a_conversion_defect_is_not_reported_as_the_fallback(self) -> None:
+        """A defect below the probe propagates instead of being disguised.
+
+        A ``None`` reason models the shape of a conversion bug: the probe
+        succeeded, so any failure past that point belongs to our own
+        logic. Previously this surfaced as the generic fallback, making
+        it indistinguishable from an unreachable analysis.
+        """
+        mgr, _ = make_merge_manager()
+        mgr._analyze_block_reason_async = AsyncMock(return_value=None)  # type: ignore[method-assign]
+
+        with pytest.raises(AttributeError):
+            await mgr._blocked_failure_summary(_pr())
+
+    @pytest.mark.asyncio
+    async def test_known_reasons_are_unchanged(self) -> None:
+        """Moving the chain out of the guard must not alter its output."""
+        mgr, _ = make_merge_manager()
+        cases = [
+            ("Blocked by failing check: build", "failing check: build"),
+            ("Blocked by 2 failing checks", "2 failing checks"),
+            (
+                "Human reviewer requested changes",
+                "human reviewer requested changes",
+            ),
+            ("Blocked by repository ruleset", "repository ruleset prevents merge"),
+            (
+                "Blocked for an undetermined reason",
+                "blocked for an undetermined reason",
+            ),
+            (
+                "Blocked by branch protection",
+                "branch protection rules prevent merge",
+            ),
+        ]
+        for reason, expected in cases:
+            mgr._analyze_block_reason_async = AsyncMock(return_value=reason)  # type: ignore[method-assign]
+            assert await mgr._blocked_failure_summary(_pr()) == expected, reason
+
+
+class TestTheUnknownStateSummaryMatches:
+    """The same shape sat two functions below, and is scoped the same way."""
+
+    @pytest.mark.asyncio
+    async def test_a_probe_failure_still_yields_the_fallback(self) -> None:
+        mgr, _ = make_merge_manager()
+        mgr._analyze_block_reason_async = AsyncMock(  # type: ignore[method-assign]
+            side_effect=RuntimeError("analysis unavailable")
+        )
+
+        summary = await mgr._unknown_state_failure_summary(_pr())
+
+        assert summary == "status checks pending or failed"
+
+    @pytest.mark.asyncio
+    async def test_a_conversion_defect_is_not_reported_as_the_fallback(self) -> None:
+        mgr, _ = make_merge_manager()
+        mgr._analyze_block_reason_async = AsyncMock(return_value=None)  # type: ignore[method-assign]
+
+        with pytest.raises(AttributeError):
+            await mgr._unknown_state_failure_summary(_pr())
+
+    @pytest.mark.asyncio
+    async def test_a_known_reason_is_unchanged(self) -> None:
+        mgr, _ = make_merge_manager()
+        mgr._analyze_block_reason_async = AsyncMock(  # type: ignore[method-assign]
+            return_value="Blocked by failing check: lint"
+        )
+
+        assert await mgr._unknown_state_failure_summary(_pr()) == "failing check: lint"

--- a/tests/test_stripe_scheduler.py
+++ b/tests/test_stripe_scheduler.py
@@ -242,6 +242,85 @@ async def test_striped_handles_duplicate_work_item_objects():
     assert len(recorder.dispatch_order) == 3
 
 
+class TestCancellationIsNotAResult:
+    """Cancellation must tear the run down, not enter the results list.
+
+    ``asyncio.CancelledError`` derives from ``BaseException`` rather than
+    ``Exception``, so it misses the ``isinstance(result, Exception)``
+    branch in ``_collect_results``.  The ``cast`` that follows is a no-op
+    at runtime, so without an explicit guard the exception object itself
+    is appended to the results list and only fails later --- and further
+    away --- when a caller touches ``.status``, with nothing connecting
+    the error to the PR that was cancelled.
+
+    The two schedulers must also agree here: ``_run_striped`` has always
+    re-raised cancellation explicitly, so interrupting an owner-wide run
+    and interrupting a single-repository run should fail the same way.
+    """
+
+    @pytest.mark.asyncio
+    async def test_flat_propagates_cancellation(self) -> None:
+        pr_list: list[PRPair] = [
+            (_make_pr(1, "owner/a"), None),
+            (_make_pr(2, "owner/b"), None),
+        ]
+        mgr = _manager(concurrency=5)
+
+        async def _cancel_one(pr_info: PullRequestInfo) -> MergeResult:
+            if pr_info.repository_full_name == "owner/b":
+                raise asyncio.CancelledError
+            return MergeResult(pr_info=pr_info, status=MergeStatus.MERGED)
+
+        mgr._merge_single_pr = _cancel_one  # type: ignore[assignment]
+
+        with pytest.raises(asyncio.CancelledError):
+            await mgr.merge_prs_parallel(pr_list)
+
+    @pytest.mark.asyncio
+    async def test_striped_propagates_cancellation(self) -> None:
+        """The pre-existing behaviour the flat path now matches."""
+        pr_list: list[PRPair] = [
+            (_make_pr(1, "owner/a"), None),
+            (_make_pr(2, "owner/b"), None),
+        ]
+        mgr = _manager(concurrency=5)
+
+        async def _cancel_one(pr_info: PullRequestInfo) -> MergeResult:
+            if pr_info.repository_full_name == "owner/b":
+                raise asyncio.CancelledError
+            return MergeResult(pr_info=pr_info, status=MergeStatus.MERGED)
+
+        mgr._merge_single_pr = _cancel_one  # type: ignore[assignment]
+
+        with pytest.raises(asyncio.CancelledError):
+            await mgr.merge_prs_parallel(pr_list, stripe=True)
+
+    @pytest.mark.asyncio
+    async def test_flat_still_converts_ordinary_failures_in_order(self) -> None:
+        """Narrowing the guard must not disturb ordinary per-PR failures."""
+        pr_list: list[PRPair] = [
+            (_make_pr(1, "owner/a"), None),
+            (_make_pr(2, "owner/b"), None),
+            (_make_pr(3, "owner/c"), None),
+        ]
+        mgr = _manager(concurrency=5)
+
+        async def _fail_middle(pr_info: PullRequestInfo) -> MergeResult:
+            if pr_info.number == 2:
+                raise RuntimeError("boom")
+            return MergeResult(pr_info=pr_info, status=MergeStatus.MERGED)
+
+        mgr._merge_single_pr = _fail_middle  # type: ignore[assignment]
+
+        results = await mgr.merge_prs_parallel(pr_list)
+
+        assert [r.pr_info.number for r in results] == [1, 2, 3]
+        assert results[1].status is MergeStatus.FAILED
+        assert results[1].error and "boom" in results[1].error
+        assert results[0].status is MergeStatus.MERGED
+        assert results[2].status is MergeStatus.MERGED
+
+
 @pytest.mark.asyncio
 async def test_run_deadline_reset_between_runs_on_reused_manager():
     """A reused manager must not carry a stale ``_run_deadline``.

--- a/tests/test_wait_head_start.py
+++ b/tests/test_wait_head_start.py
@@ -27,6 +27,7 @@ from unittest.mock import AsyncMock
 
 import pytest
 
+from dependamerge.merge_manager import MergeResult, MergeStatus
 from dependamerge.models import PullRequestInfo
 from tests.conftest import make_merge_manager
 
@@ -254,6 +255,30 @@ class TestPerRunState:
         # for the same reason, and its window can outlast the gap
         # between two runs.
         client.clear_block_reasons.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_an_empty_batch_clears_the_previous_run_results(self) -> None:
+        """A batch filtered down to nothing must not report the last run.
+
+        ``_results`` is run-scoped exactly like the observations above,
+        and it is what ``get_results_summary``, ``get_failed_prs`` and
+        ``get_successful_prs`` read.  Reuse is explicitly supported, so a
+        caller that filters a batch to empty --- everything already
+        merged, or everything excluded --- would otherwise be shown the
+        *previous* batch's outcomes as though they belonged to this run.
+        """
+        mgr, _ = _mgr()
+        mgr._results = [
+            MergeResult(pr_info=_pr(), status=MergeStatus.FAILED, error="boom"),
+            MergeResult(pr_info=_pr(), status=MergeStatus.MERGED),
+        ]
+
+        assert await mgr.merge_prs_parallel([]) == []
+
+        assert mgr._results == []
+        assert mgr.get_failed_prs() == []
+        assert mgr.get_successful_prs() == []
+        assert mgr.get_results_summary()["total"] == 0
 
 
 class TestTheClockStopsBeforeTheSlotIsReacquired:


### PR DESCRIPTION
Four defects of one class: **the run's own accounting and diagnostics are wrong on failure paths**. Each is small, each has been missing coverage, and grouping them keeps the review in one frame of reference.

Closes #442, closes #443, closes #444, closes #428.

This continues directly from #453, which narrowed an over-broad `except` on the prediction path. Two of the four below are the same defect class in different modules.

## The four

### #443 — an empty batch reports the previous run

`merge_prs_parallel` returned early for an empty batch **before** `_results` was reset, so `get_results_summary`, `get_failed_prs` and `get_successful_prs` all kept reporting the previous run.

The surrounding code already reasons about carry-over — the block-reason memo is cleared *before* the guard, the run deadline reset *after* it. `_results` was simply missed, so two pieces of run-scoped state were treated differently on the same path.

Moved the guard below the state reset so all run-scoped state is handled in one place. It cannot move further down: the org-approval lookup that follows reads `pr_list[0]`.

### #442 — a cancelled task became a result object

`_collect_results` tested only for `Exception`. `asyncio.CancelledError` derives from `BaseException`, so a cancelled task missed that branch and fell through to `cast` — a no-op at runtime. The exception object was appended to the results list and surfaced much later as an `AttributeError` on `.status`, with nothing tying it back to the cancelled PR.

It also made the schedulers disagree: `_run_striped` already re-raises cancellation explicitly, so interrupting an owner-wide run and a single-repository run failed differently. Now they match.

### #444 — a broad guard hid conversion defects

`_blocked_failure_summary`'s `except Exception` covered the analysis probe **and** the entire string-conversion chain after it. A genuine analysis failure and a bug in the conversion produced identical output — the generic fallback — with nothing to tell them apart.

Diagnostics only, so it cannot cause a wrong merge. What it degrades is exactly the output operators rely on when a merge is blocked. The fallback is plausible enough that a swallowed conversion bug could persist indefinitely, with every blocked PR reporting the generic reason.

**Scope note:** `_unknown_state_failure_summary`, two functions below, carried the identical shape. The issue names only the first, but leaving a matching defect beside a fixed one seemed worse than fixing both. Flagging it as slightly beyond the issue's letter.

### #428 — skipped PRs double-counted, denials made vague

Two defects, kept in one commit because they are one issue in one function pair.

1. The early-return branch appended to `_results` and then returned from inside a `try` whose `finally` appended the same object again — and `return` inside `try` runs `finally` first. A run skipping ten already-closed PRs reported **twenty** outcomes. The merge side had this class fixed in #413; this was not part of that work.
2. The retry loop's inner `except Exception` is broader than the dedicated `except GitHubPermissionError` after it, so denials were caught first: retried pointlessly (a token gains no scopes between attempts) and reported through the generic path, discarding the guidance naming the missing scope.

The unfixed behaviour is visible in the test log: `Attempt 1/3, 2/3, 3/3 failed ... Token lacks the required scope`, and the guidance never printed.

## Verification

**Every fix was checked red-green** by reverting only that fix and re-running. Against unfixed source, **7 of the 15 new tests fail** — exactly those targeting defects:

| Test | Failure without the fix |
| --- | --- |
| `test_an_empty_batch_clears_the_previous_run_results` | stale `_results` |
| `test_flat_propagates_cancellation` | `DID NOT RAISE CancelledError` |
| `test_a_conversion_defect_is_not_reported_as_the_fallback` (×2) | generic fallback returned |
| `test_a_skipped_pr_is_recorded_once` (×3 ids) | `len(_results) == 2` |
| `test_a_denial_is_not_retried` | 3 attempts instead of 1 |
| `test_a_denial_keeps_its_guidance` | guidance absent |

The remaining 8 are deliberate controls pinning behaviour that must **not** change — ordinary failures still map to `FAILED` in input order, known block reasons convert identically, ordinary close errors are still retried, genuine probe failures still reach their fallback.

`#428` had **no** direct unit tests for `_close_single_pr` before this, which is precisely why it went unnoticed.

## Validation

| Check | Result |
| --- | --- |
| `uv run pytest tests/ -q` | **1784 passed**, 14 skipped (was 1765) |
| Coverage | 75.72% (45% minimum enforced) |
| `uv run ruff check src/ tests/` | All checks passed |
| `uv run ruff format --check src/ tests/` | 258 files already formatted |
| `uv run mypy src/` | Success, 188 source files |
| `uv run reuse lint` | compliant |
| `prek run --all-files` | all hooks passed |
| `aislop` base-vs-head | 100 → 100, errors 0 → 0, warnings 0 → 0 — **adds nothing** |

Four commits, one per fix, each signed and independently green.
