### PR TITLE
Fix: Give the recreate path a correct contract

### DIFF
--- a/src/dependamerge/merge_manager/__init__.py
+++ b/src/dependamerge/merge_manager/__init__.py
@@ -95,6 +95,7 @@ from ._pr_state import _PullRequestStateMixin
 from ._precommit_ci import _PrecommitCiMixin
 from ._prediction import _PredictionMixin
 from ._recreated_pr import _RecreatedPullRequestMixin
+from ._recreated_pr_poll import _RecreatedPollMixin
 from ._required_workflows import _RequiredWorkflowWaitMixin
 from ._requirements import _MergeRequirementsMixin
 from ._retry import _MergeRetryMixin
@@ -106,6 +107,9 @@ from ._ticker import _StatusTickerMixin
 from ._types import (
     MergeResult,
     MergeStatus,
+    RecreateCause,
+    RecreateOutcome,
+    RecreateResult,
     _merge_already_in_progress,  # noqa: F401  (see __all__ note below)
     _merged_from_payload,  # noqa: F401  (see __all__ note below)
 )
@@ -130,6 +134,7 @@ class AsyncMergeManager(
     _StuckCheckMixin,
     _DependabotRecreateMixin,
     _RecreatedPullRequestMixin,
+    _RecreatedPollMixin,
     _PullRequestStateMixin,
     _MergeabilityRefreshMixin,
     _MergeRetryMixin,
@@ -181,6 +186,9 @@ __all__ = [
     "PRECOMMIT_CI_STUCK_PENDING_SECONDS",
     "Path",
     "PullRequestInfo",
+    "RecreateCause",
+    "RecreateOutcome",
+    "RecreateResult",
     "PullRequestStatePoller",
     "STUCK_CHECK_THRESHOLD_SECONDS",
     "UNDISPATCHED_CONFIRM_DELAY_SECONDS",

--- a/src/dependamerge/merge_manager/_base.py
+++ b/src/dependamerge/merge_manager/_base.py
@@ -28,7 +28,7 @@ if TYPE_CHECKING:
     from ..models import ComparisonResult, PullRequestInfo
     from ..pr_poller import PullRequestStatePoller
     from ..progress_tracker import MergeProgressTracker
-    from ._types import MergeResult, MergeStatus
+    from ._types import MergeResult, MergeStatus, RecreateCause, RecreateResult
 
 
 class _MergeManagerBase:
@@ -297,6 +297,24 @@ class _MergeManagerBase:
     ) -> None:
         raise NotImplementedError
 
+    def _recreated_pr_stub(
+        self,
+        repo_owner: str,
+        repo_name: str,
+        new_number: int,
+        pr_data: dict[str, Any],
+    ) -> PullRequestInfo:
+        raise NotImplementedError
+
+    async def _poll_recreated_pr(
+        self,
+        full_name: str,
+        new_number: int,
+        html_url: str,
+        check_attempt: int,
+    ) -> RecreateResult | None:
+        raise NotImplementedError
+
     async def _report_merge_failure(
         self,
         pr_info: PullRequestInfo,
@@ -349,8 +367,8 @@ class _MergeManagerBase:
         raise NotImplementedError
 
     async def _trigger_dependabot_recreate(
-        self, pr_info: PullRequestInfo
-    ) -> PullRequestInfo | None:
+        self, pr_info: PullRequestInfo, cause: RecreateCause
+    ) -> RecreateResult:
         raise NotImplementedError
 
     async def _trigger_stale_precommit_ci(self, pr_info: PullRequestInfo) -> bool:
@@ -370,8 +388,13 @@ class _MergeManagerBase:
         raise NotImplementedError
 
     async def _wait_for_recreated_pr_checks(
-        self, repo_owner: str, repo_name: str, new_number: int, pr_data: dict[str, Any]
-    ) -> PullRequestInfo | None:
+        self,
+        repo_owner: str,
+        repo_name: str,
+        new_number: int,
+        pr_data: dict[str, Any],
+        deadline: float | None = None,
+    ) -> RecreateResult:
         raise NotImplementedError
 
     async def _wait_for_required_workflows_and_retry(

--- a/src/dependamerge/merge_manager/_dependabot_recreate.py
+++ b/src/dependamerge/merge_manager/_dependabot_recreate.py
@@ -13,6 +13,7 @@ from typing import Any
 from ..bot_identity import is_dependabot
 from ..models import PullRequestInfo
 from ._base import _MergeManagerBase
+from ._types import RecreateCause, RecreateResult
 
 
 def _has_recreate_comment(comments: Any) -> bool:
@@ -32,64 +33,73 @@ class _DependabotRecreateMixin(_MergeManagerBase):
     """Driving the ``@dependabot recreate`` command."""
 
     async def _trigger_dependabot_recreate(
-        self, pr_info: PullRequestInfo
-    ) -> PullRequestInfo | None:
+        self, pr_info: PullRequestInfo, cause: RecreateCause
+    ) -> RecreateResult:
         """
-        Detect an unsigned dependabot commit and ask dependabot to recreate
-        the pull request so that the new commit is properly signed.
+        Ask dependabot to recreate a pull request from scratch.
 
-        When a repository's branch protection requires commit signatures,
-        dependabot PRs can end up with unverified commits (e.g. after a
-        rebase or force-push by GitHub).  Posting ``@dependabot recreate``
-        causes dependabot to close the current PR and open a fresh one
-        whose commit is signed by GitHub.
+        Two unrelated problems are recoverable this way, and the gates
+        differ between them:
+
+        ``UNSIGNED``
+            When a repository's branch protection requires commit
+            signatures, dependabot PRs can end up with unverified
+            commits (e.g. after a rebase or force-push by GitHub).
+            Posting ``@dependabot recreate`` produces a fresh PR whose
+            commit is signed by GitHub.  The signature checks decide
+            whether a recreate would help, so both are applied.
+
+        ``STUCK_CHECK``
+            A required check that never reported.  This is a *timing*
+            problem; signatures are irrelevant to it.  Applying the
+            signature gates here would make the recovery inert on every
+            repository that does not enforce signatures --- while still
+            telling the user a recreate was requested.
 
         Args:
             pr_info: Pull request information for the failing PR.
+            cause: Why the recreate is being requested.
 
         Returns:
-            A new ``PullRequestInfo`` for the recreated PR if the recreate
-            was triggered, the old PR was closed, and a replacement was
-            found.  Returns ``None`` if the recreate was not applicable or
-            did not succeed within the polling window.
+            A :class:`RecreateResult` describing what became of the
+            request.
         """
         if not self._github_client:
-            return None
+            return RecreateResult.none()
 
         repo_owner, repo_name = pr_info.repository_full_name.split("/", 1)
 
-        # 1. Only applies to dependabot PRs
+        # Applies to both causes: only dependabot answers the macro.
         if not is_dependabot(pr_info.author):
-            return None
+            return RecreateResult.none()
 
-        # 2. Check whether the branch requires signed commits
-        if not await self._recreate_branch_requires_signatures(
-            repo_owner, repo_name, pr_info
-        ):
-            return None
+        detail = ""
+        if cause is RecreateCause.UNSIGNED:
+            if not await self._recreate_branch_requires_signatures(
+                repo_owner, repo_name, pr_info
+            ):
+                return RecreateResult.none()
 
-        # 3. Check whether any commits are unverified
-        unverified_shas = await self._recreate_unverified_shas(
-            repo_owner, repo_name, pr_info
-        )
-        if unverified_shas is None:
-            return None
+            unverified_shas = await self._recreate_unverified_shas(
+                repo_owner, repo_name, pr_info
+            )
+            if unverified_shas is None:
+                return RecreateResult.none()
+            detail = f" [unverified commits: {', '.join(unverified_shas)}]"
 
-        # 4. Guard against duplicate recreate comments
+        # Guard against duplicate recreate comments
         if await self._recreate_already_requested(repo_owner, repo_name, pr_info):
-            return None
+            return RecreateResult.none()
 
-        # 5. Post the recreate comment
         self._pr_status(
-            f"🔄 Requesting dependabot recreate: {pr_info.html_url} "
-            f"[unverified commits: {', '.join(unverified_shas)}]",
+            f"🔄 Requesting dependabot recreate: {pr_info.html_url}{detail}",
             level="info",
         )
 
         if not await self._post_recreate_comment(repo_owner, repo_name, pr_info):
-            return None
+            return RecreateResult.none()
 
-        # 6. Poll for the old PR to close and a replacement to appear.
+        # Poll for the old PR to close and a replacement to appear.
         return await self._await_dependabot_recreate(repo_owner, repo_name, pr_info)
 
     async def _recreate_branch_requires_signatures(
@@ -215,26 +225,65 @@ class _DependabotRecreateMixin(_MergeManagerBase):
 
     async def _await_dependabot_recreate(
         self, repo_owner: str, repo_name: str, pr_info: PullRequestInfo
-    ) -> PullRequestInfo | None:
+    ) -> RecreateResult:
         """Wait for the old PR to close and its replacement to appear.
 
-        Dependabot typically responds within 30-90 seconds.  We poll
-        using the centralised merge timeout.  The whole poll (including
-        the nested recreated-PR checks wait) is a wait on dependabot +
-        CI, so the worker's concurrency slot is released for its
-        duration (``parked()``).
+        Dependabot typically responds within 30-90 seconds.  The whole
+        poll --- including the nested recreated-PR checks wait --- is a
+        wait on dependabot and CI, so the worker's concurrency slot is
+        released for its duration (``parked()``).
+
+        **One** deadline governs the whole path.  It is established here
+        and passed into the nested wait, which previously started a
+        fresh budget of its own: finding a replacement near the ceiling
+        could then add another complete ``merge_timeout`` on top of
+        whatever this loop had already spent, so a single PR could
+        consume ``2 x merge_timeout`` beyond ``--max-wait`` while
+        holding its slot lease.
         """
         # Resolved through the package at call time rather than bound at
         # import time, so that a test rebinding the constant on
         # ``dependamerge.merge_manager`` is observed here.
         from dependamerge import merge_manager as _mm
 
+        # ``--max-wait 0`` promises never to block.  The recreate macro
+        # has been posted, so dependabot still acts on it --- but note
+        # what this does **not** do: returning here means the
+        # replacement is never discovered, so nothing approves or arms
+        # auto-merge on it.  Dependabot typically takes 30-90 seconds to
+        # open the replacement, so there is nothing to find yet, and
+        # searching for it would be the very wait this flag forbids.
+        #
+        # The replacement is therefore left for a later run to collect
+        # and merge normally.  Under ``--max-wait 0`` this PR is
+        # reported as a failure, which is accurate: nothing will finish
+        # it without another run.
+        if self._no_wait:
+            self.log.debug(
+                "Not waiting for dependabot recreate on %s#%s (--max-wait 0)",
+                pr_info.repository_full_name,
+                pr_info.number,
+            )
+            return RecreateResult.none()
+
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + self._merge_timeout
+        if self._run_deadline is not None:
+            deadline = min(deadline, self._run_deadline)
+
         max_polls = self._merge_poll_max_attempts
         old_pr_closed = False
 
         async with _mm.parked():
             for attempt in range(max_polls):
-                await asyncio.sleep(self._merge_recheck_interval)
+                # Clamped rather than merely checked: sleeping a whole
+                # interval with less than that left would overshoot the
+                # ceiling, which is what the other deadline-aware waits
+                # avoid.
+                remaining = deadline - loop.time()
+                if remaining <= 0:
+                    break
+                await asyncio.sleep(min(self._merge_recheck_interval, remaining))
 
                 # 6a. Check if the old PR has been closed
                 if not old_pr_closed:
@@ -244,13 +293,13 @@ class _DependabotRecreateMixin(_MergeManagerBase):
 
                 # 6b. Once the old PR is closed, look for the replacement
                 if old_pr_closed:
-                    resolved, new_pr_info = await self._find_recreated_pr(
-                        repo_owner, repo_name, pr_info
+                    resolved, recreate = await self._find_recreated_pr(
+                        repo_owner, repo_name, pr_info, deadline
                     )
                     # Always return after the first wait attempt to avoid
                     # performing multiple long waits for the same PR.
                     if resolved:
-                        return new_pr_info
+                        return recreate
 
                 if attempt % 3 == 2:
                     self.log.debug(
@@ -266,7 +315,7 @@ class _DependabotRecreateMixin(_MergeManagerBase):
             pr_info.repository_full_name,
             pr_info.number,
         )
-        return None
+        return RecreateResult.none()
 
     async def _old_pr_is_closed(
         self,
@@ -300,33 +349,32 @@ class _DependabotRecreateMixin(_MergeManagerBase):
         return False
 
     async def _find_recreated_pr(
-        self, repo_owner: str, repo_name: str, pr_info: PullRequestInfo
-    ) -> tuple[bool, PullRequestInfo | None]:
+        self,
+        repo_owner: str,
+        repo_name: str,
+        pr_info: PullRequestInfo,
+        deadline: float | None = None,
+    ) -> tuple[bool, RecreateResult]:
         """Look for the replacement PR and wait for its checks.
 
-        Returns a ``(resolved, pr_info)`` pair.  ``resolved`` is True once
+        Returns a ``(resolved, result)`` pair.  ``resolved`` is True once
         a replacement has been found and waited on, whatever the outcome
         of that wait; the caller then stops polling.
+
+        The guard covers **only** the search request.  Wrapping the wait
+        as well would contradict the caller's own comment --- "always
+        return after the first wait attempt" --- because a failure
+        inside a multi-minute wait would be swallowed as a failed search
+        and the caller would repeat the whole wait.
         """
         if not self._github_client:
-            return False, None
+            return False, RecreateResult.none()
         try:
             # Search for open PRs from dependabot on the same head branch
             prs = await self._github_client.get(
                 f"/repos/{repo_owner}/{repo_name}/pulls"
                 f"?state=open&head={repo_owner}:{pr_info.head_branch}&per_page=5"
             )
-            if isinstance(prs, list):
-                for pr_data in prs:
-                    new_number = self._recreated_pr_number(pr_data, pr_info)
-                    if new_number is None:
-                        continue
-
-                    # Found a replacement — now wait for checks to pass
-                    new_pr_info = await self._wait_for_recreated_pr_checks(
-                        repo_owner, repo_name, new_number, pr_data
-                    )
-                    return True, new_pr_info
         except Exception as e:
             self.log.debug(
                 "Error searching for replacement PR for %s#%s: %s",
@@ -334,7 +382,22 @@ class _DependabotRecreateMixin(_MergeManagerBase):
                 pr_info.number,
                 e,
             )
-        return False, None
+            return False, RecreateResult.none()
+
+        if isinstance(prs, list):
+            for pr_data in prs:
+                new_number = self._recreated_pr_number(pr_data, pr_info)
+                if new_number is None:
+                    continue
+
+                # Found a replacement --- now wait for checks to pass.
+                # Deliberately outside the guard above: a failure here
+                # must propagate rather than trigger a second full wait.
+                recreate = await self._wait_for_recreated_pr_checks(
+                    repo_owner, repo_name, new_number, pr_data, deadline
+                )
+                return True, recreate
+        return False, RecreateResult.none()
 
     def _recreated_pr_number(self, pr_data: Any, pr_info: PullRequestInfo) -> Any:
         """Return the PR number when ``pr_data`` is a viable replacement.

--- a/src/dependamerge/merge_manager/_precommit_ci.py
+++ b/src/dependamerge/merge_manager/_precommit_ci.py
@@ -286,16 +286,42 @@ class _PrecommitCiMixin(_MergeManagerBase):
         PRs as unmergeable when the check simply hasn't finished yet.
         The whole poll is a wait on an external service, so the worker's
         concurrency slot is released for its duration (``parked()``).
+
+        The poll honours the run-wide ceiling ``--max-wait`` sets, in
+        the same way as the auto-merge and required-workflow waits: a
+        stale pre-commit status previously parked the worker for the
+        full ``merge_timeout`` even under ``--max-wait 0``, which
+        promises never to block.
         """
         # Resolved through the package at call time rather than bound at
         # import time, so that a test rebinding the constant on
         # ``dependamerge.merge_manager`` is observed here.
         from dependamerge import merge_manager as _mm
 
+        if self._no_wait:
+            self.log.debug(
+                "Not waiting for pre-commit.ci on %s#%s (--max-wait 0)",
+                pr_info.repository_full_name,
+                pr_info.number,
+            )
+            return False
+
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + self._merge_timeout
+        if self._run_deadline is not None:
+            deadline = min(deadline, self._run_deadline)
+
         max_polls = self._merge_poll_max_attempts
         async with _mm.parked():
             for attempt in range(max_polls):
-                await asyncio.sleep(self._merge_recheck_interval)
+                # Sleep no longer than the time remaining, matching
+                # ``_wait_for_auto_merge`` and the required-workflow
+                # wait.  Checking the deadline without clamping would
+                # still overshoot the ceiling by up to a full interval.
+                remaining = deadline - loop.time()
+                if remaining <= 0:
+                    break
+                await asyncio.sleep(min(self._merge_recheck_interval, remaining))
                 outcome = await self._poll_precommit_status(
                     repo_owner, repo_name, pr_info
                 )

--- a/src/dependamerge/merge_manager/_recreated_pr.py
+++ b/src/dependamerge/merge_manager/_recreated_pr.py
@@ -10,34 +10,13 @@ from __future__ import annotations
 import asyncio
 from typing import TYPE_CHECKING, Any
 
+from ..github_async import PermissionError as GitHubPermissionError
 from ..models import PullRequestInfo
 from ._base import _MergeManagerBase
+from ._types import RecreateOutcome, RecreateResult
 
 if TYPE_CHECKING:
-    from ..models import FileChange
-
-
-def _collect_file_changes(files_data: Any, into: list[FileChange]) -> None:
-    """Append one page of the files API response to ``into``.
-
-    Appends in place so a failure part-way through pagination keeps
-    whatever was already gathered, as the unrefactored loop did.
-    """
-    from ..models import FileChange
-
-    if not isinstance(files_data, list):
-        return
-    for f in files_data:
-        if isinstance(f, dict):
-            into.append(
-                FileChange(
-                    filename=f.get("filename", ""),
-                    additions=int(f.get("additions", 0)),
-                    deletions=int(f.get("deletions", 0)),
-                    changes=int(f.get("changes", 0)),
-                    status=f.get("status", "modified"),
-                )
-            )
+    pass
 
 
 class _RecreatedPullRequestMixin(_MergeManagerBase):
@@ -49,26 +28,44 @@ class _RecreatedPullRequestMixin(_MergeManagerBase):
         repo_name: str,
         new_number: int,
         pr_data: dict[str, Any],
-    ) -> PullRequestInfo | None:
+        deadline: float | None = None,
+    ) -> RecreateResult:
         """
         Wait for the recreated PR's status checks to complete.
 
-        Polls the new PR using the shared merge timeout settings. The
-        total wait here is controlled by ``self._merge_poll_max_attempts
-        * self._merge_recheck_interval`` (default: ~5 minutes), so
-        ``--merge-timeout`` also affects this loop.
+        Auto-merge is armed on the replacement **before** this poll
+        starts, so it can complete between iterations.  The wait
+        therefore distinguishes the terminal states rather than only
+        "mergeable" versus "keep polling": ready, already merged,
+        abandoned (closed unmerged, or conflicted), and still pending.
+        Reporting a merged replacement as a timeout would under-report a
+        success, which is the most damaging direction to be wrong in.
+
+        Giving up is **not** the same as finding nothing.  Once
+        auto-merge is armed the replacement is expected to merge on its
+        own, so a ceiling, an exhausted poll budget or ``--max-wait 0``
+        all yield ``PENDING`` carrying that PR, which the caller reports
+        as ``AUTO_MERGE_PENDING``.  ``NONE`` is reserved for the cases
+        where nothing was acted on --- including a replacement we could
+        not arm, which will not merge by itself.
 
         Args:
             repo_owner: Repository owner.
             repo_name: Repository name.
             new_number: The PR number of the recreated pull request.
             pr_data: The initial PR data dict from the GitHub API.
+            deadline: Monotonic deadline shared with the enclosing
+                recreate poll.  Passed in rather than derived here so
+                the recreate path spends **one** budget in total; a
+                fresh one would let a single PR consume a second full
+                ``merge_timeout`` on top of whatever the outer loop had
+                already spent.
 
         Returns:
-            A ``PullRequestInfo`` if the PR became mergeable, None on timeout.
+            A :class:`RecreateResult` naming the terminal state.
         """
         if not self._github_client:
-            return None
+            return RecreateResult.none()
 
         full_name = f"{repo_owner}/{repo_name}"
         html_url = pr_data.get(
@@ -80,48 +77,74 @@ class _RecreatedPullRequestMixin(_MergeManagerBase):
             level="info",
         )
 
-        await self._auto_merge_recreated_pr(repo_owner, repo_name, new_number, pr_data)
+        replacement = self._recreated_pr_stub(
+            repo_owner, repo_name, new_number, pr_data
+        )
+        armed = await self._auto_merge_recreated_pr(repo_owner, repo_name, replacement)
+
+        def _gave_up(reason: str) -> RecreateResult:
+            """Stop waiting without claiming the replacement failed."""
+            if not armed:
+                # Nothing will happen on its own, so there is no
+                # in-flight merge to report as pending.
+                self.log.warning(
+                    "Stopped waiting on recreated PR %s#%s (%s); "
+                    "auto-merge was not enabled",
+                    full_name,
+                    new_number,
+                    reason,
+                )
+                return RecreateResult.none()
+            self._pr_status(
+                f"⏳ Recreated PR left to auto-merge: {html_url} [{reason}]",
+                level="info",
+            )
+            return RecreateResult(RecreateOutcome.PENDING, replacement)
+
+        # ``--max-wait 0`` promises never to block.  Auto-merge has been
+        # armed above, so GitHub still completes the merge later --- the
+        # same fire-and-forget shape the other waits use.
+        if self._no_wait:
+            return _gave_up("--max-wait 0")
 
         # Poll for the new PR to become mergeable
+        loop = asyncio.get_running_loop()
         max_check_polls = self._merge_poll_max_attempts
         for check_attempt in range(max_check_polls):
-            await asyncio.sleep(self._merge_recheck_interval)
-            settled, ready = await self._poll_recreated_pr(
+            if deadline is None:
+                await asyncio.sleep(self._merge_recheck_interval)
+            else:
+                # Clamped to the remaining budget so a replacement found
+                # near ``--max-wait`` cannot extend the run past it by a
+                # further interval.
+                remaining = deadline - loop.time()
+                if remaining <= 0:
+                    return _gave_up("wait ceiling reached")
+                await asyncio.sleep(min(self._merge_recheck_interval, remaining))
+            outcome = await self._poll_recreated_pr(
                 full_name, new_number, html_url, check_attempt
             )
-            if settled:
-                return ready
+            if outcome is not None:
+                return outcome
 
-        self.log.warning(
-            "Timed out waiting for checks on recreated PR %s#%s",
-            full_name,
-            new_number,
-        )
-        return None
+        return _gave_up("timed out waiting for checks")
 
-    async def _auto_merge_recreated_pr(
+    def _recreated_pr_stub(
         self,
         repo_owner: str,
         repo_name: str,
         new_number: int,
         pr_data: dict[str, Any],
-    ) -> None:
-        """Enable auto-merge on the recreated PR.
+    ) -> PullRequestInfo:
+        """Build a minimal ``PullRequestInfo`` for the replacement.
 
-        Doing so means it still merges even if we time out waiting for
-        status checks.
+        The full object needs a files fetch this path does not need, so
+        the stub carries what arming auto-merge and reporting an
+        outcome require.  Shared by both, so a ``PENDING`` result names
+        exactly the PR auto-merge was armed on.
         """
-        if not pr_data.get("node_id"):
-            return
-
         full_name = f"{repo_owner}/{repo_name}"
-        html_url = pr_data.get(
-            "html_url", f"https://github.com/{full_name}/pull/{new_number}"
-        )
-
-        # We don't have a full PullRequestInfo yet, but we can
-        # construct a minimal one for the auto-merge helper.
-        _tmp_pr = PullRequestInfo(
+        return PullRequestInfo(
             number=new_number,
             node_id=pr_data.get("node_id"),
             title=pr_data.get("title", ""),
@@ -136,108 +159,109 @@ class _RecreatedPullRequestMixin(_MergeManagerBase):
             behind_by=None,
             files_changed=[],
             repository_full_name=full_name,
-            html_url=html_url,
+            html_url=pr_data.get(
+                "html_url", f"https://github.com/{full_name}/pull/{new_number}"
+            ),
         )
-        await self._enable_auto_merge_for_pr(_tmp_pr, repo_owner, repo_name)
 
-    async def _poll_recreated_pr(
+    async def _auto_merge_recreated_pr(
         self,
-        full_name: str,
-        new_number: int,
-        html_url: str,
-        check_attempt: int,
-    ) -> tuple[bool, PullRequestInfo | None]:
-        """Take one reading of the recreated PR's mergeability.
+        repo_owner: str,
+        repo_name: str,
+        replacement: PullRequestInfo,
+    ) -> bool:
+        """Approve the replacement and arm auto-merge, reporting **both**.
 
-        Returns a ``(settled, pr_info)`` pair.  ``settled`` is True once
-        the wait is over: either the PR is ready, in which case
-        ``pr_info`` describes it, or it is conflicted and the caller
-        should give up.
+        Arming auto-merge is a commitment to let GitHub finish the merge
+        once branch protection is satisfied, so the head must already
+        carry this run's approval --- otherwise, on a repository that
+        requires reviews, auto-merge waits forever.  The approval in
+        :meth:`_merge_recreated_pr` is reached only for ``READY``, so a
+        replacement we stop waiting on has no other chance to get one.
+
+        The approve-and-arm helper is deliberately **not** used here.
+        It swallows non-permission approval failures and returns the
+        *arming* result, so a ``True`` from it evidences only that
+        auto-merge is active --- a distinction that does not matter
+        where a real merge is attempted afterwards, but does here,
+        because ``PENDING`` is a claim about what will happen without
+        us.  Approving separately keeps the two signals apart.
+
+        Note the approval signal is **whether it raised**, not what it
+        returned.  ``_ensure_pr_approved`` returns ``True`` only when a
+        *new* review was submitted and ``False`` when the head is
+        already sufficiently approved --- by us or by anyone else ---
+        so treating ``False`` as "not approved" would reject exactly
+        the replacements that are ready to go.  Genuine failures arrive
+        as exceptions.
+
+        Returns True only when approval is satisfied **and** auto-merge
+        is active; anything less cannot be reported as pending.  Typed
+        permission errors propagate, as they do in the shared helper, so
+        the caller's dedicated handler can report them.
         """
-        if not self._github_client:
-            return False, None
+        if not replacement.node_id:
+            return False
+
+        pr_key = f"{repo_owner}/{repo_name}#{replacement.number}"
         try:
-            refreshed = await self._github_client.get(
-                f"/repos/{full_name}/pulls/{new_number}"
+            return await self._approve_and_arm_replacement(
+                repo_owner, repo_name, replacement
             )
-            if not isinstance(refreshed, dict):
-                return False, None
+        finally:
+            # Discard where it was added, rather than after the caller's
+            # outcome handling.  ``_ensure_pr_approved`` registers the
+            # replacement, but ``_merge_single_pr_impl``'s cleanup knows
+            # only about the *original* PR, so anything that leaves this
+            # path early --- an exception or cancellation while arming,
+            # polling or merging --- would strand the key.  A stale
+            # entry makes a later run on a reused manager treat a new
+            # head as already approved and skip approval recovery.
+            #
+            # Nothing in the recreate path reads the key: the ``READY``
+            # merge approves via ``_approve_pr`` directly, and GitHub
+            # itself de-duplicates a repeat approval.
+            self._recently_approved.discard(pr_key)
 
-            mergeable = refreshed.get("mergeable")
-            mergeable_state = refreshed.get("mergeable_state")
-
-            if mergeable_state == "clean" or (
-                mergeable is True and mergeable_state in ("clean", "unstable")
-            ):
-                self._pr_status(
-                    f"✅ Recreated PR is ready to merge: {html_url}",
-                    level="info",
-                )
-                files_changed = await self._recreated_pr_files(full_name, new_number)
-                return True, PullRequestInfo(
-                    number=new_number,
-                    node_id=refreshed.get("node_id"),
-                    title=refreshed.get("title", ""),
-                    body=refreshed.get("body"),
-                    author=((refreshed.get("user") or {}).get("login", "")),
-                    head_sha=((refreshed.get("head") or {}).get("sha", "")),
-                    base_branch=((refreshed.get("base") or {}).get("ref", "")),
-                    head_branch=((refreshed.get("head") or {}).get("ref", "")),
-                    state=refreshed.get("state", "open"),
-                    mergeable=mergeable,
-                    mergeable_state=mergeable_state,
-                    behind_by=None,
-                    files_changed=files_changed,
-                    repository_full_name=full_name,
-                    html_url=html_url,
-                )
-
-            if mergeable_state == "dirty":
-                self.log.warning(
-                    "Recreated PR %s#%s has merge conflicts; aborting wait.",
-                    full_name,
-                    new_number,
-                )
-                return True, None
-
-            # blocked / behind / unknown — keep polling
-            if check_attempt % 3 == 2:
-                self.log.debug(
-                    "Waiting for checks on recreated PR %s#%s "
-                    "(state=%s, %.0fs elapsed)",
-                    full_name,
-                    new_number,
-                    mergeable_state,
-                    (check_attempt + 1) * self._merge_recheck_interval,
-                )
-
-        except Exception as e:
-            self.log.debug(
-                "Error polling recreated PR %s#%s: %s",
-                full_name,
-                new_number,
-                e,
-            )
-        return False, None
-
-    async def _recreated_pr_files(
-        self, full_name: str, new_number: int
-    ) -> list[FileChange]:
-        """Gather the recreated PR's changed files, tolerating failure."""
-        files_changed: list[FileChange] = []
-        if not self._github_client:
-            return files_changed
+    async def _approve_and_arm_replacement(
+        self,
+        repo_owner: str,
+        repo_name: str,
+        replacement: PullRequestInfo,
+    ) -> bool:
+        """Approve then arm, reporting whether both succeeded."""
         try:
-            async for files_data in self._github_client.get_paginated(
-                f"/repos/{full_name}/pulls/{new_number}/files",
-                per_page=100,
-            ):
-                _collect_file_changes(files_data, files_changed)
-        except Exception as e:
-            self.log.debug(
-                "Failed to fetch files for recreated PR %s#%s: %s",
-                full_name,
-                new_number,
-                e,
+            # No propagation delay: we are arming auto-merge, not
+            # dispatching a merge, and GitHub re-checks branch
+            # protection when the required checks finish.
+            await self._ensure_pr_approved(
+                replacement, repo_owner, repo_name, propagation_delay=False
             )
-        return files_changed
+            approved = True
+        except GitHubPermissionError:
+            raise
+        except Exception as exc:
+            self.log.warning(
+                "Could not approve recreated PR %s/%s#%s: %s",
+                repo_owner,
+                repo_name,
+                replacement.number,
+                exc,
+            )
+            approved = False
+
+        armed = await self._enable_auto_merge_for_pr(replacement, repo_owner, repo_name)
+
+        if armed and not approved:
+            # Arming still helps --- the PR may merge if the repository
+            # needs no review --- but we cannot promise it, so the
+            # caller must not report it as pending.
+            self.log.warning(
+                "Auto-merge armed on %s/%s#%s but approval failed; "
+                "not reporting it as pending.",
+                repo_owner,
+                repo_name,
+                replacement.number,
+            )
+
+        return armed and approved

--- a/src/dependamerge/merge_manager/_recreated_pr_poll.py
+++ b/src/dependamerge/merge_manager/_recreated_pr_poll.py
@@ -1,0 +1,225 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 The Linux Foundation
+
+"""
+Reading a recreated pull request's state and classifying it.
+
+Split from :mod:`._recreated_pr`, which orchestrates the wait; this
+module holds the per-poll reading, the terminal classification of a
+closed replacement, and the changed-files fetch.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from ..models import PullRequestInfo
+from ._base import _MergeManagerBase
+from ._types import RecreateOutcome, RecreateResult, _merged_from_payload
+
+if TYPE_CHECKING:
+    from ..models import FileChange
+
+
+def _collect_file_changes(files_data: Any, into: list[FileChange]) -> None:
+    """Append one page of the files API response to ``into``.
+
+    Appends in place so a failure part-way through pagination keeps
+    whatever was already gathered, as the unrefactored loop did.
+    """
+    from ..models import FileChange
+
+    if not isinstance(files_data, list):
+        return
+    for f in files_data:
+        if isinstance(f, dict):
+            into.append(
+                FileChange(
+                    filename=f.get("filename", ""),
+                    additions=int(f.get("additions", 0)),
+                    deletions=int(f.get("deletions", 0)),
+                    changes=int(f.get("changes", 0)),
+                    status=f.get("status", "modified"),
+                )
+            )
+
+
+class _RecreatedPollMixin(_MergeManagerBase):
+    """Taking and classifying readings of a recreated pull request."""
+
+    async def _poll_recreated_pr(
+        self,
+        full_name: str,
+        new_number: int,
+        html_url: str,
+        check_attempt: int,
+    ) -> RecreateResult | None:
+        """Take one reading of the recreated PR's state.
+
+        Returns ``None`` while the wait should continue, or a
+        :class:`RecreateResult` once it has reached a terminal state.
+        """
+        if not self._github_client:
+            return None
+        try:
+            refreshed = await self._github_client.get(
+                f"/repos/{full_name}/pulls/{new_number}"
+            )
+            if not isinstance(refreshed, dict):
+                return None
+
+            mergeable = refreshed.get("mergeable")
+            mergeable_state = refreshed.get("mergeable_state")
+
+            # Checked first: auto-merge was armed before this loop began,
+            # so the replacement can close between polls.  A closed
+            # payload satisfies neither the ready test nor the "dirty"
+            # test below, so without this branch the loop would run to
+            # timeout and the caller would report a failure for a PR
+            # that had in fact merged.
+            if refreshed.get("state") == "closed":
+                return self._closed_recreated_pr(
+                    full_name, new_number, html_url, refreshed
+                )
+
+            # ``mergeable_state == "clean"`` alone is enough; the second
+            # test covers "unstable", where non-required checks are still
+            # running but the PR can merge.
+            if mergeable_state == "clean" or (
+                mergeable is True and mergeable_state == "unstable"
+            ):
+                self._pr_status(
+                    f"✅ Recreated PR is ready to merge: {html_url}",
+                    level="info",
+                )
+                files_changed = await self._recreated_pr_files(full_name, new_number)
+                return RecreateResult(
+                    RecreateOutcome.READY,
+                    PullRequestInfo(
+                        number=new_number,
+                        node_id=refreshed.get("node_id"),
+                        title=refreshed.get("title", ""),
+                        body=refreshed.get("body"),
+                        author=((refreshed.get("user") or {}).get("login", "")),
+                        head_sha=((refreshed.get("head") or {}).get("sha", "")),
+                        base_branch=((refreshed.get("base") or {}).get("ref", "")),
+                        head_branch=((refreshed.get("head") or {}).get("ref", "")),
+                        state=refreshed.get("state", "open"),
+                        mergeable=mergeable,
+                        mergeable_state=mergeable_state,
+                        behind_by=None,
+                        files_changed=files_changed,
+                        repository_full_name=full_name,
+                        html_url=html_url,
+                    ),
+                )
+
+            if mergeable_state == "dirty":
+                self.log.warning(
+                    "Recreated PR %s#%s has merge conflicts; aborting wait.",
+                    full_name,
+                    new_number,
+                )
+                # Carry the replacement, as the closed branch does: the
+                # caller reports ABANDONED against this PR, and the
+                # original is already closed by dependabot, so without
+                # it the operator would be pointed at the wrong PR.
+                repo_owner, repo_name = full_name.split("/", 1)
+                return RecreateResult(
+                    RecreateOutcome.ABANDONED,
+                    self._recreated_pr_stub(
+                        repo_owner, repo_name, new_number, refreshed
+                    ),
+                )
+
+            # blocked / behind / unknown — keep polling
+            if check_attempt % 3 == 2:
+                self.log.debug(
+                    "Waiting for checks on recreated PR %s#%s "
+                    "(state=%s, %.0fs elapsed)",
+                    full_name,
+                    new_number,
+                    mergeable_state,
+                    (check_attempt + 1) * self._merge_recheck_interval,
+                )
+
+        except Exception as e:
+            self.log.debug(
+                "Error polling recreated PR %s#%s: %s",
+                full_name,
+                new_number,
+                e,
+            )
+        return None
+
+    def _closed_recreated_pr(
+        self,
+        full_name: str,
+        new_number: int,
+        html_url: str,
+        refreshed: dict[str, Any],
+    ) -> RecreateResult:
+        """Classify a replacement PR that has closed.
+
+        Closed-and-merged is a success; closed-unmerged is a resolved
+        failure.  Neither should keep polling, and neither should be
+        merged again by the caller.
+        """
+        merged = _merged_from_payload(refreshed)
+        pr_info = PullRequestInfo(
+            number=new_number,
+            node_id=refreshed.get("node_id"),
+            title=refreshed.get("title", ""),
+            body=refreshed.get("body"),
+            author=((refreshed.get("user") or {}).get("login", "")),
+            head_sha=((refreshed.get("head") or {}).get("sha", "")),
+            base_branch=((refreshed.get("base") or {}).get("ref", "")),
+            head_branch=((refreshed.get("head") or {}).get("ref", "")),
+            state="closed",
+            mergeable=refreshed.get("mergeable"),
+            mergeable_state=refreshed.get("mergeable_state"),
+            behind_by=None,
+            files_changed=[],
+            repository_full_name=full_name,
+            html_url=html_url,
+        )
+
+        if merged:
+            self._pr_status(
+                f"✅ Recreated PR merged while waiting: {html_url}",
+                level="info",
+            )
+            return RecreateResult(RecreateOutcome.MERGED, pr_info)
+
+        # ``merged`` may be None for a payload carrying neither field.
+        # Treat that as unmerged: the PR is closed either way, so there
+        # is nothing left to wait for, and claiming a merge we cannot
+        # evidence would be the wrong direction to guess in.
+        self.log.warning(
+            "Recreated PR %s#%s closed without merging; aborting wait.",
+            full_name,
+            new_number,
+        )
+        return RecreateResult(RecreateOutcome.ABANDONED, pr_info)
+
+    async def _recreated_pr_files(
+        self, full_name: str, new_number: int
+    ) -> list[FileChange]:
+        """Gather the recreated PR's changed files, tolerating failure."""
+        files_changed: list[FileChange] = []
+        if not self._github_client:
+            return files_changed
+        try:
+            async for files_data in self._github_client.get_paginated(
+                f"/repos/{full_name}/pulls/{new_number}/files",
+                per_page=100,
+            ):
+                _collect_file_changes(files_data, files_changed)
+        except Exception as e:
+            self.log.debug(
+                "Failed to fetch files for recreated PR %s#%s: %s",
+                full_name,
+                new_number,
+                e,
+            )
+        return files_changed

--- a/src/dependamerge/merge_manager/_single_pr_outcome.py
+++ b/src/dependamerge/merge_manager/_single_pr_outcome.py
@@ -13,9 +13,10 @@ rescue.
 
 from __future__ import annotations
 
+from ..models import PullRequestInfo
 from ._single_pr_context import _MergeFlow
 from ._single_pr_recreate import _SinglePrRecreateMixin
-from ._types import MergeResult, MergeStatus
+from ._types import MergeResult, MergeStatus, RecreateOutcome
 
 
 class _SinglePrOutcomeMixin(_SinglePrRecreateMixin):
@@ -68,9 +69,27 @@ class _SinglePrOutcomeMixin(_SinglePrRecreateMixin):
         # decision and the final error reporting.
         failure_reason = await self._get_failure_summary(flow.pr_info)
 
-        recreated_pr = await self._maybe_recreate_dependabot_pr(flow, failure_reason)
-        if recreated_pr is not None:
-            await self._merge_recreated_pr(flow, recreated_pr)
+        recreate = await self._maybe_recreate_dependabot_pr(flow, failure_reason)
+        if recreate.outcome is RecreateOutcome.READY and recreate.pr_info is not None:
+            await self._merge_recreated_pr(flow, recreate.pr_info)
+        elif (
+            recreate.outcome is RecreateOutcome.MERGED and recreate.pr_info is not None
+        ):
+            # Auto-merge is armed on the replacement before the wait
+            # begins, so it can complete between polls.  Record the
+            # success rather than attempting a merge on a closed PR.
+            self._record_recreated_merge(flow, recreate.pr_info)
+        elif (
+            recreate.outcome is RecreateOutcome.PENDING and recreate.pr_info is not None
+        ):
+            # We stopped waiting, but the replacement is open, approved
+            # and armed, so it is expected to merge on its own.
+            # Reporting the original as FAILED would under-report a
+            # success, and ``_confirm_failure`` could not correct it:
+            # it rechecks the original PR, not the replacement.
+            self._record_recreated_pending(flow, recreate.pr_info)
+        elif recreate.outcome is RecreateOutcome.ABANDONED:
+            self._record_recreated_abandoned(flow, recreate.pr_info)
         else:
             await self._report_merge_failure(
                 flow.pr_info,
@@ -80,6 +99,75 @@ class _SinglePrOutcomeMixin(_SinglePrRecreateMixin):
                 failure_reason,
             )
         return None
+
+    def _record_recreated_merge(
+        self, flow: _MergeFlow, recreated_pr: PullRequestInfo
+    ) -> None:
+        """Record a replacement PR that merged while we were waiting."""
+        flow.result.status = MergeStatus.MERGED
+        flow.result.pr_info = recreated_pr
+        self._pr_status(
+            f"✅ Merged (recreated, by auto-merge): {recreated_pr.html_url}",
+            level="debug",
+        )
+
+    def _record_recreated_pending(
+        self, flow: _MergeFlow, recreated_pr: PullRequestInfo
+    ) -> None:
+        """Record a replacement PR left in flight under auto-merge.
+
+        The same treatment ``--max-wait`` gives any armed-but-unfinished
+        merge: report it as pending rather than as a failure, so the
+        run's counts describe what is actually going to happen.
+
+        The reason goes on ``error`` because that is the field the
+        end-of-run report reads (``cli/_merge_report.py``), and the
+        convention every other ``AUTO_MERGE_PENDING`` path already
+        follows.  Putting it on ``warning`` would leave the operator
+        looking at "no reason reported".
+        """
+        flow.result.status = MergeStatus.AUTO_MERGE_PENDING
+        flow.result.pr_info = recreated_pr
+        flow.result.error = (
+            "auto-merge pending: dependabot recreated this PR as "
+            f"#{recreated_pr.number}, which is approved and armed"
+        )
+        self._pr_status(
+            f"⏳ Auto-merge pending (recreated): {recreated_pr.html_url}",
+            level="debug",
+        )
+
+    def _record_recreated_abandoned(
+        self, flow: _MergeFlow, replacement: PullRequestInfo | None
+    ) -> None:
+        """Record a replacement that will not merge without help.
+
+        ``BLOCKED`` rather than ``FAILED``, because after a recreate the
+        **original** PR is closed unmerged by dependabot --- so a
+        ``FAILED`` result is rewritten to ``CLOSED`` by
+        ``_confirm_failure``, which documents ``CLOSED`` as "nothing for
+        the operator to follow up on".  That is the opposite of what a
+        conflicted or closed-unmerged replacement needs.
+        ``_confirm_failure`` returns early for any status other than
+        ``FAILED``, so ``BLOCKED`` survives it, and it is the status
+        already used elsewhere for "will not merge on its own".
+        """
+        flow.result.status = MergeStatus.BLOCKED
+        if replacement is not None:
+            flow.result.pr_info = replacement
+            flow.result.error = (
+                f"dependabot recreated this PR as #{replacement.number}, "
+                "which is conflicted or closed unmerged and needs attention"
+            )
+        else:
+            flow.result.error = (
+                "dependabot recreated this PR, but the replacement is "
+                "conflicted or closed unmerged and needs attention"
+            )
+        self._pr_status(
+            f"🛑 Blocked (recreated): {flow.result.pr_info.html_url}",
+            level="debug",
+        )
 
     async def _external_closure_result(self, flow: _MergeFlow) -> MergeResult | None:
         """Recognise a PR that merged or closed outside this run.

--- a/src/dependamerge/merge_manager/_single_pr_recreate.py
+++ b/src/dependamerge/merge_manager/_single_pr_recreate.py
@@ -27,7 +27,7 @@ from ..bot_identity import is_dependabot
 from ..models import PullRequestInfo
 from ._base import _MergeManagerBase
 from ._single_pr_context import _MergeFlow
-from ._types import MergeStatus
+from ._types import MergeStatus, RecreateCause, RecreateResult
 
 
 class _SinglePrRecreateMixin(_MergeManagerBase):
@@ -35,24 +35,32 @@ class _SinglePrRecreateMixin(_MergeManagerBase):
 
     async def _maybe_recreate_dependabot_pr(
         self, flow: _MergeFlow, failure_reason: str
-    ) -> PullRequestInfo | None:
+    ) -> RecreateResult:
         """Ask dependabot to recreate the PR, when that can help."""
         pr_info = flow.pr_info
         if not (is_dependabot(pr_info.author) and not self.preview_mode):
-            return None
-        if not await self._should_request_recreate(flow, failure_reason):
-            return None
+            return RecreateResult.none()
+        cause = await self._should_request_recreate(flow, failure_reason)
+        if cause is None:
+            return RecreateResult.none()
 
         self._track_pr_state(pr_info, "recreating")
         try:
-            return await self._trigger_dependabot_recreate(pr_info)
+            return await self._trigger_dependabot_recreate(pr_info, cause)
         finally:
             self._track_pr_state(pr_info, None)
 
     async def _should_request_recreate(
         self, flow: _MergeFlow, failure_reason: str
-    ) -> bool:
-        """Whether the failure is one a fresh head SHA would clear."""
+    ) -> RecreateCause | None:
+        """Why a fresh head SHA would clear this failure, if it would.
+
+        Returning the *cause* rather than a bare boolean is what lets
+        ``_trigger_dependabot_recreate`` apply the signature gates to the
+        unsigned-commit case alone.  Applied to a stuck check they make
+        the recovery inert on any repository that does not require
+        signatures.
+        """
         pr_info = flow.pr_info
         reason_lower = failure_reason.lower()
         # Branch protection *and* repository rulesets can both block a
@@ -61,7 +69,7 @@ class _SinglePrRecreateMixin(_MergeManagerBase):
         # alike so the recreate path is not silently skipped on repos
         # that have migrated from classic protection to rulesets.
         if "branch protection" in reason_lower or "ruleset" in reason_lower:
-            return True
+            return RecreateCause.UNSIGNED
 
         try:
             (
@@ -76,9 +84,7 @@ class _SinglePrRecreateMixin(_MergeManagerBase):
                 pr_info.number,
                 exc,
             )
-            is_stuck = False
-            stuck_check = None
-            stuck_age = 0.0
+            return None
         if is_stuck:
             self._pr_status(
                 f"⏳ Stuck required check detected: {pr_info.html_url} "
@@ -86,8 +92,8 @@ class _SinglePrRecreateMixin(_MergeManagerBase):
                 f"{stuck_age:.0f}s, requesting recreate]",
                 level="info",
             )
-            return True
-        return False
+            return RecreateCause.STUCK_CHECK
+        return None
 
     async def _merge_recreated_pr(
         self, flow: _MergeFlow, recreated_pr: PullRequestInfo
@@ -109,20 +115,42 @@ class _SinglePrRecreateMixin(_MergeManagerBase):
                 f"✅ Merged (recreated): {recreated_pr.html_url}",
                 level="debug",
             )
-        else:
-            result.status = MergeStatus.FAILED
-            result.error = (
-                f"Dependabot recreated PR #{recreated_pr.number} but merge still failed"
-            )
-            self.log.error(
-                "Failed to merge recreated PR %s#%s",
-                recreated_pr.repository_full_name,
-                recreated_pr.number,
-            )
-            self._pr_status(
-                f"❌ Failed: {recreated_pr.html_url} [recreated PR merge failed]",
-                level="error",
-            )
+            return
+
+        # A ``False`` here is not yet evidence of failure.  Auto-merge
+        # was armed on this replacement before the checks wait began, so
+        # it can start between the wait's last poll and this dispatch ---
+        # in which case GitHub answers "merge already in progress",
+        # ``_dispatch_recreated_merge`` swallows it, and we would report
+        # a failure for a PR that is merging.  The outer
+        # ``_confirm_failure`` cannot catch that: it rechecks the
+        # *original* PR, which dependabot has already closed.
+        #
+        # So confirm against the **replacement** before reporting.
+        result.status = MergeStatus.FAILED
+        result.pr_info = recreated_pr
+        result.error = (
+            f"Dependabot recreated PR #{recreated_pr.number} but merge still failed"
+        )
+        await self._confirm_failure(recreated_pr, result)
+
+        if result.status is not MergeStatus.FAILED:
+            # Confirmation corrected it (merged, or closed unmerged).
+            return
+
+        # Genuinely unmerged.  Report BLOCKED rather than FAILED so the
+        # outer confirmation --- which rechecks the closed original ---
+        # cannot rewrite this to CLOSED, i.e. "nothing to follow up on".
+        result.status = MergeStatus.BLOCKED
+        self.log.error(
+            "Failed to merge recreated PR %s#%s",
+            recreated_pr.repository_full_name,
+            recreated_pr.number,
+        )
+        self._pr_status(
+            f"🛑 Blocked: {recreated_pr.html_url} [recreated PR merge failed]",
+            level="error",
+        )
 
     async def _dispatch_recreated_merge(
         self, new_owner: str, new_repo: str, recreated_pr: PullRequestInfo

--- a/src/dependamerge/merge_manager/_types.py
+++ b/src/dependamerge/merge_manager/_types.py
@@ -53,6 +53,72 @@ class MergeResult:
     duration: float = 0.0
 
 
+class RecreateCause(Enum):
+    """Why a Dependabot recreate was requested.
+
+    The two causes are unrelated, and the gates that apply to one do not
+    apply to the other.  ``UNSIGNED`` is the original case: branch
+    protection requires signed commits and this PR carries unverified
+    ones, so the signature checks decide whether a recreate would help.
+    ``STUCK_CHECK`` is a *timing* problem --- a required check that never
+    reported --- where signatures are irrelevant.
+    """
+
+    UNSIGNED = "unsigned"
+    STUCK_CHECK = "stuck_check"
+
+
+class RecreateOutcome(Enum):
+    """What became of a recreate request.
+
+    ``NONE`` covers only the paths where **no replacement was acted
+    on**: the recreate was not applicable, was not triggered, or no
+    replacement was ever found.
+
+    ``MERGED`` is a success --- auto-merge is armed on the replacement
+    before the wait begins, so it can complete between polls.
+
+    ``ABANDONED`` is a *resolved* failure: the replacement is closed or
+    conflicted, so there is nothing left to wait for and nothing to
+    merge.
+
+    ``PENDING`` is the replacement we found, armed and then stopped
+    waiting on --- because the ceiling arrived, the poll budget ran
+    out, or ``--max-wait 0`` asked us not to block at all.  It is
+    deliberately distinct from ``NONE``: the replacement is real, open
+    and expected to merge on its own, so reporting the original as a
+    failure would under-report a success exactly as the closed/merged
+    case did.  ``_confirm_failure`` cannot rescue that, since it
+    rechecks only the original PR.
+    """
+
+    NONE = "none"
+    READY = "ready"
+    MERGED = "merged"
+    ABANDONED = "abandoned"
+    PENDING = "pending"
+
+
+@dataclass(frozen=True)
+class RecreateResult:
+    """The terminal state of a recreate, and the PR it refers to.
+
+    Carrying the outcome separately from the PR is what stops a caller
+    merging a replacement that has already merged, or waiting on one
+    that has closed.  ``pr_info`` is populated for ``READY``,
+    ``MERGED`` and ``PENDING``; it may be present for ``ABANDONED`` to
+    name the PR in a message, and is always ``None`` for ``NONE``.
+    """
+
+    outcome: RecreateOutcome
+    pr_info: PullRequestInfo | None = None
+
+    @classmethod
+    def none(cls) -> RecreateResult:
+        """No replacement was acted on."""
+        return cls(RecreateOutcome.NONE)
+
+
 def _merged_from_payload(payload: dict[str, Any]) -> bool | None:
     """Whether a PR REST payload says the PR merged.
 

--- a/tests/test_dependabot_recreate.py
+++ b/tests/test_dependabot_recreate.py
@@ -28,7 +28,12 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 from dependamerge.github_async import GitHubAsync
-from dependamerge.merge_manager import MergeStatus
+from dependamerge.merge_manager import (
+    MergeStatus,
+    RecreateCause,
+    RecreateOutcome,
+    RecreateResult,
+)
 from dependamerge.models import PullRequestInfo
 
 
@@ -376,24 +381,24 @@ class TestTriggerDependabotRecreateConditions:
     async def test_non_dependabot_author_returns_none(self):
         mgr, _client = _make_manager()  # typed mock client pattern (see conftest.py)
         pr = _make_pr_info(author="some-human")
-        result = await mgr._trigger_dependabot_recreate(pr)
-        assert result is None
+        result = await mgr._trigger_dependabot_recreate(pr, RecreateCause.UNSIGNED)
+        assert result.outcome is RecreateOutcome.NONE
 
     @pytest.mark.asyncio
     async def test_no_github_client_returns_none(self):
         mgr, _client = _make_manager()  # typed mock client pattern (see conftest.py)
         mgr._github_client = None  # intentionally set to None for this test
         pr = _make_pr_info()
-        result = await mgr._trigger_dependabot_recreate(pr)
-        assert result is None
+        result = await mgr._trigger_dependabot_recreate(pr, RecreateCause.UNSIGNED)
+        assert result.outcome is RecreateOutcome.NONE
 
     @pytest.mark.asyncio
     async def test_no_signature_requirement_returns_none(self):
         mgr, client = _make_manager()  # typed mock client pattern (see conftest.py)
         pr = _make_pr_info()
         client.requires_commit_signatures = AsyncMock(return_value=False)
-        result = await mgr._trigger_dependabot_recreate(pr)
-        assert result is None
+        result = await mgr._trigger_dependabot_recreate(pr, RecreateCause.UNSIGNED)
+        assert result.outcome is RecreateOutcome.NONE
         client.requires_commit_signatures.assert_called_once_with(
             "lfreleng-actions", "gerrit-clone-action", "main"
         )
@@ -404,8 +409,8 @@ class TestTriggerDependabotRecreateConditions:
         pr = _make_pr_info()
         client.requires_commit_signatures = AsyncMock(return_value=True)
         client.check_pr_commit_signatures = AsyncMock(return_value=(True, []))
-        result = await mgr._trigger_dependabot_recreate(pr)
-        assert result is None
+        result = await mgr._trigger_dependabot_recreate(pr, RecreateCause.UNSIGNED)
+        assert result.outcome is RecreateOutcome.NONE
 
     @pytest.mark.asyncio
     async def test_duplicate_recreate_comment_returns_none(self):
@@ -421,8 +426,8 @@ class TestTriggerDependabotRecreateConditions:
                 {"body": "@dependabot recreate", "user": {"login": "someuser"}},
             ]
         )
-        result = await mgr._trigger_dependabot_recreate(pr)
-        assert result is None
+        result = await mgr._trigger_dependabot_recreate(pr, RecreateCause.UNSIGNED)
+        assert result.outcome is RecreateOutcome.NONE
 
     @pytest.mark.asyncio
     async def test_signature_check_error_returns_none(self):
@@ -431,8 +436,8 @@ class TestTriggerDependabotRecreateConditions:
         client.requires_commit_signatures = AsyncMock(
             side_effect=Exception("API error")
         )
-        result = await mgr._trigger_dependabot_recreate(pr)
-        assert result is None
+        result = await mgr._trigger_dependabot_recreate(pr, RecreateCause.UNSIGNED)
+        assert result.outcome is RecreateOutcome.NONE
 
 
 # ---------------------------------------------------------------------------
@@ -502,12 +507,13 @@ class TestTriggerDependabotRecreateHappyPath:
         client.get_paginated = lambda *a, **kw: _async_gen([])
 
         with patch("asyncio.sleep", new_callable=AsyncMock):
-            result = await mgr._trigger_dependabot_recreate(pr)
+            result = await mgr._trigger_dependabot_recreate(pr, RecreateCause.UNSIGNED)
 
-        assert result is not None
-        assert result.number == 107
-        assert result.mergeable is True
-        assert result.mergeable_state == "clean"
+        assert result.outcome is RecreateOutcome.READY
+        assert result.pr_info is not None
+        assert result.pr_info.number == 107
+        assert result.pr_info.mergeable is True
+        assert result.pr_info.mergeable_state == "clean"
         client.post_issue_comment.assert_called_once_with(
             "lfreleng-actions",
             "gerrit-clone-action",
@@ -527,8 +533,8 @@ class TestTriggerDependabotRecreateHappyPath:
         client.get = AsyncMock(return_value=[])  # no duplicate comments
         client.post_issue_comment = AsyncMock(side_effect=Exception("403 Forbidden"))
 
-        result = await mgr._trigger_dependabot_recreate(pr)
-        assert result is None
+        result = await mgr._trigger_dependabot_recreate(pr, RecreateCause.UNSIGNED)
+        assert result.outcome is RecreateOutcome.NONE
 
 
 # ---------------------------------------------------------------------------
@@ -557,9 +563,9 @@ class TestTriggerDependabotRecreateTimeout:
         )
 
         with patch("asyncio.sleep", new_callable=AsyncMock):
-            result = await mgr._trigger_dependabot_recreate(pr)
+            result = await mgr._trigger_dependabot_recreate(pr, RecreateCause.UNSIGNED)
 
-        assert result is None
+        assert result.outcome is RecreateOutcome.NONE
 
     @pytest.mark.asyncio
     async def test_timeout_waiting_for_new_pr_checks(self):
@@ -604,9 +610,9 @@ class TestTriggerDependabotRecreateTimeout:
         client.get = AsyncMock(side_effect=call_sequence)
 
         with patch("asyncio.sleep", new_callable=AsyncMock):
-            result = await mgr._trigger_dependabot_recreate(pr)
+            result = await mgr._trigger_dependabot_recreate(pr, RecreateCause.UNSIGNED)
 
-        assert result is None
+        assert result.outcome is RecreateOutcome.NONE
 
 
 # ---------------------------------------------------------------------------
@@ -646,9 +652,10 @@ class TestWaitForRecreatedPrChecks:
                 "owner", "repo", 107, pr_data
             )
 
-        assert result is not None
-        assert result.number == 107
-        assert result.mergeable_state == "clean"
+        assert result.outcome is RecreateOutcome.READY
+        assert result.pr_info is not None
+        assert result.pr_info.number == 107
+        assert result.pr_info.mergeable_state == "clean"
 
     @pytest.mark.asyncio
     async def test_returns_none_on_dirty(self):
@@ -669,14 +676,14 @@ class TestWaitForRecreatedPrChecks:
                 "owner", "repo", 107, pr_data
             )
 
-        assert result is None
+        assert result.outcome is RecreateOutcome.ABANDONED
 
     @pytest.mark.asyncio
     async def test_returns_none_without_client(self):
         mgr, _client = _make_manager()  # typed mock client pattern (see conftest.py)
         mgr._github_client = None  # intentionally set to None for this test
         result = await mgr._wait_for_recreated_pr_checks("owner", "repo", 107, {})
-        assert result is None
+        assert result.outcome is RecreateOutcome.NONE
 
     @pytest.mark.asyncio
     async def test_returns_pr_info_on_unstable_with_mergeable_true(self):
@@ -707,8 +714,9 @@ class TestWaitForRecreatedPrChecks:
                 "owner", "repo", 107, pr_data
             )
 
-        assert result is not None
-        assert result.number == 107
+        assert result.outcome is RecreateOutcome.READY
+        assert result.pr_info is not None
+        assert result.pr_info.number == 107
 
 
 # ---------------------------------------------------------------------------
@@ -768,7 +776,7 @@ class TestMergeSinglePrRecreateIntegration:
                 mgr,
                 "_trigger_dependabot_recreate",
                 new_callable=AsyncMock,
-                return_value=recreated_pr,
+                return_value=RecreateResult(RecreateOutcome.READY, recreated_pr),
             ) as mock_recreate,
             patch.object(
                 mgr,
@@ -782,7 +790,7 @@ class TestMergeSinglePrRecreateIntegration:
             result = await mgr._merge_single_pr(pr)
 
         # The recreate should have been attempted
-        mock_recreate.assert_called_once_with(pr)
+        mock_recreate.assert_called_once_with(pr, RecreateCause.UNSIGNED)
         assert result.status == MergeStatus.MERGED
         assert result.pr_info.number == 107
 
@@ -901,7 +909,7 @@ class TestMergeSinglePrRecreateIntegration:
                 mgr,
                 "_trigger_dependabot_recreate",
                 new_callable=AsyncMock,
-                return_value=None,
+                return_value=RecreateResult.none(),
             ),
             patch.object(
                 mgr,
@@ -959,7 +967,7 @@ class TestMergeSinglePrRecreateIntegration:
                 mgr,
                 "_trigger_dependabot_recreate",
                 new_callable=AsyncMock,
-                return_value=recreated_pr,
+                return_value=RecreateResult(RecreateOutcome.READY, recreated_pr),
             ),
             patch.object(
                 mgr,
@@ -969,7 +977,13 @@ class TestMergeSinglePrRecreateIntegration:
         ):
             result = await mgr._merge_single_pr(pr)
 
-        assert result.status == MergeStatus.FAILED
+        # BLOCKED, not FAILED: after a recreate the *original* PR is
+        # closed unmerged, so a FAILED result would be rewritten to
+        # CLOSED by ``_confirm_failure`` --- "nothing to follow up on"
+        # --- which is the opposite of what an unmerged replacement
+        # needs.  The result also points at the replacement now.
+        assert result.status == MergeStatus.BLOCKED
+        assert result.pr_info.number == 107
         assert "recreated" in (result.error or "").lower()
 
 
@@ -1015,9 +1029,9 @@ class TestNewPrDiscoveryEdgeCases:
         client.get = AsyncMock(side_effect=call_sequence)
 
         with patch("asyncio.sleep", new_callable=AsyncMock):
-            result = await mgr._trigger_dependabot_recreate(pr)
+            result = await mgr._trigger_dependabot_recreate(pr, RecreateCause.UNSIGNED)
 
-        assert result is None
+        assert result.outcome is RecreateOutcome.NONE
 
     @pytest.mark.asyncio
     async def test_ignores_same_pr_number(self):
@@ -1054,9 +1068,9 @@ class TestNewPrDiscoveryEdgeCases:
         client.get = AsyncMock(side_effect=call_sequence)
 
         with patch("asyncio.sleep", new_callable=AsyncMock):
-            result = await mgr._trigger_dependabot_recreate(pr)
+            result = await mgr._trigger_dependabot_recreate(pr, RecreateCause.UNSIGNED)
 
-        assert result is None
+        assert result.outcome is RecreateOutcome.NONE
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_recreate_path_contract.py
+++ b/tests/test_recreate_path_contract.py
@@ -1,0 +1,983 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 The Linux Foundation
+
+"""The recreate path's terminal states, gates and wait budget.
+
+Three defects converged on this path, and the corrected return contract
+is what ties them together.
+
+**#441** --- auto-merge is armed on the replacement *before* the checks
+wait begins, so it can complete between polls.  A closed/merged payload
+satisfied neither the ready test nor the ``dirty`` test, so the loop ran
+to timeout and the caller reported a failure for a PR that had in fact
+merged.  Under-reporting a success is the most damaging direction to be
+wrong in, and it cost the full wait window to get there.
+
+**#440** --- a stuck required check set the recreate in motion, but the
+trigger applied signature-only gates, so on any repository that does not
+enforce commit signatures the recovery was inert.  The user was still
+told ``requesting recreate``, so the failure was silent unless someone
+read debug logs.
+
+**#434** --- the recreate poll and the nested checks wait each ran their
+own full budget, ignoring the run-wide ceiling.  A single PR could
+consume ``2 x merge_timeout`` beyond ``--max-wait`` while holding its
+slot lease, and ``--max-wait 0`` --- documented as "never block" ---
+blocked anyway.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+
+from dependamerge.merge_manager import (
+    MergeResult,
+    MergeStatus,
+    RecreateCause,
+    RecreateOutcome,
+    RecreateResult,
+)
+from dependamerge.merge_manager._single_pr_context import _MergeFlow
+from dependamerge.models import PullRequestInfo
+from tests.conftest import make_merge_manager
+
+REPO = "lfreleng-actions/some-repo"
+
+
+def _pr(number: int = 1) -> PullRequestInfo:
+    return PullRequestInfo(
+        number=number,
+        title="Chore: Bump a dependency",
+        body=None,
+        author="dependabot[bot]",
+        head_sha="a" * 40,
+        base_branch="main",
+        head_branch="dependabot/pip/thing-1.2.3",
+        state="open",
+        mergeable=False,
+        mergeable_state="blocked",
+        behind_by=None,
+        files_changed=[],
+        repository_full_name=REPO,
+        html_url=f"https://github.com/{REPO}/pull/{number}",
+        reviews=[],
+        review_comments=[],
+    )
+
+
+def _payload(**overrides: Any) -> dict[str, Any]:
+    base: dict[str, Any] = {
+        "number": 107,
+        "node_id": "PR_kw107",
+        "title": "Chore: Bump a dependency",
+        "state": "open",
+        "user": {"login": "dependabot[bot]"},
+        "head": {"sha": "b" * 40, "ref": "dependabot/pip/thing-1.2.3"},
+        "base": {"ref": "main"},
+        "html_url": f"https://github.com/{REPO}/pull/107",
+    }
+    base.update(overrides)
+    return base
+
+
+def _mgr(**overrides: Any):
+    mgr, client = make_merge_manager(**overrides)
+    # The wait approves *and* arms first. Both are stubbed because
+    # PENDING requires both --- see TestTheReplacementIsApprovedNotJustArmed.
+    mgr._ensure_pr_approved = AsyncMock(return_value=True)  # type: ignore[method-assign]
+    mgr._enable_auto_merge_for_pr = AsyncMock(return_value=True)  # type: ignore[method-assign]
+    mgr._merge_recheck_interval = 0.001
+    mgr._merge_poll_max_attempts = 3
+    return mgr, client
+
+
+class TestAReplacementThatClosesIsTerminal:
+    """Closed is an answer, not a reason to keep polling."""
+
+    @pytest.mark.asyncio
+    async def test_merged_by_auto_merge_is_a_success(self) -> None:
+        """The defect: this used to poll to timeout and report a failure."""
+        mgr, client = _mgr()
+        client.get = AsyncMock(
+            return_value=_payload(state="closed", merged=True, merged_at="2026-08-25")
+        )
+
+        result = await mgr._wait_for_recreated_pr_checks("o", "r", 107, _payload())
+
+        assert result.outcome is RecreateOutcome.MERGED
+        assert result.pr_info is not None
+        assert result.pr_info.number == 107
+
+    @pytest.mark.asyncio
+    async def test_it_stops_polling_immediately(self) -> None:
+        """Promptness is half the fix: the old path burned the whole window."""
+        mgr, client = _mgr()
+        client.get = AsyncMock(
+            return_value=_payload(state="closed", merged=True, merged_at="2026-08-25")
+        )
+
+        await mgr._wait_for_recreated_pr_checks("o", "r", 107, _payload())
+
+        assert client.get.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_closed_unmerged_is_a_resolved_failure(self) -> None:
+        mgr, client = _mgr()
+        client.get = AsyncMock(
+            return_value=_payload(state="closed", merged=False, merged_at=None)
+        )
+
+        result = await mgr._wait_for_recreated_pr_checks("o", "r", 107, _payload())
+
+        assert result.outcome is RecreateOutcome.ABANDONED
+
+    @pytest.mark.asyncio
+    async def test_an_ambiguous_payload_is_not_claimed_as_merged(self) -> None:
+        """Neither ``merged`` nor ``merged_at`` present: do not guess upward."""
+        mgr, client = _mgr()
+        client.get = AsyncMock(return_value=_payload(state="closed"))
+
+        result = await mgr._wait_for_recreated_pr_checks("o", "r", 107, _payload())
+
+        assert result.outcome is RecreateOutcome.ABANDONED
+
+    @pytest.mark.asyncio
+    async def test_a_clean_replacement_is_still_ready(self) -> None:
+        """The path that already worked must be unchanged."""
+        mgr, client = _mgr()
+        client.get = AsyncMock(
+            return_value=_payload(mergeable=True, mergeable_state="clean")
+        )
+        mgr._recreated_pr_files = AsyncMock(return_value=[])  # type: ignore[method-assign]
+
+        result = await mgr._wait_for_recreated_pr_checks("o", "r", 107, _payload())
+
+        assert result.outcome is RecreateOutcome.READY
+        assert result.pr_info is not None
+
+
+class TestAStuckCheckCanActuallyTriggerARecreate:
+    """The gates belong to the unsigned-commit cause, not to every cause."""
+
+    @pytest.mark.asyncio
+    async def test_a_stuck_check_posts_the_macro_without_signatures(self) -> None:
+        """The defect: this returned at the first gate and posted nothing."""
+        mgr, client = _mgr()
+        # A repository that does not require signed commits at all.
+        client.requires_commit_signatures = AsyncMock(return_value=False)
+        client.check_pr_commit_signatures = AsyncMock(return_value=(True, []))
+        client.get = AsyncMock(return_value=[])
+        client.post_issue_comment = AsyncMock(return_value=None)
+        mgr._await_dependabot_recreate = AsyncMock()  # type: ignore[method-assign]
+
+        await mgr._trigger_dependabot_recreate(_pr(), RecreateCause.STUCK_CHECK)
+
+        client.post_issue_comment.assert_awaited_once()
+        assert "@dependabot recreate" in client.post_issue_comment.await_args.args[3]
+
+    @pytest.mark.asyncio
+    async def test_a_stuck_check_ignores_verified_commits(self) -> None:
+        """Signed commits are the common case, and irrelevant to a stall."""
+        mgr, client = _mgr()
+        client.requires_commit_signatures = AsyncMock(return_value=True)
+        client.check_pr_commit_signatures = AsyncMock(return_value=(True, []))
+        client.get = AsyncMock(return_value=[])
+        client.post_issue_comment = AsyncMock(return_value=None)
+        mgr._await_dependabot_recreate = AsyncMock()  # type: ignore[method-assign]
+
+        await mgr._trigger_dependabot_recreate(_pr(), RecreateCause.STUCK_CHECK)
+
+        client.post_issue_comment.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_the_unsigned_cause_still_applies_both_gates(self) -> None:
+        mgr, client = _mgr()
+        client.requires_commit_signatures = AsyncMock(return_value=False)
+        client.post_issue_comment = AsyncMock(return_value=None)
+
+        result = await mgr._trigger_dependabot_recreate(_pr(), RecreateCause.UNSIGNED)
+
+        assert result.outcome is RecreateOutcome.NONE
+        client.post_issue_comment.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_a_non_dependabot_pr_is_rejected_on_both_causes(self) -> None:
+        for cause in (RecreateCause.UNSIGNED, RecreateCause.STUCK_CHECK):
+            mgr, client = _mgr()
+            client.post_issue_comment = AsyncMock(return_value=None)
+            human = _pr()
+            human.author = "a-human"
+
+            result = await mgr._trigger_dependabot_recreate(human, cause)
+
+            assert result.outcome is RecreateOutcome.NONE, cause
+            client.post_issue_comment.assert_not_awaited()
+
+
+class TestTheRecreatePathHonoursTheWaitCeiling:
+    """``--max-wait`` bounds the run; the recreate path used to escape it."""
+
+    @pytest.mark.asyncio
+    async def test_no_wait_skips_the_recreate_poll(self) -> None:
+        """``--max-wait 0`` promises never to block."""
+        mgr, client = _mgr(max_wait=0)
+        mgr._no_wait = True
+        client.get = AsyncMock(return_value=_payload())
+
+        result = await mgr._await_dependabot_recreate("o", "r", _pr())
+
+        assert result.outcome is RecreateOutcome.NONE
+        client.get.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_the_precommit_sleep_is_clamped_near_the_deadline(self) -> None:
+        """The pre-commit loop needs the same proof as the recreate one.
+
+        Only ``_no_wait`` was covered here, so swapping the clamped
+        sleep back for a full-interval one would have left the suite
+        green while reintroducing the ``--max-wait`` overshoot.
+        """
+        mgr, client = _mgr()
+        mgr._merge_recheck_interval = 5.0
+        loop = asyncio.get_running_loop()
+        mgr._run_deadline = loop.time() + 0.1
+        client.get = AsyncMock(return_value={})
+        slept: list[float] = []
+
+        async def _sleep(seconds: float) -> None:
+            slept.append(seconds)
+
+        import dependamerge.merge_manager as mod
+
+        original = mod.asyncio.sleep
+        mod.asyncio.sleep = _sleep  # type: ignore[assignment]
+        try:
+            await mgr._await_precommit_ci("o", "r", _pr())
+        finally:
+            mod.asyncio.sleep = original  # type: ignore[assignment]
+
+        assert slept, "expected at least one sleep"
+        assert max(slept) <= 0.1, slept
+
+    @pytest.mark.asyncio
+    async def test_no_wait_skips_the_precommit_poll(self) -> None:
+        mgr, client = _mgr(max_wait=0)
+        mgr._no_wait = True
+        client.get = AsyncMock(return_value={})
+
+        assert await mgr._await_precommit_ci("o", "r", _pr()) is False
+        client.get.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_an_expired_run_deadline_stops_the_recreate_poll(self) -> None:
+        mgr, client = _mgr()
+        loop = asyncio.get_running_loop()
+        mgr._run_deadline = loop.time() - 1.0
+        client.get = AsyncMock(return_value=_payload())
+
+        result = await mgr._await_dependabot_recreate("o", "r", _pr())
+
+        assert result.outcome is RecreateOutcome.NONE
+        client.get.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_the_nested_wait_shares_the_outer_deadline(self) -> None:
+        """The compounding case: no second full budget.
+
+        Passing an already-expired deadline models a recreate that found
+        its replacement right at the ceiling. The nested wait must stop
+        rather than start a fresh ``merge_timeout`` of its own --- and
+        must not poll at all.
+        """
+        mgr, client = _mgr()
+        loop = asyncio.get_running_loop()
+        client.get = AsyncMock(return_value=_payload())
+
+        result = await mgr._wait_for_recreated_pr_checks(
+            "o", "r", 107, _payload(), loop.time() - 1.0
+        )
+
+        # Stopped immediately: no polling happened.
+        client.get.assert_not_awaited()
+        # But the replacement is armed and in flight, so this is not
+        # "nothing found" --- see TestGivingUpIsNotTheSameAsFinding.
+        assert result.outcome is RecreateOutcome.PENDING
+
+    @pytest.mark.asyncio
+    async def test_a_near_deadline_sleep_is_clamped(self) -> None:
+        """Checking the deadline is not enough; the sleep must be clamped.
+
+        With less than one interval of budget left, sleeping a whole
+        interval overshoots the ceiling. The established waits clamp to
+        the remaining budget, and these now match.
+        """
+        mgr, client = _mgr()
+        mgr._merge_recheck_interval = 5.0
+        loop = asyncio.get_running_loop()
+        client.get = AsyncMock(return_value=_payload())
+        slept: list[float] = []
+
+        async def _sleep(seconds: float) -> None:
+            slept.append(seconds)
+
+        import dependamerge.merge_manager as mod
+
+        original = mod.asyncio.sleep
+        mod.asyncio.sleep = _sleep  # type: ignore[assignment]
+        try:
+            await mgr._wait_for_recreated_pr_checks(
+                "o", "r", 107, _payload(), loop.time() + 0.1
+            )
+        finally:
+            mod.asyncio.sleep = original  # type: ignore[assignment]
+
+        assert slept, "expected at least one sleep"
+        assert max(slept) <= 0.1, slept
+
+
+class TestAFailingWaitIsNotRetried:
+    """The search guard must not swallow a failure inside the wait.
+
+    ``_find_recreated_pr`` previously wrapped the entire multi-minute
+    wait in its ``try``, so an exception there was reported as a failed
+    search and the outer loop repeated the whole wait --- contradicting
+    its own comment, *"always return after the first wait attempt"*.
+    """
+
+    @pytest.mark.asyncio
+    async def test_an_exception_in_the_wait_propagates(self) -> None:
+        mgr, client = _mgr()
+        client.get = AsyncMock(return_value=[_payload()])
+        mgr._wait_for_recreated_pr_checks = AsyncMock(  # type: ignore[method-assign]
+            side_effect=RuntimeError("wait blew up")
+        )
+
+        with pytest.raises(RuntimeError, match="wait blew up"):
+            await mgr._find_recreated_pr("o", "r", _pr())
+
+        # One search, one wait --- not a second full wait.
+        assert mgr._wait_for_recreated_pr_checks.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_a_failing_search_is_still_tolerated(self) -> None:
+        """The guard still covers the request it was written for."""
+        mgr, client = _mgr()
+        client.get = AsyncMock(side_effect=RuntimeError("search failed"))
+
+        resolved, result = await mgr._find_recreated_pr("o", "r", _pr())
+
+        assert resolved is False
+        assert result.outcome is RecreateOutcome.NONE
+
+
+class TestGivingUpIsNotTheSameAsFinding:
+    """An armed replacement left in flight is pending, not a failure.
+
+    Auto-merge is armed on the replacement before the wait begins, so
+    once we stop waiting --- ceiling, exhausted budget, or
+    ``--max-wait 0`` --- the PR is still open and still expected to
+    merge. Reporting the original as FAILED would under-report a
+    success in exactly the way the closed/merged case did, and
+    ``_confirm_failure`` cannot correct it: it rechecks the *original*
+    PR, not the replacement.
+
+    ``NONE`` is therefore reserved for the cases where nothing was
+    acted on --- including a replacement that could not be armed, which
+    will not merge by itself.
+    """
+
+    @pytest.mark.asyncio
+    async def test_an_exhausted_budget_is_pending(self) -> None:
+        mgr, client = _mgr()
+        # Never resolves, so the poll budget runs out.
+        client.get = AsyncMock(return_value=_payload(mergeable_state="blocked"))
+
+        result = await mgr._wait_for_recreated_pr_checks("o", "r", 107, _payload())
+
+        assert result.outcome is RecreateOutcome.PENDING
+        assert result.pr_info is not None
+        assert result.pr_info.number == 107
+
+    @pytest.mark.asyncio
+    async def test_no_wait_is_pending_and_does_not_poll(self) -> None:
+        """``--max-wait 0``: arm, report pending, move on.
+
+        The guard belongs to this wait too, not only to its callers: a
+        direct call with the default ``deadline=None`` would otherwise
+        run the whole poll loop under a flag that promises never to
+        block.
+        """
+        mgr, client = _mgr(max_wait=0)
+        mgr._no_wait = True
+        client.get = AsyncMock(return_value=_payload(mergeable_state="blocked"))
+
+        result = await mgr._wait_for_recreated_pr_checks("o", "r", 107, _payload())
+
+        assert result.outcome is RecreateOutcome.PENDING
+        client.get.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_no_wait_still_arms_auto_merge(self) -> None:
+        """Fire-and-forget only works if the fire part still happens."""
+        mgr, client = _mgr(max_wait=0)
+        mgr._no_wait = True
+        client.get = AsyncMock(return_value=_payload())
+
+        await mgr._wait_for_recreated_pr_checks("o", "r", 107, _payload())
+
+        mgr._enable_auto_merge_for_pr.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_an_unarmed_replacement_is_not_pending(self) -> None:
+        """Nothing will happen on its own, so this is not in flight."""
+        mgr, client = _mgr()
+        mgr._enable_auto_merge_for_pr = AsyncMock(return_value=False)  # type: ignore[method-assign]
+        client.get = AsyncMock(return_value=_payload(mergeable_state="blocked"))
+
+        result = await mgr._wait_for_recreated_pr_checks("o", "r", 107, _payload())
+
+        assert result.outcome is RecreateOutcome.NONE
+
+    @pytest.mark.asyncio
+    async def test_a_replacement_without_a_node_id_is_not_pending(self) -> None:
+        """Auto-merge cannot be armed without one, so it cannot be in flight."""
+        mgr, client = _mgr()
+        payload = _payload(mergeable_state="blocked")
+        payload.pop("node_id")
+        client.get = AsyncMock(return_value=payload)
+
+        result = await mgr._wait_for_recreated_pr_checks("o", "r", 107, payload)
+
+        assert result.outcome is RecreateOutcome.NONE
+        mgr._enable_auto_merge_for_pr.assert_not_awaited()
+
+
+class TestTheReplacementIsApprovedNotJustArmed:
+    """``PENDING`` claims the replacement will merge without us.
+
+    Arming auto-merge commits GitHub to finish the merge once branch
+    protection is satisfied, so the head must already carry this run's
+    approval, or auto-merge waits forever on a missing review. The
+    approval in ``_merge_recreated_pr`` is reached only for ``READY``,
+    so a replacement we stop waiting on has no other chance to get one.
+
+    ``_enable_auto_merge_with_approval`` is deliberately not used: it
+    swallows non-permission approval failures and returns the *arming*
+    result, so its ``True`` evidences only that auto-merge is active.
+    That is fine where a real merge follows, but ``PENDING`` is a claim
+    about what happens without us, so the two signals are kept apart.
+    """
+
+    @pytest.mark.asyncio
+    async def test_both_approval_and_arming_are_required(self) -> None:
+        mgr, client = _mgr()
+        client.get = AsyncMock(return_value=_payload(mergeable_state="blocked"))
+
+        result = await mgr._wait_for_recreated_pr_checks("o", "r", 107, _payload())
+
+        assert result.outcome is RecreateOutcome.PENDING
+        mgr._ensure_pr_approved.assert_awaited_once()
+        mgr._enable_auto_merge_for_pr.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_an_already_approved_replacement_is_pending(self) -> None:
+        """``False`` means "already sufficiently approved", not "declined".
+
+        ``_ensure_pr_approved`` returns True only when it submits a
+        *new* review, and False when the head already carries adequate
+        approval --- from us or anyone else. Treating False as "not
+        approved" would reject exactly the replacements ready to merge.
+        """
+        mgr, client = _mgr()
+        mgr._ensure_pr_approved = AsyncMock(return_value=False)  # type: ignore[method-assign]
+        client.get = AsyncMock(return_value=_payload(mergeable_state="blocked"))
+
+        result = await mgr._wait_for_recreated_pr_checks("o", "r", 107, _payload())
+
+        assert result.outcome is RecreateOutcome.PENDING
+
+    @pytest.mark.asyncio
+    async def test_a_swallowed_approval_error_is_not_pending(self) -> None:
+        """A transient approval failure must not become a promise."""
+        mgr, client = _mgr()
+        mgr._ensure_pr_approved = AsyncMock(  # type: ignore[method-assign]
+            side_effect=RuntimeError("transient approval hiccup")
+        )
+        client.get = AsyncMock(return_value=_payload(mergeable_state="blocked"))
+
+        result = await mgr._wait_for_recreated_pr_checks("o", "r", 107, _payload())
+
+        assert result.outcome is RecreateOutcome.NONE
+        # Arming is still attempted: it may help where no review is
+        # required, it simply cannot be promised.
+        mgr._enable_auto_merge_for_pr.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_a_permission_error_propagates(self) -> None:
+        """Typed permission errors reach the caller's dedicated handler."""
+        from dependamerge.github_async import PermissionError as GitHubPermissionError
+
+        mgr, client = _mgr()
+        mgr._ensure_pr_approved = AsyncMock(  # type: ignore[method-assign]
+            side_effect=GitHubPermissionError(
+                operation="approve", message="token lacks the required scope"
+            )
+        )
+        client.get = AsyncMock(return_value=_payload(mergeable_state="blocked"))
+
+        with pytest.raises(GitHubPermissionError):
+            await mgr._wait_for_recreated_pr_checks("o", "r", 107, _payload())
+
+    @pytest.mark.asyncio
+    async def test_it_is_approved_against_the_replacement(self) -> None:
+        """Not the original PR: approval must land on the new head."""
+        mgr, client = _mgr()
+        client.get = AsyncMock(return_value=_payload(mergeable_state="blocked"))
+
+        await mgr._wait_for_recreated_pr_checks("o", "r", 107, _payload())
+
+        approved = mgr._ensure_pr_approved.await_args.args[0]
+        assert approved.number == 107
+        assert approved.node_id == "PR_kw107"
+
+
+class TestTheFlowActsOnTheOutcome:
+    """The contract is only worth having if the caller honours it."""
+
+    def _flow(self, mgr) -> _MergeFlow:
+        pr = _pr()
+        return _MergeFlow(
+            pr_info=pr,
+            repo_owner="lfreleng-actions",
+            repo_name="some-repo",
+            result=MergeResult(pr_info=pr, status=MergeStatus.PENDING),
+        )
+
+    @pytest.mark.asyncio
+    async def test_a_merged_replacement_is_not_merged_again(self) -> None:
+        """``MERGED`` records the success without a second merge call."""
+        mgr, _ = _mgr()
+        replacement = _pr(number=107)
+        mgr._get_failure_summary = AsyncMock(return_value="blocked")  # type: ignore[method-assign]
+        mgr._external_closure_result = AsyncMock(return_value=None)  # type: ignore[method-assign]
+        mgr._behind_auto_merge_result = lambda flow: None  # type: ignore[method-assign]
+        mgr._maybe_recreate_dependabot_pr = AsyncMock(  # type: ignore[method-assign]
+            return_value=RecreateResult(RecreateOutcome.MERGED, replacement)
+        )
+        mgr._merge_recreated_pr = AsyncMock()  # type: ignore[method-assign]
+        mgr._report_merge_failure = AsyncMock()  # type: ignore[method-assign]
+
+        flow = self._flow(mgr)
+        await mgr._handle_failed_merge(flow)
+
+        mgr._merge_recreated_pr.assert_not_awaited()
+        mgr._report_merge_failure.assert_not_awaited()
+        assert flow.result.status is MergeStatus.MERGED
+        assert flow.result.pr_info is replacement
+
+    @pytest.mark.asyncio
+    async def test_a_ready_replacement_is_merged(self) -> None:
+        mgr, _ = _mgr()
+        replacement = _pr(number=107)
+        mgr._get_failure_summary = AsyncMock(return_value="blocked")  # type: ignore[method-assign]
+        mgr._external_closure_result = AsyncMock(return_value=None)  # type: ignore[method-assign]
+        mgr._behind_auto_merge_result = lambda flow: None  # type: ignore[method-assign]
+        mgr._maybe_recreate_dependabot_pr = AsyncMock(  # type: ignore[method-assign]
+            return_value=RecreateResult(RecreateOutcome.READY, replacement)
+        )
+        mgr._merge_recreated_pr = AsyncMock()  # type: ignore[method-assign]
+        mgr._report_merge_failure = AsyncMock()  # type: ignore[method-assign]
+
+        await mgr._handle_failed_merge(self._flow(mgr))
+
+        mgr._merge_recreated_pr.assert_awaited_once()
+        assert mgr._merge_recreated_pr.await_args.args[1] is replacement
+
+    @pytest.mark.asyncio
+    async def test_an_abandoned_replacement_is_blocked_not_failed(self) -> None:
+        """``BLOCKED`` survives ``_confirm_failure``; ``FAILED`` would not.
+
+        After a recreate the *original* PR is closed unmerged by
+        dependabot, so a ``FAILED`` result is rewritten to ``CLOSED``
+        --- documented as "nothing for the operator to follow up on",
+        the opposite of what a conflicted replacement needs.
+        """
+        mgr, _ = _mgr()
+        replacement = _pr(number=107)
+        mgr._get_failure_summary = AsyncMock(return_value="blocked")  # type: ignore[method-assign]
+        mgr._external_closure_result = AsyncMock(return_value=None)  # type: ignore[method-assign]
+        mgr._behind_auto_merge_result = lambda flow: None  # type: ignore[method-assign]
+        mgr._maybe_recreate_dependabot_pr = AsyncMock(  # type: ignore[method-assign]
+            return_value=RecreateResult(RecreateOutcome.ABANDONED, replacement)
+        )
+        mgr._merge_recreated_pr = AsyncMock()  # type: ignore[method-assign]
+        mgr._report_merge_failure = AsyncMock()  # type: ignore[method-assign]
+
+        flow = self._flow(mgr)
+        await mgr._handle_failed_merge(flow)
+
+        mgr._merge_recreated_pr.assert_not_awaited()
+        mgr._report_merge_failure.assert_not_awaited()
+        assert flow.result.status is MergeStatus.BLOCKED
+        assert flow.result.pr_info is replacement
+        assert flow.result.error and "needs attention" in flow.result.error
+
+    @pytest.mark.asyncio
+    async def test_an_abandoned_outcome_survives_confirm_failure(self) -> None:
+        """End to end through the confirmation step, not just the branch.
+
+        Drives the real ``_confirm_failure`` against an original PR that
+        is closed unmerged --- the state dependabot leaves it in --- and
+        asserts the outcome is not rewritten to ``CLOSED``.
+        """
+        mgr, client = _mgr()
+        replacement = _pr(number=107)
+        mgr._get_failure_summary = AsyncMock(return_value="blocked")  # type: ignore[method-assign]
+        mgr._external_closure_result = AsyncMock(return_value=None)  # type: ignore[method-assign]
+        mgr._behind_auto_merge_result = lambda flow: None  # type: ignore[method-assign]
+        mgr._maybe_recreate_dependabot_pr = AsyncMock(  # type: ignore[method-assign]
+            return_value=RecreateResult(RecreateOutcome.ABANDONED, replacement)
+        )
+        # The original PR as dependabot leaves it: closed, unmerged.
+        client.get = AsyncMock(
+            return_value={"state": "closed", "merged": False, "merged_at": None}
+        )
+
+        flow = self._flow(mgr)
+        await mgr._handle_failed_merge(flow)
+        confirmed = await mgr._confirm_failure(flow.pr_info, flow.result)
+
+        assert confirmed.status is MergeStatus.BLOCKED
+
+    @pytest.mark.asyncio
+    async def test_a_failed_outcome_would_have_been_rewritten(self) -> None:
+        """The control that makes the test above meaningful.
+
+        Confirms ``_confirm_failure`` really does rewrite a ``FAILED``
+        result to ``CLOSED`` in this exact situation --- so the previous
+        test is pinning a real hazard, not a hypothetical one.
+        """
+        mgr, client = _mgr()
+        pr = _pr()
+        result = MergeResult(pr_info=pr, status=MergeStatus.FAILED, error="boom")
+        client.get = AsyncMock(
+            return_value={"state": "closed", "merged": False, "merged_at": None}
+        )
+
+        confirmed = await mgr._confirm_failure(pr, result)
+
+        assert confirmed.status is MergeStatus.CLOSED
+
+    @pytest.mark.asyncio
+    async def test_a_pending_replacement_is_reported_as_pending(self) -> None:
+        """Not merged again, and not reported as a failure either."""
+        mgr, _ = _mgr()
+        replacement = _pr(number=107)
+        mgr._get_failure_summary = AsyncMock(return_value="blocked")  # type: ignore[method-assign]
+        mgr._external_closure_result = AsyncMock(return_value=None)  # type: ignore[method-assign]
+        mgr._behind_auto_merge_result = lambda flow: None  # type: ignore[method-assign]
+        mgr._maybe_recreate_dependabot_pr = AsyncMock(  # type: ignore[method-assign]
+            return_value=RecreateResult(RecreateOutcome.PENDING, replacement)
+        )
+        mgr._merge_recreated_pr = AsyncMock()  # type: ignore[method-assign]
+        mgr._report_merge_failure = AsyncMock()  # type: ignore[method-assign]
+
+        flow = self._flow(mgr)
+        await mgr._handle_failed_merge(flow)
+
+        mgr._merge_recreated_pr.assert_not_awaited()
+        mgr._report_merge_failure.assert_not_awaited()
+        assert flow.result.status is MergeStatus.AUTO_MERGE_PENDING
+        assert flow.result.pr_info is replacement
+        # The reason must land on ``error``: that is the field the
+        # end-of-run report reads, so ``warning`` would show the
+        # operator "no reason reported".
+        assert flow.result.error and "auto-merge pending" in flow.result.error
+
+
+class TestTheCauseIsSelectedNotAssumed:
+    """The gate fix only helps if the right cause reaches the trigger."""
+
+    def _flow(self, pr: PullRequestInfo) -> _MergeFlow:
+        return _MergeFlow(
+            pr_info=pr,
+            repo_owner="lfreleng-actions",
+            repo_name="some-repo",
+            result=MergeResult(pr_info=pr, status=MergeStatus.PENDING),
+        )
+
+    @pytest.mark.asyncio
+    async def test_a_stuck_check_selects_the_stuck_cause(self) -> None:
+        """Returning ``UNSIGNED`` here would leave recovery inert again."""
+        mgr, _ = _mgr()
+        pr = _pr()
+        mgr._detect_stuck_required_check = AsyncMock(  # type: ignore[method-assign]
+            return_value=(True, "dco", 900.0)
+        )
+        mgr._trigger_dependabot_recreate = AsyncMock(  # type: ignore[method-assign]
+            return_value=RecreateResult.none()
+        )
+
+        await mgr._maybe_recreate_dependabot_pr(self._flow(pr), "blocked by checks")
+
+        mgr._trigger_dependabot_recreate.assert_awaited_once_with(
+            pr, RecreateCause.STUCK_CHECK
+        )
+
+    @pytest.mark.asyncio
+    async def test_branch_protection_selects_the_unsigned_cause(self) -> None:
+        mgr, _ = _mgr()
+        pr = _pr()
+        mgr._trigger_dependabot_recreate = AsyncMock(  # type: ignore[method-assign]
+            return_value=RecreateResult.none()
+        )
+
+        await mgr._maybe_recreate_dependabot_pr(
+            self._flow(pr), "branch protection rules prevent merge"
+        )
+
+        mgr._trigger_dependabot_recreate.assert_awaited_once_with(
+            pr, RecreateCause.UNSIGNED
+        )
+
+    @pytest.mark.asyncio
+    async def test_no_recognised_cause_triggers_nothing(self) -> None:
+        mgr, _ = _mgr()
+        mgr._detect_stuck_required_check = AsyncMock(  # type: ignore[method-assign]
+            return_value=(False, None, 0.0)
+        )
+        mgr._trigger_dependabot_recreate = AsyncMock()  # type: ignore[method-assign]
+
+        result = await mgr._maybe_recreate_dependabot_pr(
+            self._flow(_pr()), "some other failure"
+        )
+
+        assert result.outcome is RecreateOutcome.NONE
+        mgr._trigger_dependabot_recreate.assert_not_awaited()
+
+
+class TestThePendingReasonReachesTheOperator:
+    """The end-of-run report is the only place reasons appear.
+
+    ``_print_failed_pr_details`` covers ``AUTO_MERGE_PENDING`` and reads
+    ``r.error``, falling back to "no reason reported". Nothing in the
+    reporting path reads ``warning``, so a reason recorded there would
+    be invisible --- which is why the recreate-pending reason lives on
+    ``error``, as every other auto-merge-pending path already does.
+    """
+
+    def test_the_reason_is_rendered(self, capsys) -> None:
+        from dependamerge.cli._merge_report import _print_failed_pr_details
+
+        replacement = _pr(number=107)
+        result = MergeResult(
+            pr_info=replacement,
+            status=MergeStatus.AUTO_MERGE_PENDING,
+            error=(
+                "auto-merge pending: dependabot recreated this PR as "
+                "#107, which is approved and armed"
+            ),
+        )
+
+        _print_failed_pr_details([result])
+
+        out = capsys.readouterr().out
+        assert "Auto-merge pending PRs" in out
+        assert "no reason reported" not in out
+        assert "dependabot recreated this PR" in out
+
+    def test_a_reason_on_warning_would_be_invisible(self, capsys) -> None:
+        """Pins *why* the reason must not live on ``warning``.
+
+        If a future change moves it, this fails rather than silently
+        degrading the report to "no reason reported".
+        """
+        from dependamerge.cli._merge_report import _print_failed_pr_details
+
+        result = MergeResult(
+            pr_info=_pr(number=107),
+            status=MergeStatus.AUTO_MERGE_PENDING,
+            warning="this text is never read by the reporter",
+        )
+
+        _print_failed_pr_details([result])
+
+        out = capsys.readouterr().out
+        assert "no reason reported" in out
+        assert "never read by the reporter" not in out
+
+
+class TestAConflictedReplacementNamesItself:
+    """The report must point at the PR that needs attention.
+
+    A conflicted replacement previously returned ``ABANDONED`` with no
+    ``pr_info``, so the BLOCKED result kept pointing at the *original*
+    PR --- which dependabot has already closed. The operator was sent
+    to the wrong PR, and the one actually needing work went unnamed.
+    """
+
+    @pytest.mark.asyncio
+    async def test_a_dirty_replacement_carries_its_pr(self) -> None:
+        mgr, client = _mgr()
+        client.get = AsyncMock(return_value=_payload(mergeable_state="dirty"))
+
+        result = await mgr._wait_for_recreated_pr_checks("o", "r", 107, _payload())
+
+        assert result.outcome is RecreateOutcome.ABANDONED
+        assert result.pr_info is not None
+        assert result.pr_info.number == 107
+        assert result.pr_info.html_url.endswith("/pull/107")
+
+
+class TestTheRecreatedMergeConfirmsBeforeFailing:
+    """Auto-merge can win the race against our manual dispatch.
+
+    It is armed on the replacement before the checks wait begins, so it
+    can start between the wait's last poll and the dispatch. GitHub then
+    answers "merge already in progress", ``_dispatch_recreated_merge``
+    swallows it and returns False --- and the outer ``_confirm_failure``
+    cannot correct the result, because it rechecks the *original* PR,
+    which dependabot has closed. That is the success-under-reporting
+    race #441 exists to close, reappearing on the READY path.
+    """
+
+    def _flow(self, mgr) -> _MergeFlow:
+        pr = _pr()
+        return _MergeFlow(
+            pr_info=pr,
+            repo_owner="lfreleng-actions",
+            repo_name="some-repo",
+            result=MergeResult(pr_info=pr, status=MergeStatus.PENDING),
+        )
+
+    @pytest.mark.asyncio
+    async def test_a_replacement_that_merged_meanwhile_is_a_success(self) -> None:
+        mgr, client = _mgr()
+        replacement = _pr(number=107)
+        mgr._approve_pr = AsyncMock(return_value=True)  # type: ignore[method-assign]
+        # GitHub refused the dispatch because auto-merge already started.
+        mgr._dispatch_recreated_merge = AsyncMock(return_value=False)  # type: ignore[method-assign]
+        # The replacement is in fact merged.
+        client.get = AsyncMock(
+            return_value={"state": "closed", "merged": True, "merged_at": "2026-08-25"}
+        )
+
+        flow = self._flow(mgr)
+        await mgr._merge_recreated_pr(flow, replacement)
+
+        assert flow.result.status is MergeStatus.MERGED
+
+    @pytest.mark.asyncio
+    async def test_a_genuinely_unmerged_replacement_is_blocked(self) -> None:
+        """BLOCKED, so the outer confirmation cannot rewrite it to CLOSED."""
+        mgr, client = _mgr()
+        replacement = _pr(number=107)
+        mgr._approve_pr = AsyncMock(return_value=True)  # type: ignore[method-assign]
+        mgr._dispatch_recreated_merge = AsyncMock(return_value=False)  # type: ignore[method-assign]
+        # The replacement is still open: the merge really did fail.
+        client.get = AsyncMock(
+            return_value={"state": "open", "merged": False, "merged_at": None}
+        )
+
+        flow = self._flow(mgr)
+        await mgr._merge_recreated_pr(flow, replacement)
+
+        assert flow.result.status is MergeStatus.BLOCKED
+        assert flow.result.pr_info is replacement
+
+        # And it survives the confirmation the run applies afterwards,
+        # which rechecks the *original* (closed) PR.
+        client.get = AsyncMock(
+            return_value={"state": "closed", "merged": False, "merged_at": None}
+        )
+        confirmed = await mgr._confirm_failure(flow.pr_info, flow.result)
+        assert confirmed.status is MergeStatus.BLOCKED
+
+    @pytest.mark.asyncio
+    async def test_a_successful_dispatch_is_unchanged(self) -> None:
+        mgr, _ = _mgr()
+        replacement = _pr(number=107)
+        mgr._approve_pr = AsyncMock(return_value=True)  # type: ignore[method-assign]
+        mgr._dispatch_recreated_merge = AsyncMock(return_value=True)  # type: ignore[method-assign]
+
+        flow = self._flow(mgr)
+        await mgr._merge_recreated_pr(flow, replacement)
+
+        assert flow.result.status is MergeStatus.MERGED
+        assert flow.result.pr_info is replacement
+
+
+class TestTheReplacementApprovalKeyNeverLeaks:
+    """Cleared where it is added, so no exit path can strand it.
+
+    ``_ensure_pr_approved`` registers the replacement in
+    ``_recently_approved``, but ``_merge_single_pr_impl``'s cleanup
+    knows only about the *original* PR. Clearing it in the caller's
+    outcome handling would leave it behind whenever an exception or
+    cancellation skipped that handling --- while arming, polling, or
+    merging the replacement.
+
+    A stale entry makes ``_approve_and_retry_if_review_required`` treat
+    a later run as having already approved this PR, silently disabling
+    approval recovery for a new head.
+    """
+
+    def _key(self, number: int = 107) -> str:
+        return f"o/r#{number}"
+
+    @pytest.mark.asyncio
+    async def test_it_is_cleared_on_the_normal_path(self) -> None:
+        mgr, client = _mgr()
+        client.get = AsyncMock(return_value=_payload(mergeable_state="blocked"))
+
+        async def _approve(pr, owner, repo, **_kw):
+            mgr._recently_approved.add(f"{owner}/{repo}#{pr.number}")
+            return True
+
+        mgr._ensure_pr_approved = _approve  # type: ignore[method-assign]
+
+        await mgr._wait_for_recreated_pr_checks("o", "r", 107, _payload())
+
+        assert self._key() not in mgr._recently_approved
+
+    @pytest.mark.asyncio
+    async def test_it_is_cleared_when_arming_raises(self) -> None:
+        mgr, client = _mgr()
+        client.get = AsyncMock(return_value=_payload(mergeable_state="blocked"))
+
+        async def _approve(pr, owner, repo, **_kw):
+            mgr._recently_approved.add(f"{owner}/{repo}#{pr.number}")
+            return True
+
+        mgr._ensure_pr_approved = _approve  # type: ignore[method-assign]
+        mgr._enable_auto_merge_for_pr = AsyncMock(  # type: ignore[method-assign]
+            side_effect=RuntimeError("arming blew up")
+        )
+
+        with pytest.raises(RuntimeError):
+            await mgr._wait_for_recreated_pr_checks("o", "r", 107, _payload())
+
+        assert self._key() not in mgr._recently_approved
+
+    @pytest.mark.asyncio
+    async def test_it_is_cleared_when_the_wait_is_cancelled(self) -> None:
+        """Cancellation must not strand it either."""
+        mgr, client = _mgr()
+
+        async def _approve(pr, owner, repo, **_kw):
+            mgr._recently_approved.add(f"{owner}/{repo}#{pr.number}")
+            return True
+
+        mgr._ensure_pr_approved = _approve  # type: ignore[method-assign]
+        mgr._enable_auto_merge_for_pr = AsyncMock(  # type: ignore[method-assign]
+            side_effect=asyncio.CancelledError
+        )
+
+        with pytest.raises(asyncio.CancelledError):
+            await mgr._wait_for_recreated_pr_checks("o", "r", 107, _payload())
+
+        assert self._key() not in mgr._recently_approved


### PR DESCRIPTION
Closes #440, closes #441, closes #434.

Three defects converged on the Dependabot recreate path. They share a cause — **the wait had no way to say what had become of the replacement**, so every caller inferred it — and the corrected return contract is what ties the fixes together.

## 1. A merged replacement was reported as a failure (#441)

Auto-merge is armed on the replacement **before** the checks wait begins, so it can merge between polls. A closed payload satisfied neither the ready test nor the `dirty` test, so the loop ran to timeout and the caller reported a **failure for a PR that had in fact merged**. Under-reporting a success is the most damaging direction to be wrong in, and it cost the full wait window to get there.

`RecreateResult` now carries a `RecreateOutcome`:

| Outcome | Meaning |
| --- | --- |
| `READY` | mergeable — merge it |
| `MERGED` | auto-merge got there first — record the success, do **not** merge again |
| `PENDING` | found, approved and armed, but we stopped waiting — report `AUTO_MERGE_PENDING` |
| `ABANDONED` | conflicted, or closed unmerged — report `BLOCKED`, carrying the replacement |
| `NONE` | nothing was acted on |

A payload carrying neither `merged` nor `merged_at` is treated as unmerged; claiming a merge we cannot evidence would guess in the wrong direction. Reuses `_merged_from_payload`, so merged-ness is derived identically to `_recheck_pr_before_retry` and `_fetch_pr_state_now`. Also drops the unreachable `"clean"` from the second disjunct.

Review found the same race surviving on **two further paths**, both now closed:

- **Giving up is not finding nothing.** A ceiling, exhausted budget or `--max-wait 0` returned `NONE` despite the replacement being armed, so the original was reported `FAILED` while the replacement merged. `_confirm_failure` cannot correct that — it rechecks the *original*.
- **`READY` is only a snapshot.** Auto-merge can start between the wait's last poll and our manual dispatch; GitHub answers *"merge already in progress"*, which `_dispatch_recreated_merge` swallows. `_merge_recreated_pr` now confirms against the **replacement** before reporting, and reports `BLOCKED` (not `FAILED`) when the merge genuinely did not happen — because after a recreate the original is closed unmerged, so a `FAILED` result would be rewritten to `CLOSED`, i.e. *"nothing to follow up on"*.

`PENDING` requires **both** approval and arming. `_ensure_pr_approved` returns `True` only for a *new* review and `False` when the head is already sufficiently approved, with genuine failures raised — so approval is judged by whether it raised, not by the boolean.

## 2. A stuck check could not trigger a recreate (#440)

`_should_request_recreate` set a recreate in motion for **either** an unsigned commit **or** a stalled required check — but the trigger applied signature gates unconditionally. On any repository not enforcing commit signatures the stuck-check recovery was **inert**: the user was told `requesting recreate` and nothing was posted.

The causes are unrelated — a stalled check is a *timing* problem. `_should_request_recreate` now returns a `RecreateCause`, and the signature gates apply to `UNSIGNED` alone. The `is_dependabot` guard still applies to both.

## 3. Three waits escaped the run-wide ceiling (#434)

The pre-commit.ci poll, the recreate poll and the recreated-PR checks wait each ran their own budget, consulting neither `_no_wait` nor `_run_deadline`. The third **compounded** the second: reached *from* the recreate poll, it started a fresh full budget, so a single PR could consume **`2 × merge_timeout` beyond `--max-wait`** while holding its slot lease.

The recreate path now establishes **one** deadline and passes it into the nested wait. All three carry the `_no_wait` guard directly, and each **clamps its sleep** to the remaining budget rather than merely checking the deadline before sleeping a full interval.

**What `--max-wait 0` actually does here**, since an earlier version of this description overstated it: the recreate macro is posted, and `_await_dependabot_recreate` then returns without discovering the replacement — so nothing approves or arms it. Dependabot takes 30–90 seconds to open the replacement, so searching for it *is* the wait the flag forbids. The replacement is left for a later run, and this PR is reported as a failure, which is accurate.

## Review

Six rounds, 21 threads, all resolved. Most found the *fix* introducing the next problem — consistently the same shape: asserting an outcome the evidence did not support. Notable catches: the `PENDING` outcome; the missing `_no_wait` guard; arming ≠ approving; `ABANDONED` being neutralised by `_confirm_failure`; a `_recently_approved` key leak; and an unreachable line that `ruff`, `mypy` and a passing test all failed to catch.

`_recreated_pr.py` was split at the end — the wait orchestration stays, the per-poll reading and terminal classification move to `_recreated_pr_poll.py` — to stay inside the 400-line gate after the extraction.

## Test coverage

45 tests in `tests/test_recreate_path_contract.py`, plus 35 existing recreate tests migrated:

| Area | Pins |
| --- | --- |
| Closed/merged | `MERGED`, and **promptly** — one GET, not polled to timeout |
| Closed/unmerged, conflicted | `ABANDONED`, **carrying the replacement** so the report names it |
| Ambiguous payload | not claimed as merged |
| Exhausted budget / ceiling | `PENDING` |
| Unarmed, or missing `node_id` | `NONE` — never claimed as in flight |
| Already-approved replacement | `PENDING` (`False` means sufficient, not declined) |
| Approval raised / permission error | `NONE` / propagates |
| `--max-wait 0` direct call | `PENDING`, no polling, auto-merge still armed |
| Near-deadline sleeps | clamped — recreate **and** pre-commit loops |
| `READY` dispatch refused | confirms the replacement → `MERGED`, or `BLOCKED` if truly unmerged |
| `ABANDONED` end to end | survives the real `_confirm_failure`, with a control proving `FAILED` would not |
| Flow level | `PENDING` → `AUTO_MERGE_PENDING` with the reason on **`error`** (the field the report reads) |
| Report rendering | reason shown; a reason on `warning` proven invisible |
| Approval key | cleared on the normal path, on exception, and on cancellation |
| Cause selection | stuck check → `STUCK_CHECK`; branch protection → `UNSIGNED`; neither → no trigger |
| Failing wait | propagates; **not** retried as a second full wait |

Each fix was checked **red-green** by reverting it in isolation.

## Validation

| Check | Result |
| --- | --- |
| `uv run pytest tests/ -q` | **1829 passed**, 14 skipped |
| Coverage | 76.08% (45% minimum enforced) |
| `uv run ruff check src/ tests/` | All checks passed |
| `uv run ruff format --check src/ tests/` | 260 files already formatted |
| `uv run mypy src/` | Success, 189 source files |
| `prek` hooks | passed |
| `aislop` vs `main` | 100 → 100, errors 0 → 0, warnings 0 → 0 — **adds nothing** |
