### PR TITLE
Fix: Correct wait sizing and merge dispatch locking

### DIFF
--- a/src/dependamerge/merge_manager/_approval.py
+++ b/src/dependamerge/merge_manager/_approval.py
@@ -126,7 +126,7 @@ class _ApprovalMixin(_MergeManagerBase):
             approved = await self._ensure_pr_approved(pr_info, owner, repo)
             if not approved:
                 return False
-            return await self._merge_pr_with_retry(pr_info, owner, repo)
+            return await self._retry_merge_under_dispatch_lock(pr_info, owner, repo)
 
         # Fall back to the heuristic block-reason classifier only when the
         # cached state actually shows the PR as ``blocked``.  A missing
@@ -167,7 +167,29 @@ class _ApprovalMixin(_MergeManagerBase):
         approved = await self._ensure_pr_approved(pr_info, owner, repo)
         if not approved:
             return False
-        return await self._merge_pr_with_retry(pr_info, owner, repo)
+        return await self._retry_merge_under_dispatch_lock(pr_info, owner, repo)
+
+    async def _retry_merge_under_dispatch_lock(
+        self, pr_info: PullRequestInfo, owner: str, repo: str
+    ) -> bool:
+        """Re-dispatch a merge with the per-repo lock held.
+
+        This recovery runs *after* the direct merge was rejected, by
+        which point the caller has released the dispatch lock.  Retrying
+        without re-acquiring it lets a same-repository worker slip a
+        merge in between the failed first attempt and this retry, so two
+        merge calls hit the repository back to back --- exactly the race
+        the lock exists to prevent, and which every other dispatch site
+        already avoids.
+
+        The consequence is a merge raced against freshly-propagated
+        branch protection, which surfaces as an intermittent and
+        hard-to-attribute failure rather than as anything pointing at
+        the lock.
+        """
+        dispatch_lock = await self._get_merge_dispatch_lock(owner, repo)
+        async with dispatch_lock:
+            return await self._merge_pr_with_retry(pr_info, owner, repo)
 
     @staticmethod
     def _merge_error_indicates_missing_approval(error_text: str) -> bool:

--- a/src/dependamerge/merge_manager/_required_workflows.py
+++ b/src/dependamerge/merge_manager/_required_workflows.py
@@ -126,9 +126,17 @@ class _RequiredWorkflowWaitMixin(_MergeManagerBase):
                 if closed:
                     return merged_during
                 try:
-                    merged = await self._github_client.merge_pull_request(
-                        owner, repo, pr_info.number, merge_method
-                    )
+                    # Under the per-repo dispatch lock, like every other
+                    # merge call.  Held around the dispatch alone and
+                    # *not* across the wait above: holding it through a
+                    # multi-minute wait would serialise the whole
+                    # repository batch behind this one PR, which is the
+                    # head-of-line blocking the lock design avoids.
+                    dispatch_lock = await self._get_merge_dispatch_lock(owner, repo)
+                    async with dispatch_lock:
+                        merged = await self._github_client.merge_pull_request(
+                            owner, repo, pr_info.number, merge_method
+                        )
                 except GitHubPermissionError:
                     raise
                 except Exception as exc:

--- a/src/dependamerge/merge_manager/_wait.py
+++ b/src/dependamerge/merge_manager/_wait.py
@@ -83,8 +83,13 @@ class _AutoMergeWaitMixin(_MergeManagerBase):
         continue_states: tuple[str, ...],
         stop_on_clean: bool,
         measures_checks: bool,
-    ) -> None:
+    ) -> bool:
         """Sleep past the latency this repository has already demonstrated.
+
+        Returns whether it actually slept, so the caller can restore the
+        short first-poll cadence: the head start is sized to land as the
+        checks finish, and following it with the full steady-state
+        interval would add that interval to every wait it applies to.
 
         Applies only to waits that measure checks.  The figure describes
         check latency, so using it to skip ahead in a *rebase* wait would
@@ -97,21 +102,32 @@ class _AutoMergeWaitMixin(_MergeManagerBase):
         ``clean``; sleeping first would burn up to half the shared
         deadline before the loop noticed it should return immediately.
 
+        Called **after** the first live poll rather than before it, so
+        ``pr_info`` carries state the loop has just read.  Sizing it from
+        the run's opening snapshot meant that in a striped run --- where
+        a repository's PRs are deliberately serialised --- a sibling
+        could sleep up to half its remaining budget having *already* gone
+        green, because its snapshot still said ``blocked`` from minutes
+        earlier.  The head start exists to save time on slow
+        repositories, so spending it on a resolved PR is the exact
+        opposite of the intent, and most likely on precisely the
+        repositories it was added to help.
+
         Extracted from :meth:`_wait_for_auto_merge` to keep that method
         within the complexity budget; see :meth:`_wait_head_start` for
         the sizing decision.
         """
         if not measures_checks:
-            return
+            return False
         if stop_on_clean and pr_info.mergeable_state == "clean":
-            return
+            return False
         if continue_states and pr_info.mergeable_state not in continue_states:
             # Already outside the states this call waits through, so the
             # loop is about to exit; there is nothing to skip ahead to.
-            return
+            return False
         head_start = self._wait_head_start(pr_info.repository_full_name, remaining)
         if head_start <= 0:
-            return
+            return False
         self.log.debug(
             "Head start of %.0fs for %s: this repository's checks have "
             "taken that long already",
@@ -119,6 +135,7 @@ class _AutoMergeWaitMixin(_MergeManagerBase):
             pr_key,
         )
         await asyncio.sleep(head_start)
+        return True
 
     async def _wait_for_auto_merge(
         self,
@@ -195,6 +212,9 @@ class _AutoMergeWaitMixin(_MergeManagerBase):
         closed_during_wait = False
         merged_during_wait = False
         first_poll = True
+        # Set per iteration: whether that poll supplied a usable live
+        # ``mergeable_state``.  Guards the head start below.
+        live_state_seen = False
         # Bound before the try so the ``finally`` can always read it,
         # even if the parked block is never entered.
         wait_started = loop.time()
@@ -208,16 +228,11 @@ class _AutoMergeWaitMixin(_MergeManagerBase):
             # never starve runnable PRs (see ``slot_lease.py``).  The
             # polling GETs are paced by the HTTP client's own limits.
             async with _mm.parked():
-                # Skip ahead when this repository has already shown how
-                # long its checks take (see ``_wait_head_start``).
-                await self._apply_wait_head_start(
-                    pr_info,
-                    pr_key,
-                    max(0.0, deadline - loop.time()),
-                    continue_states,
-                    stop_on_clean,
-                    measures_checks,
-                )
+                # The head start is applied after the first live poll,
+                # not here: see ``_apply_wait_head_start``.  Sizing it
+                # from the fetch-time snapshot could sleep through a PR
+                # that had already gone green.
+                head_start_pending = measures_checks
                 while loop.time() < deadline:
                     if stop_on_clean and pr_info.mergeable_state == "clean":
                         break
@@ -254,6 +269,20 @@ class _AutoMergeWaitMixin(_MergeManagerBase):
                         )
                         continue
                     if isinstance(refreshed_wait, dict):
+                        # ``_apply_wait_refresh`` deliberately keeps the
+                        # previous value when GitHub answers ``null`` /
+                        # ``""`` / ``"unknown"`` while recomputing, and
+                        # ``_fetch_pr_state`` can return ``None`` without
+                        # raising when a per-PR fallback fails.  Either
+                        # way ``pr_info`` still holds the *snapshot*
+                        # value, so the head start must not be sized
+                        # from it --- that is the stale read this change
+                        # exists to remove.
+                        live_state_seen = refreshed_wait.get("mergeable_state") not in (
+                            None,
+                            "",
+                            "unknown",
+                        )
                         if self._apply_wait_refresh(pr_info, refreshed_wait):
                             closed_during_wait = True
                             merged_during_wait = bool(
@@ -271,6 +300,31 @@ class _AutoMergeWaitMixin(_MergeManagerBase):
                     # state, so exit and let the caller decide.
                     if pr_info.mergeable_state not in continue_states:
                         break
+
+                    # Reaching here means the PR has been read live and
+                    # genuinely still needs waiting through: it is not
+                    # clean, not closed, and still in a continue state.
+                    # Only now is a head start worth taking.  Pending
+                    # rather than tied to the first iteration, so a
+                    # transient fetch failure --- or a reading GitHub
+                    # could not supply --- defers it instead of
+                    # discarding it or spending it on a stale value.
+                    if head_start_pending and live_state_seen:
+                        head_start_pending = False
+                        if await self._apply_wait_head_start(
+                            pr_info,
+                            pr_key,
+                            max(0.0, deadline - loop.time()),
+                            continue_states,
+                            stop_on_clean,
+                            measures_checks,
+                        ):
+                            # The head start is sized to land as the
+                            # checks finish, so read promptly afterwards.
+                            # Without this the next sleep would be the
+                            # full steady-state interval, adding it to
+                            # every wait the optimisation applies to.
+                            first_poll = True
                 # Stop the clock inside the park: leaving it re-acquires
                 # this worker's slot, and that queue is the scheduler's
                 # time, not the repository's.  Only a wait that polled

--- a/tests/test_wait_sizing_and_dispatch_lock.py
+++ b/tests/test_wait_sizing_and_dispatch_lock.py
@@ -1,0 +1,337 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 The Linux Foundation
+
+"""Wait sizing and merge-dispatch serialisation on the recovery paths.
+
+A defect on a path reached only after something has already gone
+wrong, which is why neither had coverage.
+
+**#436** --- ``_apply_wait_head_start`` sized its skip-ahead from the
+``pr_info`` snapshot the run fetched up front.  Owner-wide runs serialise
+each repository's pull requests deliberately, and that serialisation is
+also what makes the snapshot stale: while PR #1 was merging, PR #2's
+checks were running, so by the time #2's worker starts its checks may
+have finished while its snapshot still says ``blocked``.  The head start
+is sized from the repository's *observed* median check latency, which in
+that situation is the latency of a wait that has already elapsed --- so a
+pull request that had gone green could sleep up to half its remaining
+budget before the first live poll.
+
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+
+from dependamerge.models import PullRequestInfo
+from tests.conftest import make_merge_manager
+
+REPO = "lfreleng-actions/slow-repo"
+
+# Any sleep longer than this is a head start rather than a poll interval:
+# the tests drive the poll cadence down to a millisecond.
+HEAD_START_FLOOR = 1.0
+
+
+def _pr(mergeable_state: str = "blocked") -> PullRequestInfo:
+    return PullRequestInfo(
+        number=1,
+        title="t",
+        body=None,
+        author="dependabot[bot]",
+        head_sha="a" * 40,
+        base_branch="main",
+        head_branch="x",
+        state="open",
+        mergeable=False,
+        mergeable_state=mergeable_state,
+        behind_by=None,
+        files_changed=[],
+        repository_full_name=REPO,
+        html_url=f"https://github.com/{REPO}/pull/1",
+        reviews=[],
+        review_comments=[],
+    )
+
+
+def _mgr(**overrides: Any):
+    mgr, client = make_merge_manager(**overrides)
+    mgr._merge_recheck_interval = 0.001
+    mgr._merge_timeout = 600.0
+    # One slow repository already observed, so a head start is available.
+    mgr._record_wait_duration(REPO, 240.0)
+    return mgr, client
+
+
+class _SleepRecorder:
+    """Substitute for ``asyncio.sleep`` that records every delay."""
+
+    def __init__(self) -> None:
+        self.slept: list[float] = []
+
+    async def __call__(self, seconds: float) -> None:
+        self.slept.append(seconds)
+
+    @property
+    def took_a_head_start(self) -> bool:
+        return any(s > HEAD_START_FLOOR for s in self.slept)
+
+
+class TestTheHeadStartIsSizedFromLiveState:
+    """A skip-ahead is only sound if the state it skips over is current."""
+
+    async def _run_wait(self, mgr, live_state: dict[str, Any]) -> _SleepRecorder:
+        recorder = _SleepRecorder()
+        mgr._fetch_pr_state = AsyncMock(return_value=live_state)  # type: ignore[method-assign]
+
+        import dependamerge.merge_manager as mod
+
+        original = mod.asyncio.sleep
+        mod.asyncio.sleep = recorder  # type: ignore[assignment]
+        try:
+            await mgr._wait_for_auto_merge(
+                _pr(),
+                "lfreleng-actions",
+                "slow-repo",
+                continue_states=("blocked", "unstable"),
+                measures_checks=True,
+            )
+        finally:
+            mod.asyncio.sleep = original  # type: ignore[assignment]
+        return recorder
+
+    async def _run_wait_sequence(
+        self, mgr, states: list[dict[str, Any]]
+    ) -> _SleepRecorder:
+        """Drive the loop through ``states``, one per poll.
+
+        The substituted ``sleep`` does not advance the clock, so a wait
+        that never observes a terminal state would spin against the
+        deadline. Ending the sequence on a non-continue state lets the
+        loop exit naturally.
+        """
+        recorder = _SleepRecorder()
+        mgr._fetch_pr_state = AsyncMock(side_effect=states)  # type: ignore[method-assign]
+
+        import dependamerge.merge_manager as mod
+
+        original = mod.asyncio.sleep
+        mod.asyncio.sleep = recorder  # type: ignore[assignment]
+        try:
+            await mgr._wait_for_auto_merge(
+                _pr(),
+                "lfreleng-actions",
+                "slow-repo",
+                continue_states=("blocked", "unstable"),
+                measures_checks=True,
+            )
+        finally:
+            mod.asyncio.sleep = original  # type: ignore[assignment]
+        return recorder
+
+    @pytest.mark.asyncio
+    async def test_no_head_start_when_the_pr_has_already_gone_green(self) -> None:
+        """The defect: the stale snapshot said blocked, so it slept anyway."""
+        mgr, _ = _mgr()
+
+        recorder = await self._run_wait(
+            mgr, {"state": "open", "mergeable": True, "mergeable_state": "clean"}
+        )
+
+        assert not recorder.took_a_head_start, recorder.slept
+
+    @pytest.mark.asyncio
+    async def test_no_head_start_when_the_pr_merged_during_the_gap(self) -> None:
+        mgr, _ = _mgr()
+
+        recorder = await self._run_wait(
+            mgr, {"state": "closed", "merged": True, "merged_at": "2026-08-25"}
+        )
+
+        assert not recorder.took_a_head_start, recorder.slept
+
+    @pytest.mark.asyncio
+    async def test_a_head_start_is_still_taken_when_it_is_warranted(self) -> None:
+        """The optimisation must survive: a genuinely blocked PR skips ahead."""
+        mgr, _ = _mgr()
+
+        recorder = await self._run_wait_sequence(
+            mgr,
+            [
+                {"state": "open", "mergeable": False, "mergeable_state": "blocked"},
+                {"state": "open", "mergeable": True, "mergeable_state": "clean"},
+            ],
+        )
+
+        assert recorder.took_a_head_start, recorder.slept
+
+    @pytest.mark.asyncio
+    async def test_the_first_poll_precedes_any_head_start(self) -> None:
+        """Ordering is the fix: read, then decide whether to skip ahead."""
+        mgr, _ = _mgr()
+        order: list[str] = []
+        recorder = _SleepRecorder()
+        states = [
+            {"state": "open", "mergeable": False, "mergeable_state": "blocked"},
+            {"state": "open", "mergeable": True, "mergeable_state": "clean"},
+        ]
+        remaining = list(states)
+
+        async def _fetch(*_args: Any, **_kwargs: Any) -> dict[str, Any]:
+            order.append("poll")
+            return remaining.pop(0) if remaining else states[-1]
+
+        async def _sleep(seconds: float) -> None:
+            if seconds > HEAD_START_FLOOR:
+                order.append("head-start")
+            await recorder(seconds)
+
+        mgr._fetch_pr_state = _fetch  # type: ignore[method-assign]
+
+        import dependamerge.merge_manager as mod
+
+        original = mod.asyncio.sleep
+        mod.asyncio.sleep = _sleep  # type: ignore[assignment]
+        try:
+            await mgr._wait_for_auto_merge(
+                _pr(),
+                "lfreleng-actions",
+                "slow-repo",
+                continue_states=("blocked", "unstable"),
+                measures_checks=True,
+            )
+        finally:
+            mod.asyncio.sleep = original  # type: ignore[assignment]
+
+        assert "head-start" in order, order
+        assert order.index("poll") < order.index("head-start"), order
+
+
+class TestTheHeadStartNeedsAUsableReading:
+    """ "Polled" is not the same as "read".
+
+    ``_apply_wait_refresh`` deliberately keeps the previous
+    ``mergeable_state`` when GitHub answers ``null``, ``""`` or
+    ``"unknown"`` while recomputing, and ``_fetch_pr_state`` can return
+    ``None`` without raising when a per-PR fallback fails. In both cases
+    ``pr_info`` still holds the *snapshot* value --- so consuming the
+    head start there would size it from exactly the stale state this
+    change exists to remove.
+    """
+
+    async def _run(self, mgr, states: list[Any]) -> _SleepRecorder:
+        recorder = _SleepRecorder()
+        mgr._fetch_pr_state = AsyncMock(side_effect=states)  # type: ignore[method-assign]
+
+        import dependamerge.merge_manager as mod
+
+        original = mod.asyncio.sleep
+        mod.asyncio.sleep = recorder  # type: ignore[assignment]
+        try:
+            await mgr._wait_for_auto_merge(
+                _pr(),
+                "lfreleng-actions",
+                "slow-repo",
+                continue_states=("blocked", "unstable"),
+                measures_checks=True,
+            )
+        finally:
+            mod.asyncio.sleep = original  # type: ignore[assignment]
+        return recorder
+
+    @pytest.mark.parametrize("unusable", [None, "", "unknown"])
+    @pytest.mark.asyncio
+    async def test_a_recomputing_state_defers_the_head_start(self, unusable) -> None:
+        """The reading is not live, so the head start stays pending."""
+        mgr, _ = _mgr()
+
+        recorder = await self._run(
+            mgr,
+            [
+                {"state": "open", "mergeable": False, "mergeable_state": unusable},
+                {"state": "open", "mergeable": True, "mergeable_state": "clean"},
+            ],
+        )
+
+        assert not recorder.took_a_head_start, recorder.slept
+
+    @pytest.mark.asyncio
+    async def test_a_missing_payload_defers_the_head_start(self) -> None:
+        """``_fetch_pr_state`` returning None must not spend it either."""
+        mgr, _ = _mgr()
+
+        recorder = await self._run(
+            mgr,
+            [
+                None,
+                {"state": "open", "mergeable": True, "mergeable_state": "clean"},
+            ],
+        )
+
+        assert not recorder.took_a_head_start, recorder.slept
+
+    @pytest.mark.asyncio
+    async def test_it_is_still_taken_once_a_live_state_arrives(self) -> None:
+        """Deferred, not discarded: a later usable reading still gets it."""
+        mgr, _ = _mgr()
+
+        recorder = await self._run(
+            mgr,
+            [
+                {"state": "open", "mergeable": False, "mergeable_state": "unknown"},
+                {"state": "open", "mergeable": False, "mergeable_state": "blocked"},
+                {"state": "open", "mergeable": True, "mergeable_state": "clean"},
+            ],
+        )
+
+        assert recorder.took_a_head_start, recorder.slept
+
+
+class TestTheCadenceResumesAfterAHeadStart:
+    """The head start lands as checks finish, so read promptly after it.
+
+    ``first_poll`` is consumed by the loop's first iteration, so moving
+    the head start into the loop left the *next* sleep at the full
+    steady-state interval. With the defaults that is 10s rather than the
+    2s first-poll cadence --- 8s added to every wait the optimisation
+    applies to, which eats into what it saves.
+    """
+
+    @pytest.mark.asyncio
+    async def test_the_poll_after_a_head_start_is_short(self) -> None:
+        mgr, _ = _mgr()
+        mgr._merge_recheck_interval = 10.0
+        recorder = _SleepRecorder()
+        states = [
+            {"state": "open", "mergeable": False, "mergeable_state": "blocked"},
+            {"state": "open", "mergeable": False, "mergeable_state": "blocked"},
+            {"state": "open", "mergeable": True, "mergeable_state": "clean"},
+        ]
+        mgr._fetch_pr_state = AsyncMock(side_effect=states)  # type: ignore[method-assign]
+
+        import dependamerge.merge_manager as mod
+
+        original = mod.asyncio.sleep
+        mod.asyncio.sleep = recorder  # type: ignore[assignment]
+        try:
+            await mgr._wait_for_auto_merge(
+                _pr(),
+                "lfreleng-actions",
+                "slow-repo",
+                continue_states=("blocked", "unstable"),
+                measures_checks=True,
+            )
+        finally:
+            mod.asyncio.sleep = original  # type: ignore[assignment]
+
+        # slept: [short first poll, head start, short poll again, ...]
+        # The head start is sized from a 240s observation, so it is far
+        # larger than any poll interval --- identify it by magnitude
+        # rather than a fixed floor, which the 2s first poll exceeds.
+        head_start_at = recorder.slept.index(max(recorder.slept))
+        assert recorder.slept[head_start_at] > 50.0, recorder.slept
+        after = recorder.slept[head_start_at + 1]
+        assert after < 10.0, recorder.slept

--- a/tests/test_wait_sizing_and_dispatch_lock.py
+++ b/tests/test_wait_sizing_and_dispatch_lock.py
@@ -3,7 +3,7 @@
 
 """Wait sizing and merge-dispatch serialisation on the recovery paths.
 
-A defect on a path reached only after something has already gone
+Two defects, both on paths reached only after something has already gone
 wrong, which is why neither had coverage.
 
 **#436** --- ``_apply_wait_head_start`` sized its skip-ahead from the
@@ -17,10 +17,17 @@ that situation is the latency of a wait that has already elapsed --- so a
 pull request that had gone green could sleep up to half its remaining
 budget before the first live poll.
 
+**#435** --- two recovery paths dispatched ``merge_pull_request``
+**outside** the per-repository dispatch lock, defeating the serialisation
+that lock exists to provide.  Both are reached only after a rejected
+first attempt, and the consequence is a merge raced against
+freshly-propagated branch protection: an intermittent, hard-to-attribute
+failure rather than anything pointing at the lock.
 """
 
 from __future__ import annotations
 
+import asyncio
 from typing import Any
 from unittest.mock import AsyncMock
 
@@ -208,6 +215,106 @@ class TestTheHeadStartIsSizedFromLiveState:
 
         assert "head-start" in order, order
         assert order.index("poll") < order.index("head-start"), order
+
+
+class TestEveryMergeDispatchHoldsTheRepoLock:
+    """The lock's guarantee is worthless if a recovery path skips it."""
+
+    @pytest.mark.asyncio
+    async def test_approve_on_demand_retry_is_locked(self) -> None:
+        mgr, client = _mgr()
+        pr = _pr()
+        owner, repo = "lfreleng-actions", "slow-repo"
+        lock = asyncio.Lock()
+        mgr._get_merge_dispatch_lock = AsyncMock(return_value=lock)  # type: ignore[method-assign]
+        mgr._last_merge_exception[f"{owner}/{repo}#1"] = Exception(
+            "GitHub: At least 1 approving review is required by reviewers "
+            "with write access."
+        )
+        mgr._ensure_pr_approved = AsyncMock(return_value=True)  # type: ignore[method-assign]
+
+        observed: dict[str, bool] = {}
+
+        async def _retry(*_args: Any, **_kwargs: Any) -> bool:
+            observed["locked"] = lock.locked()
+            return True
+
+        mgr._merge_pr_with_retry = _retry  # type: ignore[method-assign]
+
+        assert await mgr._approve_and_retry_if_review_required(pr, owner, repo) is True
+        assert observed["locked"] is True
+
+    @pytest.mark.asyncio
+    async def test_the_heuristic_path_retry_is_locked(self) -> None:
+        """The same function reaches the retry twice; both must be locked."""
+        mgr, client = _mgr()
+        pr = _pr()
+        owner, repo = "lfreleng-actions", "slow-repo"
+        lock = asyncio.Lock()
+        mgr._get_merge_dispatch_lock = AsyncMock(return_value=lock)  # type: ignore[method-assign]
+        client.analyze_block_reason = AsyncMock(
+            return_value="PR requires approval from a code owner"
+        )
+        mgr._ensure_pr_approved = AsyncMock(return_value=True)  # type: ignore[method-assign]
+
+        observed: dict[str, bool] = {}
+
+        async def _retry(*_args: Any, **_kwargs: Any) -> bool:
+            observed["locked"] = lock.locked()
+            return True
+
+        mgr._merge_pr_with_retry = _retry  # type: ignore[method-assign]
+
+        assert await mgr._approve_and_retry_if_review_required(pr, owner, repo) is True
+        assert observed["locked"] is True
+
+    @pytest.mark.asyncio
+    async def test_required_workflow_retry_is_locked(self) -> None:
+        mgr, client = _mgr()
+        pr = _pr()
+        owner, repo = "lfreleng-actions", "slow-repo"
+        lock = asyncio.Lock()
+        mgr._get_merge_dispatch_lock = AsyncMock(return_value=lock)  # type: ignore[method-assign]
+        mgr._wait_for_auto_merge = AsyncMock(return_value=(False, False))  # type: ignore[method-assign]
+
+        observed: dict[str, bool] = {}
+
+        async def _merge(*_args: Any, **_kwargs: Any) -> bool:
+            observed["locked"] = lock.locked()
+            return True
+
+        client.merge_pull_request = _merge
+
+        assert await mgr._wait_for_required_workflows_and_retry(pr, owner, repo) is True
+        assert observed["locked"] is True
+
+    @pytest.mark.asyncio
+    async def test_the_lock_is_not_held_across_the_wait(self) -> None:
+        """Holding it through the wait would block the whole repository.
+
+        The lock serialises the *moment of merge*, not the waiting that
+        precedes it. Holding it across a multi-minute wait would queue
+        every sibling in the repository behind this one pull request ---
+        the head-of-line blocking the design deliberately avoids.
+        """
+        mgr, client = _mgr()
+        pr = _pr()
+        owner, repo = "lfreleng-actions", "slow-repo"
+        lock = asyncio.Lock()
+        mgr._get_merge_dispatch_lock = AsyncMock(return_value=lock)  # type: ignore[method-assign]
+
+        observed: dict[str, bool] = {}
+
+        async def _wait(*_args: Any, **_kwargs: Any) -> tuple[bool, bool]:
+            observed["locked_during_wait"] = lock.locked()
+            return False, False
+
+        mgr._wait_for_auto_merge = _wait  # type: ignore[method-assign]
+        client.merge_pull_request = AsyncMock(return_value=True)
+
+        await mgr._wait_for_required_workflows_and_retry(pr, owner, repo)
+
+        assert observed["locked_during_wait"] is False
 
 
 class TestTheHeadStartNeedsAUsableReading:


### PR DESCRIPTION
Closes #436, closes #435.

Rebased onto `main` now that #457 has merged, so this is **two commits** on a clean linear history.

Both defects sit on paths reached **only after something has already gone wrong**, which is why neither had coverage. Both were surfaced by Copilot during #433 and are verbatim moves that reproduce against `upstream/main`.

## #436 — the head start trusted a stale mergeable state

`_apply_wait_head_start` sized its skip-ahead from the `pr_info` snapshot the run fetched **up front**. All three of its guards read that field.

The mechanism is counterintuitive and worth stating plainly: owner-wide runs serialise each repository's pull requests *deliberately*, so an earlier merge cannot invalidate a later sibling. **That same serialisation is what makes the snapshot stale.** While PR #1 was being merged, PR #2's checks were running — so by the time #2's worker starts, its checks may well have finished while its snapshot still says `blocked`.

The head start is then sized from the repository's *observed* median check latency, which in that situation is the latency of a wait that has **already elapsed**. The damage is bounded — `_wait_head_start` caps the sleep at half the remaining budget — but half a budget spent asleep on an already-green PR is the exact opposite of an optimisation added to save time, and it lands on precisely the repositories it was meant to help.

**Fix:** invert the order. Poll first, apply the head start only if the *live* state still needs waiting through. This costs nothing — it uses a GET the loop was going to make anyway, and the first poll already runs on the shorter `MERGE_WAIT_FIRST_POLL_SECONDS` interval — and removes the reliance on snapshot freshness rather than papering over it.

The head start is tracked as *pending* rather than tied to the first iteration, so a transient fetch failure defers it instead of silently discarding it for the rest of the wait.

## #435 — two merge retries dispatched outside the repo lock

`_get_merge_dispatch_lock` documents the guarantee: holding it around `merge_pull_request` prevents back-to-back merges on one repository from racing GitHub's branch-protection propagation.

| Site | Locked before | Locked now |
| --- | --- | --- |
| direct merge in the main flow | ✅ | ✅ |
| recreated-PR merge | ✅ | ✅ |
| `_handle_merge_conflict` fallback | ✅ | ✅ |
| `_approve_and_retry_if_review_required` (×2 paths) | ❌ | ✅ |
| `_wait_for_required_workflows_and_retry` | ❌ | ✅ |

`_approve_and_retry_if_review_required` runs *after* a direct merge was rejected, by which point the caller has released the lock. A same-repository worker could then acquire it between the failed first attempt and this retry, putting two merge calls back to back — the exact condition the lock prevents everywhere else. The same shape appeared **twice** in that function, on the authoritative block-reason path and the heuristic fallback; both now route through one `_retry_merge_under_dispatch_lock` helper.

`_wait_for_required_workflows_and_retry` had the same gap held open for longer: it alternates wait and retry, and every retry dispatched unlocked. Because the wait runs for minutes, the interleaving window was correspondingly wide.

**Deliberately not fixed by widening the lock.** It is taken *inside* the retry step, not around the alternating loop — holding it across a multi-minute wait would serialise the entire repository batch behind one PR, the head-of-line blocking the design avoids. `test_the_lock_is_not_held_across_the_wait` pins that.

## Verification

8 new tests. **Red-green checked**: against unfixed source **6 of 8 fail**, and the 2 that pass either way are deliberate controls.

| Test | Fails without the fix |
| --- | --- |
| `test_no_head_start_when_the_pr_has_already_gone_green` | ✅ |
| `test_no_head_start_when_the_pr_merged_during_the_gap` | ✅ |
| `test_the_first_poll_precedes_any_head_start` | ✅ |
| `test_approve_on_demand_retry_is_locked` | ✅ `assert False is True` |
| `test_the_heuristic_path_retry_is_locked` | ✅ |
| `test_required_workflow_retry_is_locked` | ✅ |
| `test_a_head_start_is_still_taken_when_it_is_warranted` | control — optimisation preserved |
| `test_the_lock_is_not_held_across_the_wait` | control — no head-of-line blocking |

The lock tests assert `lock.locked()` **from inside** the mocked dispatch, so they observe the lock genuinely held at the moment of merge rather than merely that one was requested.

## Validation

Re-run after the rebase, against `main` at `2d0ccf3`:

| Check | Result |
| --- | --- |
| `uv run pytest tests/ -q` | **1837 passed**, 14 skipped |
| Coverage | 76.10% (45% minimum enforced) |
| `uv run ruff check src/ tests/` | All checks passed |
| `uv run ruff format --check src/ tests/` | 261 files already formatted |
| `uv run mypy src/` | Success, 189 source files |
| `uv run reuse lint` | compliant |
| `prek` hooks | passed |
| `aislop` vs `main` | 100 → 100, errors 0 → 0, warnings 0 → 0 — **adds nothing** |

Two commits, one per issue, each signed and independently green.
